### PR TITLE
Mark private SDK elements as internal

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Constants.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Constants.kt
@@ -1,10 +1,10 @@
 package com.ably.tracking.publisher
 
-const val MILLISECONDS_PER_SECOND = 1000
+internal const val MILLISECONDS_PER_SECOND = 1000
 
-const val LOCATION_TYPE_FUSED = "fused"
+internal const val LOCATION_TYPE_FUSED = "fused"
 
-object EventNames {
+internal object EventNames {
     const val RAW = "raw"
     const val ENHANCED = "enhanced"
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/GeoJsonMappers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/GeoJsonMappers.kt
@@ -4,7 +4,7 @@ import android.location.Location
 import com.google.gson.Gson
 import io.ably.lib.types.Message
 
-fun Location.toGeoJson(): GeoJsonMessage =
+internal fun Location.toGeoJson(): GeoJsonMessage =
     GeoJsonMessage(
         GeoJsonTypes.FEATURE,
         GeoJsonGeometry(GeoJsonTypes.POINT, listOf(longitude, latitude)),
@@ -17,13 +17,13 @@ fun Location.toGeoJson(): GeoJsonMessage =
         )
     )
 
-fun GeoJsonMessage.toJsonArray(gson: Gson): String =
+internal fun GeoJsonMessage.toJsonArray(gson: Gson): String =
     gson.toJson(listOf(this))
 
-fun List<GeoJsonMessage>.toJsonArray(gson: Gson): String =
+internal fun List<GeoJsonMessage>.toJsonArray(gson: Gson): String =
     gson.toJson(this)
 
-fun GeoJsonMessage.toLocation(): Location =
+internal fun GeoJsonMessage.toLocation(): Location =
     Location(LOCATION_TYPE_FUSED).apply {
         longitude = geometry.coordinates[GEOMETRY_LONG_INDEX]
         latitude = geometry.coordinates[GEOMETRY_LAT_INDEX]
@@ -34,5 +34,5 @@ fun GeoJsonMessage.toLocation(): Location =
         time = (properties.time * MILLISECONDS_PER_SECOND).toLong()
     }
 
-fun Message.getGeoJsonMessages(gson: Gson): List<GeoJsonMessage> =
+internal fun Message.getGeoJsonMessages(gson: Gson): List<GeoJsonMessage> =
     gson.fromJson(data as String, Array<GeoJsonMessage>::class.java).toList()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/MessageModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/MessageModels.kt
@@ -1,14 +1,14 @@
 package com.ably.tracking.publisher
 
-object GeoJsonTypes {
+internal object GeoJsonTypes {
     const val FEATURE = "Feature"
     const val POINT = "Point"
 }
 
-const val GEOMETRY_LONG_INDEX = 0
-const val GEOMETRY_LAT_INDEX = 1
+internal const val GEOMETRY_LONG_INDEX = 0
+internal const val GEOMETRY_LAT_INDEX = 1
 
-data class GeoJsonMessage(
+internal data class GeoJsonMessage(
     val type: String,
     val geometry: GeoJsonGeometry,
     val properties: GeoJsonProperties
@@ -19,9 +19,9 @@ data class GeoJsonMessage(
         "[time:${properties.time}; lon:${geometry.coordinates[GEOMETRY_LONG_INDEX]} lat:${geometry.coordinates[GEOMETRY_LAT_INDEX]}; brg:${properties.bearing}]"
 }
 
-data class GeoJsonGeometry(val type: String, val coordinates: List<Double>)
+internal data class GeoJsonGeometry(val type: String, val coordinates: List<Double>)
 
-data class GeoJsonProperties(
+internal data class GeoJsonProperties(
     val accuracyHorizontal: Float,
     val altitude: Double,
     val bearing: Float,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
@@ -15,7 +15,7 @@ import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
 import timber.log.Timber
 
-class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
+internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
     LocationEngine {
     private val gson = Gson()
     private var lastLocationResult: LocationEngineResult? = null


### PR DESCRIPTION
Elements that shouldn't be visible outside the SDK were marked as `internal`.
Partially fixes the issue https://github.com/ably/ably-asset-tracking-android/issues/38