### PR TITLE
Import only the core MapBox dependencies that we really need

### DIFF
--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -7,7 +7,13 @@ plugins {
 dependencies {
     api project(':core-sdk')
 
-    // TODO work out if these are the right dependencies to be importing for MapBox
-    implementation "com.mapbox.navigation:ui:1.1.0"
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.5.0'
+    // The MapBox Navigation SDK for Android.
+    // We're not using the pre-built UI components, so just need the core dependency.
+    // https://docs.mapbox.com/android/navigation/overview/
+    implementation 'com.mapbox.navigation:core:1.1.0'
+
+    // Only the Core SDK portion of the MapBox Maps SDK for Android.
+    // https://docs.mapbox.com/android/maps/overview/
+    // https://docs.mapbox.com/android/core/overview/
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:3.1.0'
 }


### PR DESCRIPTION
This has been bugging me since the inception of this project, so I decided to spend some time this afternoon browsing the MapBox documentation site to work out how they slice their SDKs.

Thankfully they expose convenient core SDK subsets which fit our needs, in terms of those APIs we're currently using.