### PR TITLE
Add tracked asset destination support

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -20,7 +20,6 @@ import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
@@ -353,14 +352,6 @@ constructor(
             }
         }
     }
-
-    private fun getRouteCoordinates(
-        startingLocation: Location,
-        destination: Destination
-    ): List<Point> = listOf(
-        Point.fromLngLat(startingLocation.longitude, startingLocation.latitude),
-        Point.fromLngLat(destination.longitude, destination.latitude)
-    )
 
     private fun removeCurrentDestination() {
         mapboxNavigation.setRoutes(emptyList())

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/MabpoxHelpers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/MabpoxHelpers.kt
@@ -1,0 +1,18 @@
+package com.ably.tracking.publisher
+
+import android.location.Location
+import com.mapbox.geojson.Point
+
+/**
+ *  Returns list of [Point] that Mapbox will treat as a route for a trip.
+ *  First element in the list is the starting position.
+ *  Last element in the list is the final position.
+ * */
+internal fun getRouteCoordinates(
+    startingLocation: Location,
+    destination: Destination
+): List<Point> =
+    listOf(
+        Point.fromLngLat(startingLocation.longitude, startingLocation.latitude),
+        Point.fromLngLat(destination.longitude, destination.latitude)
+    )


### PR DESCRIPTION
In order to set destination we need to have a starting point and a destination. I'm using the latest known raw location as the starting point.
In case of a situation in which the destination is being set before we get any location update, first raw location update will also set the destination. It's not the most elegant solution but it works. 
In the future we may use the `getLastLocation()` method of `LocationEngine` when we'll be implementing our own location engine.