### PR TITLE
Add workflow for assemble

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: ./gradlew check --profile
+      - run: ./gradlew assemble
         env:
           ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
       


### PR DESCRIPTION
Very simple for now and just functions as a smoke test, until we work out where we're going to send the AAR and APK artifacts for ease of distribution. That may also need to include signed builds (TBC).

I had a quick look at the diff between the tasks invoked by Gradle's `check` (existing workflow) versus `assemble` (this workflow) and there's quite some difference, which I guess is to be expected. Therefore, just the presence of this workflow adds a whole load more sanity checks for this repository as we evolve the projects.

For the record, just looking at the `publishing-sdk` project...

### check Tasks

```
% ./gradlew clean :publishing-sdk:check --dry-run
:clean SKIPPED
:publishing-example-app:clean SKIPPED
:publishing-example-java-app:clean SKIPPED
:publishing-sdk:clean SKIPPED
:subscribing-sdk:clean SKIPPED
:publishing-sdk:ktlintAndroidTestDebugSourceSetCheck SKIPPED
:publishing-sdk:ktlintAndroidTestReleaseSourceSetCheck SKIPPED
:publishing-sdk:ktlintAndroidTestSourceSetCheck SKIPPED
:publishing-sdk:ktlintDebugSourceSetCheck SKIPPED
:publishing-sdk:ktlintKotlinScriptCheck SKIPPED
:publishing-sdk:ktlintMainSourceSetCheck SKIPPED
:publishing-sdk:ktlintReleaseSourceSetCheck SKIPPED
:publishing-sdk:ktlintTestDebugSourceSetCheck SKIPPED
:publishing-sdk:ktlintTestReleaseSourceSetCheck SKIPPED
:publishing-sdk:ktlintTestSourceSetCheck SKIPPED
:publishing-sdk:preBuild SKIPPED
:publishing-sdk:preDebugBuild SKIPPED
:publishing-sdk:compileDebugAidl SKIPPED
:publishing-sdk:compileDebugRenderscript SKIPPED
:publishing-sdk:generateDebugBuildConfig SKIPPED
:publishing-sdk:generateDebugResValues SKIPPED
:publishing-sdk:generateDebugResources SKIPPED
:publishing-sdk:packageDebugResources SKIPPED
:publishing-sdk:parseDebugLocalResources SKIPPED
:publishing-sdk:processDebugManifest SKIPPED
:publishing-sdk:generateDebugRFile SKIPPED
:publishing-sdk:compileDebugKotlin SKIPPED
:publishing-sdk:javaPreCompileDebug SKIPPED
:publishing-sdk:compileDebugJavaWithJavac SKIPPED
:publishing-sdk:preReleaseBuild SKIPPED
:publishing-sdk:compileReleaseAidl SKIPPED
:publishing-sdk:compileReleaseRenderscript SKIPPED
:publishing-sdk:generateReleaseBuildConfig SKIPPED
:publishing-sdk:generateReleaseResValues SKIPPED
:publishing-sdk:generateReleaseResources SKIPPED
:publishing-sdk:packageReleaseResources SKIPPED
:publishing-sdk:parseReleaseLocalResources SKIPPED
:publishing-sdk:processReleaseManifest SKIPPED
:publishing-sdk:generateReleaseRFile SKIPPED
:publishing-sdk:compileReleaseKotlin SKIPPED
:publishing-sdk:javaPreCompileRelease SKIPPED
:publishing-sdk:compileReleaseJavaWithJavac SKIPPED
:publishing-sdk:lint SKIPPED
:publishing-sdk:processDebugJavaRes SKIPPED
:publishing-sdk:bundleLibResDebug SKIPPED
:publishing-sdk:bundleLibRuntimeToJarDebug SKIPPED
:publishing-sdk:bundleLibCompileToJarDebug SKIPPED
:publishing-sdk:preDebugUnitTestBuild SKIPPED
:publishing-sdk:generateDebugUnitTestStubRFile SKIPPED
:publishing-sdk:compileDebugUnitTestKotlin SKIPPED
:publishing-sdk:javaPreCompileDebugUnitTest SKIPPED
:publishing-sdk:compileDebugUnitTestJavaWithJavac SKIPPED
:publishing-sdk:processDebugUnitTestJavaRes SKIPPED
:publishing-sdk:testDebugUnitTest SKIPPED
:publishing-sdk:processReleaseJavaRes SKIPPED
:publishing-sdk:bundleLibResRelease SKIPPED
:publishing-sdk:bundleLibRuntimeToJarRelease SKIPPED
:publishing-sdk:bundleLibCompileToJarRelease SKIPPED
:publishing-sdk:preReleaseUnitTestBuild SKIPPED
:publishing-sdk:generateReleaseUnitTestStubRFile SKIPPED
:publishing-sdk:compileReleaseUnitTestKotlin SKIPPED
:publishing-sdk:javaPreCompileReleaseUnitTest SKIPPED
:publishing-sdk:compileReleaseUnitTestJavaWithJavac SKIPPED
:publishing-sdk:processReleaseUnitTestJavaRes SKIPPED
:publishing-sdk:testReleaseUnitTest SKIPPED
:publishing-sdk:test SKIPPED
:publishing-sdk:check SKIPPED
```

### assemble Tasks

```
% ./gradlew clean :publishing-sdk:assemble --dry-run
:clean SKIPPED
:publishing-example-app:clean SKIPPED
:publishing-example-java-app:clean SKIPPED
:publishing-sdk:clean SKIPPED
:subscribing-sdk:clean SKIPPED
:publishing-sdk:preBuild SKIPPED
:publishing-sdk:preDebugBuild SKIPPED
:publishing-sdk:compileDebugAidl SKIPPED
:publishing-sdk:mergeDebugJniLibFolders SKIPPED
:publishing-sdk:mergeDebugNativeLibs SKIPPED
:publishing-sdk:stripDebugDebugSymbols SKIPPED
:publishing-sdk:copyDebugJniLibsProjectAndLocalJars SKIPPED
:publishing-sdk:compileDebugRenderscript SKIPPED
:publishing-sdk:generateDebugBuildConfig SKIPPED
:publishing-sdk:generateDebugResValues SKIPPED
:publishing-sdk:generateDebugResources SKIPPED
:publishing-sdk:packageDebugResources SKIPPED
:publishing-sdk:parseDebugLocalResources SKIPPED
:publishing-sdk:processDebugManifest SKIPPED
:publishing-sdk:generateDebugRFile SKIPPED
:publishing-sdk:compileDebugKotlin SKIPPED
:publishing-sdk:javaPreCompileDebug SKIPPED
:publishing-sdk:compileDebugJavaWithJavac SKIPPED
:publishing-sdk:extractDebugAnnotations SKIPPED
:publishing-sdk:mergeDebugGeneratedProguardFiles SKIPPED
:publishing-sdk:mergeDebugConsumerProguardFiles SKIPPED
:publishing-sdk:mergeDebugShaders SKIPPED
:publishing-sdk:compileDebugShaders SKIPPED
:publishing-sdk:generateDebugAssets SKIPPED
:publishing-sdk:packageDebugAssets SKIPPED
:publishing-sdk:packageDebugRenderscript SKIPPED
:publishing-sdk:prepareLintJarForPublish SKIPPED
:publishing-sdk:processDebugJavaRes SKIPPED
:publishing-sdk:mergeDebugJavaResource SKIPPED
:publishing-sdk:syncDebugLibJars SKIPPED
:publishing-sdk:writeDebugAarMetadata SKIPPED
:publishing-sdk:bundleDebugAar SKIPPED
:publishing-sdk:compileDebugSources SKIPPED
:publishing-sdk:assembleDebug SKIPPED
:publishing-sdk:preReleaseBuild SKIPPED
:publishing-sdk:compileReleaseAidl SKIPPED
:publishing-sdk:mergeReleaseJniLibFolders SKIPPED
:publishing-sdk:mergeReleaseNativeLibs SKIPPED
:publishing-sdk:stripReleaseDebugSymbols SKIPPED
:publishing-sdk:copyReleaseJniLibsProjectAndLocalJars SKIPPED
:publishing-sdk:compileReleaseRenderscript SKIPPED
:publishing-sdk:generateReleaseBuildConfig SKIPPED
:publishing-sdk:generateReleaseResValues SKIPPED
:publishing-sdk:generateReleaseResources SKIPPED
:publishing-sdk:packageReleaseResources SKIPPED
:publishing-sdk:parseReleaseLocalResources SKIPPED
:publishing-sdk:processReleaseManifest SKIPPED
:publishing-sdk:generateReleaseRFile SKIPPED
:publishing-sdk:compileReleaseKotlin SKIPPED
:publishing-sdk:javaPreCompileRelease SKIPPED
:publishing-sdk:compileReleaseJavaWithJavac SKIPPED
:publishing-sdk:extractReleaseAnnotations SKIPPED
:publishing-sdk:mergeReleaseGeneratedProguardFiles SKIPPED
:publishing-sdk:mergeReleaseConsumerProguardFiles SKIPPED
:publishing-sdk:mergeReleaseShaders SKIPPED
:publishing-sdk:compileReleaseShaders SKIPPED
:publishing-sdk:generateReleaseAssets SKIPPED
:publishing-sdk:packageReleaseAssets SKIPPED
:publishing-sdk:packageReleaseRenderscript SKIPPED
:publishing-sdk:processReleaseJavaRes SKIPPED
:publishing-sdk:mergeReleaseJavaResource SKIPPED
:publishing-sdk:syncReleaseLibJars SKIPPED
:publishing-sdk:writeReleaseAarMetadata SKIPPED
:publishing-sdk:bundleReleaseAar SKIPPED
:publishing-sdk:compileReleaseSources SKIPPED
:publishing-sdk:mergeReleaseResources SKIPPED
:publishing-sdk:verifyReleaseResources SKIPPED
:publishing-sdk:assembleRelease SKIPPED
:publishing-sdk:assemble SKIPPED
```