### PR TITLE
Add listener for notifying if tracked asset is online

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Constants.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Constants.kt
@@ -8,3 +8,8 @@ internal object EventNames {
     const val RAW = "raw"
     const val ENHANCED = "enhanced"
 }
+
+internal object ClientTypes {
+    const val SUBSCRIBER = "subscriber"
+    const val PUBLISHER = "publisher"
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -66,6 +66,7 @@ constructor(
             sendEnhancedLocationMessage(enhancedLocation, keyPoints)
         }
     }
+    private val presenceData = PresenceData(ClientTypes.PUBLISHER)
     private var isTracking: Boolean = false
     private var mapboxReplayer: MapboxReplayer? = null
 
@@ -178,7 +179,8 @@ constructor(
         channel = ably.channels.get(delivery.id).apply {
             try {
                 presence.enterClient(
-                    ablyConfiguration.clientId, "",
+                    ablyConfiguration.clientId,
+                    gson.toJson(presenceData),
                     object : CompletionListener {
                         override fun onSuccess() = Unit
 
@@ -222,7 +224,8 @@ constructor(
                 channel = null
                 try {
                     it.presence.leaveClient(
-                        ablyConfiguration.clientId, "",
+                        ablyConfiguration.clientId,
+                        gson.toJson(presenceData),
                         object : CompletionListener {
                             override fun onSuccess() = Unit
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/MessageModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/MessageModels.kt
@@ -28,3 +28,5 @@ internal data class GeoJsonProperties(
     val speed: Float,
     val time: Double
 )
+
+internal data class PresenceData(val type: String)

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -63,7 +63,13 @@ class MainActivity : AppCompatActivity() {
             .rawLocationUpdatedListener {} // if you prefer to display raw location call showMarkerOnMap() here
             .enhancedLocationUpdatedListener { showMarkerOnMap(it) }
             .trackingId(trackingId)
+            .assetStatusListener { updateAssetStatusInfo(it) }
             .start()
+    }
+
+    private fun updateAssetStatusInfo(isOnline: Boolean) {
+        assetStatusTextView.text =
+            getString(if (isOnline) R.string.asset_status_online else R.string.asset_status_offline)
     }
 
     private fun stopSubscribing() {

--- a/subscribing-example-app/src/main/res/layout/activity_main.xml
+++ b/subscribing-example-app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,16 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
+    android:id="@+id/assetStatusTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="30dp"
+    android:text="@string/asset_status_offline"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintBottom_toBottomOf="@id/animationSwitch"
+    app:layout_constraintTop_toTopOf="@id/animationSwitch" />
+
+  <TextView
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginEnd="10dp"

--- a/subscribing-example-app/src/main/res/values/strings.xml
+++ b/subscribing-example-app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
   <string name="start_button_working">Stop</string>
   <string name="tracking_id">Tracking ID</string>
   <string name="animation">Animation</string>
+  <string name="asset_status_offline">The asset is offline</string>
+  <string name="asset_status_online">The asset is online</string>
 </resources>

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/AssetSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/AssetSubscriber.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.subscriber
 import android.location.Location
 
 typealias LocationUpdatedListener = (Location) -> Unit
+typealias StatusListener = (Boolean) -> Unit
 
 interface AssetSubscriber {
     companion object {
@@ -72,6 +73,14 @@ interface AssetSubscriber {
          * @return A new instance of the builder with tracking ID changed
          */
         fun trackingId(trackingId: String): Builder
+
+        /**
+         * Sets asset status listener for checking if asset is online
+         *
+         * @param listener Listener function that takes [Boolean] that's true when asset is online
+         * @return A new instance of the builder with this field changed
+         */
+        fun assetStatusListener(listener: StatusListener): Builder
 
         /**
          * Creates an [AssetSubscriber] and starts subscribing to the asset location

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/AssetSubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/AssetSubscriberBuilder.kt
@@ -6,7 +6,8 @@ internal data class AssetSubscriberBuilder(
     val rawLocationUpdatedListener: LocationUpdatedListener? = null,
     val enhancedLocationUpdatedListener: LocationUpdatedListener? = null,
     val resolution: Double? = null,
-    val trackingId: String? = null
+    val trackingId: String? = null,
+    val assetStatusListener: StatusListener? = null
 ) : AssetSubscriber.Builder {
 
     override fun ablyConfig(configuration: AblyConfiguration): AssetSubscriber.Builder =
@@ -27,6 +28,9 @@ internal data class AssetSubscriberBuilder(
     override fun trackingId(trackingId: String): AssetSubscriber.Builder =
         this.copy(trackingId = trackingId)
 
+    override fun assetStatusListener(listener: (Boolean) -> Unit): AssetSubscriber.Builder =
+        this.copy(assetStatusListener = listener)
+
     override fun start(): AssetSubscriber {
         if (isMissingRequiredFields()) {
             throw BuilderConfigurationIncompleteException()
@@ -36,7 +40,8 @@ internal data class AssetSubscriberBuilder(
             ablyConfiguration!!,
             rawLocationUpdatedListener!!,
             enhancedLocationUpdatedListener!!,
-            trackingId!!
+            trackingId!!,
+            assetStatusListener
         )
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Constants.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Constants.kt
@@ -8,3 +8,8 @@ internal object EventNames {
     const val RAW = "raw"
     const val ENHANCED = "enhanced"
 }
+
+internal object ClientTypes {
+    const val SUBSCRIBER = "subscriber"
+    const val PUBLISHER = "publisher"
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/MessageMappers.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/MessageMappers.kt
@@ -1,0 +1,7 @@
+package com.ably.tracking.subscriber
+
+import com.google.gson.Gson
+import io.ably.lib.types.PresenceMessage
+
+internal fun PresenceMessage.getData(gson: Gson): PresenceData =
+    gson.fromJson(data as String, PresenceData::class.java)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/MessageModels.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/MessageModels.kt
@@ -23,3 +23,5 @@ internal data class GeoJsonProperties(
     val speed: Float,
     val time: Double
 )
+
+internal data class PresenceData(val type: String)

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
@@ -175,6 +175,32 @@ class FactoryUnitTests {
     }
 
     @Test
+    fun `setting asset status listener updates builder field`() {
+        // given
+        val listener: StatusListener = {}
+
+        // when
+        val builder =
+            AssetSubscriber.subscribers().assetStatusListener(listener) as AssetSubscriberBuilder
+
+        // then
+        Assert.assertEquals(listener, builder.assetStatusListener)
+    }
+
+    @Test
+    fun `setting asset status listener returns a new copy of builder`() {
+        // given
+        val listener: StatusListener = {}
+        val originalBuilder = AssetSubscriber.subscribers()
+
+        // when
+        val newBuilder = originalBuilder.assetStatusListener(listener)
+
+        // then
+        Assert.assertNotEquals(newBuilder, originalBuilder)
+    }
+
+    @Test
     fun `setting all data should update all builder fields`() {
         // given
         val builder = AssetSubscriber.subscribers()


### PR DESCRIPTION
I've added a listener that notifies subscriber SDK user about asset connection changes. It checks the presence and if a publisher is present in the presence then the connection is online. In other cases it is offline. In example app the connection status is displayed as a text above the map.