### PR TITLE
Add Multidex library in order to fix too many methods error during build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ subprojects {
                 if (evaluatedSubProjectIsALibrary) {
                     consumerProguardFiles "consumer-rules.pro"
                 }
+                if (evaluatedSubProjectIsAnApp) {
+                    multiDexEnabled true
+                }
             }
 
             compileOptions {
@@ -140,6 +143,7 @@ subprojects {
 
             if (evaluatedSubProjectIsAnApp) {
                 implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+                implementation 'androidx.multidex:multidex:2.0.1'
             }
 
             testImplementation 'junit:junit:4.13.1'

--- a/publishing-example-app/src/main/AndroidManifest.xml
+++ b/publishing-example-app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.ably.tracking.example.publisher">
 
     <application
+        android:name=".PublishingExampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublishingExampleApplication.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublishingExampleApplication.kt
@@ -1,0 +1,5 @@
+package com.ably.tracking.example.publisher
+
+import androidx.multidex.MultiDexApplication
+
+class PublishingExampleApplication : MultiDexApplication()


### PR DESCRIPTION
I've added the Multidex library and used it in the Kotlin example app.