### PR TITLE
Rename Ably configuration to connection configuration

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking
 
-data class AblyConfiguration(val apiKey: String, val clientId: String)
+data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
 data class LogConfiguration(val enabled: Boolean) // TODO - specify config
 

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -20,7 +20,7 @@ import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.TransportationMode
 import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.realtime.ConnectionStateListener
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import kotlinx.android.synthetic.main.activity_main.*
 import pub.devrel.easypermissions.AfterPermissionGranted
 import pub.devrel.easypermissions.EasyPermissions
@@ -107,7 +107,7 @@ class MainActivity : AppCompatActivity() {
     private fun createAndStartAssetPublisher(trackingId: String, historyData: String? = null) {
         clearLocationInfo()
         publisher = Publisher.publishers()
-            .ably(AblyConfiguration(ABLY_API_KEY, CLIENT_ID))
+            .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID))
             .map(MapConfiguration(MAPBOX_ACCESS_TOKEN))
             .debug(createDebugConfiguration(historyData))
             .locationUpdatedListener { updateLocationInfo(it) }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -8,7 +8,7 @@ import android.location.Location
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.PresenceData
@@ -40,7 +40,7 @@ private const val DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 10
 internal class DefaultPublisher
 @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
 constructor(
-    private val ablyConfiguration: AblyConfiguration,
+    private val connectionConfiguration: ConnectionConfiguration,
     mapConfiguration: MapConfiguration,
     private val debugConfiguration: DebugConfiguration?,
     private val locationUpdatedListener: LocationUpdatedListener,
@@ -77,7 +77,7 @@ constructor(
     private var mapboxReplayer: MapboxReplayer? = null
 
     init {
-        ably = AblyRealtime(ablyConfiguration.apiKey)
+        ably = AblyRealtime(connectionConfiguration.apiKey)
 
         Timber.w("Started.")
 
@@ -111,7 +111,7 @@ constructor(
     ) {
         mapboxBuilder.locationEngine(
             AblySimulationLocationEngine(
-                ClientOptions(ablyConfiguration.apiKey),
+                ClientOptions(connectionConfiguration.apiKey),
                 locationSource.simulationChannelName
             )
         )
@@ -181,7 +181,7 @@ constructor(
         channel = ably.channels.get(trackable.id).apply {
             try {
                 presence.enterClient(
-                    ablyConfiguration.clientId,
+                    connectionConfiguration.clientId,
                     gson.toJson(presenceData),
                     object : CompletionListener {
                         override fun onSuccess() = Unit
@@ -236,7 +236,7 @@ constructor(
                 channel = null
                 try {
                     it.presence.leaveClient(
-                        ablyConfiguration.clientId,
+                        connectionConfiguration.clientId,
                         gson.toJson(presenceData),
                         object : CompletionListener {
                             override fun onSuccess() = Unit

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -5,7 +5,7 @@ import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import android.location.Location
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LogConfiguration
 
 typealias LocationUpdatedListener = (Location) -> Unit
@@ -91,12 +91,12 @@ interface Publisher {
 
     interface Builder {
         /**
-         * Sets the Ably configuration.
+         * Sets the Ably connection configuration.
          *
-         * @param configuration The configuration to be used for Ably.
+         * @param configuration The configuration to be used for Ably connection.
          * @return A new instance of the builder with this property changed.
          */
-        fun ably(configuration: AblyConfiguration): Builder
+        fun connection(configuration: ConnectionConfiguration): Builder
 
         /**
          * Sets the maps configuration.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -4,12 +4,12 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AblyConfiguration
 import com.ably.tracking.BuilderConfigurationIncompleteException
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LogConfiguration
 
 internal data class PublisherBuilder(
-    val ablyConfiguration: AblyConfiguration? = null,
+    val connectionConfiguration: ConnectionConfiguration? = null,
     val mapConfiguration: MapConfiguration? = null,
     val logConfiguration: LogConfiguration? = null,
     val debugConfiguration: DebugConfiguration? = null,
@@ -19,8 +19,8 @@ internal data class PublisherBuilder(
     val resolutionPolicy: ResolutionPolicy? = null
 ) : Publisher.Builder {
 
-    override fun ably(configuration: AblyConfiguration): Publisher.Builder =
-        this.copy(ablyConfiguration = configuration)
+    override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
+        this.copy(connectionConfiguration = configuration)
 
     override fun map(configuration: MapConfiguration): Publisher.Builder =
         this.copy(mapConfiguration = configuration)
@@ -50,7 +50,7 @@ internal data class PublisherBuilder(
         }
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultPublisher(
-            ablyConfiguration!!,
+            connectionConfiguration!!,
             mapConfiguration!!,
             debugConfiguration,
             locationUpdatedListener!!,
@@ -60,7 +60,7 @@ internal data class PublisherBuilder(
 
     // TODO - define which fields are required and which are optional (for now: only fields needed to create Publisher)
     private fun isMissingRequiredFields() =
-        ablyConfiguration == null ||
+        connectionConfiguration == null ||
             mapConfiguration == null ||
             locationUpdatedListener == null ||
             androidContext == null ||

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
@@ -2,8 +2,8 @@ package com.ably.tracking.publisher
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.ably.tracking.AblyConfiguration
 import com.ably.tracking.BuilderConfigurationIncompleteException
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LogConfiguration
 import io.mockk.mockk
 import org.junit.Assert
@@ -25,25 +25,25 @@ class FactoryUnitTests {
     }
 
     @Test
-    fun `setting Ably config updates builder field`() {
+    fun `setting Ably connection config updates builder field`() {
         // given
-        val configuration = AblyConfiguration("", "")
+        val configuration = ConnectionConfiguration("", "")
 
         // when
-        val builder = Publisher.publishers().ably(configuration) as PublisherBuilder
+        val builder = Publisher.publishers().connection(configuration) as PublisherBuilder
 
         // then
-        Assert.assertEquals(configuration, builder.ablyConfiguration)
+        Assert.assertEquals(configuration, builder.connectionConfiguration)
     }
 
     @Test
-    fun `setting Ably config returns a new copy of builder`() {
+    fun `setting Ably connection config returns a new copy of builder`() {
         // given
-        val configuration = AblyConfiguration("", "")
+        val configuration = ConnectionConfiguration("", "")
         val originalBuilder = Publisher.publishers()
 
         // when
-        val newBuilder = originalBuilder.ably(configuration)
+        val newBuilder = originalBuilder.connection(configuration)
 
         // then
         Assert.assertNotEquals(newBuilder, originalBuilder)
@@ -186,7 +186,7 @@ class FactoryUnitTests {
 
         // when
         val updatedBuilder = builder
-            .ably(AblyConfiguration("", ""))
+            .connection(ConnectionConfiguration("", ""))
             .map(MapConfiguration(""))
             .log(LogConfiguration(true))
             .locationUpdatedListener { }
@@ -203,7 +203,7 @@ class FactoryUnitTests {
     }
 
     private fun assertAllBuilderFieldsAreNull(builder: PublisherBuilder) {
-        Assert.assertNull(builder.ablyConfiguration)
+        Assert.assertNull(builder.connectionConfiguration)
         Assert.assertNull(builder.mapConfiguration)
         Assert.assertNull(builder.logConfiguration)
         Assert.assertNull(builder.locationUpdatedListener)
@@ -211,7 +211,7 @@ class FactoryUnitTests {
     }
 
     private fun assertAllBuilderFieldsAreNotNull(builder: PublisherBuilder) {
-        Assert.assertNotNull(builder.ablyConfiguration)
+        Assert.assertNotNull(builder.connectionConfiguration)
         Assert.assertNotNull(builder.mapConfiguration)
         Assert.assertNotNull(builder.logConfiguration)
         Assert.assertNotNull(builder.locationUpdatedListener)

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -4,7 +4,7 @@ import android.location.Location
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.subscriber.Subscriber
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun createAndStartAssetSubscriber(trackingId: String) {
         subscriber = Subscriber.subscribers()
-            .ably(AblyConfiguration(ABLY_API_KEY, CLIENT_ID))
+            .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID))
             .rawLocationUpdatedListener {} // if you prefer to display raw location call showMarkerOnMap() here
             .enhancedLocationUpdatedListener { showMarkerOnMap(it) }
             .trackingId(trackingId)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.subscriber
 import android.location.Location
 import android.os.Handler
 import android.os.Looper
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.PresenceData
@@ -20,7 +20,7 @@ import io.ably.lib.types.PresenceMessage
 import timber.log.Timber
 
 internal class DefaultSubscriber(
-    private val ablyConfiguration: AblyConfiguration,
+    private val connectionConfiguration: ConnectionConfiguration,
     rawLocationUpdatedListener: LocationUpdatedListener,
     enhancedLocationUpdatedListener: LocationUpdatedListener,
     trackingId: String,
@@ -32,7 +32,7 @@ internal class DefaultSubscriber(
     private val presenceData = PresenceData(ClientTypes.SUBSCRIBER)
 
     init {
-        ably = AblyRealtime(ablyConfiguration.apiKey)
+        ably = AblyRealtime(connectionConfiguration.apiKey)
         channel = ably.channels.get(
             trackingId,
             ChannelOptions().apply { params = mapOf("rewind" to "1") }
@@ -76,7 +76,7 @@ internal class DefaultSubscriber(
             notifyAssetIsOffline()
             channel.presence.subscribe { onPresenceMessage(it) }
             channel.presence.enterClient(
-                ablyConfiguration.clientId,
+                connectionConfiguration.clientId,
                 gson.toJson(presenceData),
                 object : CompletionListener {
                     override fun onSuccess() = Unit
@@ -100,7 +100,7 @@ internal class DefaultSubscriber(
             channel.presence.unsubscribe()
             notifyAssetIsOffline()
             channel.presence.leaveClient(
-                ablyConfiguration.clientId,
+                connectionConfiguration.clientId,
                 gson.toJson(presenceData),
                 object : CompletionListener {
                     override fun onSuccess() = Unit

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.subscriber
 
 import android.location.Location
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LogConfiguration
 
 typealias LocationUpdatedListener = (Location) -> Unit
@@ -29,12 +29,12 @@ interface Subscriber {
 
     interface Builder {
         /**
-         * Sets the Ably configuration.
+         * Sets the Ably connection configuration.
          *
-         * @param configuration Ably library configuration object [AblyConfiguration]
-         * @return A new instance of the builder with Ably configuration changed
+         * @param configuration The configuration to be used for Ably connection.
+         * @return A new instance of the builder with this property changed.
          */
-        fun ably(configuration: AblyConfiguration): Builder
+        fun connection(configuration: ConnectionConfiguration): Builder
 
         /**
          * Sets the logging configuration.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -1,11 +1,11 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AblyConfiguration
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.LogConfiguration
 
 internal data class SubscriberBuilder(
-    val ablyConfiguration: AblyConfiguration? = null,
+    val connectionConfiguration: ConnectionConfiguration? = null,
     val logConfiguration: LogConfiguration? = null,
     val rawLocationUpdatedListener: LocationUpdatedListener? = null,
     val enhancedLocationUpdatedListener: LocationUpdatedListener? = null,
@@ -14,8 +14,8 @@ internal data class SubscriberBuilder(
     val assetStatusListener: StatusListener? = null
 ) : Subscriber.Builder {
 
-    override fun ably(configuration: AblyConfiguration): Subscriber.Builder =
-        this.copy(ablyConfiguration = configuration)
+    override fun connection(configuration: ConnectionConfiguration): Subscriber.Builder =
+        this.copy(connectionConfiguration = configuration)
 
     override fun log(configuration: LogConfiguration): Subscriber.Builder =
         this.copy(logConfiguration = configuration)
@@ -41,7 +41,7 @@ internal data class SubscriberBuilder(
         }
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultSubscriber(
-            ablyConfiguration!!,
+            connectionConfiguration!!,
             rawLocationUpdatedListener!!,
             enhancedLocationUpdatedListener!!,
             trackingId!!,
@@ -51,7 +51,7 @@ internal data class SubscriberBuilder(
 
     // TODO - define which fields are required and which are optional (for now: only fields needed to create AssetSubscriber)
     private fun isMissingRequiredFields() =
-        ablyConfiguration == null ||
+        connectionConfiguration == null ||
             rawLocationUpdatedListener == null ||
             enhancedLocationUpdatedListener == null ||
             trackingId == null

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
@@ -2,8 +2,8 @@ package com.ably.tracking.subscriber
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.ably.tracking.AblyConfiguration
 import com.ably.tracking.BuilderConfigurationIncompleteException
+import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LogConfiguration
 import io.mockk.mockk
 import org.junit.Assert
@@ -22,26 +22,26 @@ class FactoryUnitTests {
     }
 
     @Test
-    fun `setting Ably config updates builder field`() {
+    fun `setting Ably connection config updates builder field`() {
         // given
-        val configuration = AblyConfiguration("", "")
+        val configuration = ConnectionConfiguration("", "")
 
         // when
         val builder =
-            Subscriber.subscribers().ably(configuration) as SubscriberBuilder
+            Subscriber.subscribers().connection(configuration) as SubscriberBuilder
 
         // then
-        Assert.assertEquals(configuration, builder.ablyConfiguration)
+        Assert.assertEquals(configuration, builder.connectionConfiguration)
     }
 
     @Test
-    fun `setting Ably config returns a new copy of builder`() {
+    fun `setting Ably connection config returns a new copy of builder`() {
         // given
-        val configuration = AblyConfiguration("", "")
+        val configuration = ConnectionConfiguration("", "")
         val originalBuilder = Subscriber.subscribers()
 
         // when
-        val newBuilder = originalBuilder.ably(configuration)
+        val newBuilder = originalBuilder.connection(configuration)
 
         // then
         Assert.assertNotEquals(newBuilder, originalBuilder)
@@ -212,7 +212,7 @@ class FactoryUnitTests {
 
         // when
         val updatedBuilder = builder
-            .ably(AblyConfiguration("", ""))
+            .connection(ConnectionConfiguration("", ""))
             .log(LogConfiguration(true))
             .rawLocationUpdatedListener { }
             .enhancedLocationUpdatedListener { }
@@ -230,7 +230,7 @@ class FactoryUnitTests {
     }
 
     private fun assertAllBuilderFieldsAreNull(builder: SubscriberBuilder) {
-        Assert.assertNull(builder.ablyConfiguration)
+        Assert.assertNull(builder.connectionConfiguration)
         Assert.assertNull(builder.logConfiguration)
         Assert.assertNull(builder.rawLocationUpdatedListener)
         Assert.assertNull(builder.enhancedLocationUpdatedListener)
@@ -239,7 +239,7 @@ class FactoryUnitTests {
     }
 
     private fun assertAllBuilderFieldsAreNotNull(builder: SubscriberBuilder) {
-        Assert.assertNotNull(builder.ablyConfiguration)
+        Assert.assertNotNull(builder.connectionConfiguration)
         Assert.assertNotNull(builder.logConfiguration)
         Assert.assertNotNull(builder.rawLocationUpdatedListener)
         Assert.assertNotNull(builder.enhancedLocationUpdatedListener)


### PR DESCRIPTION
I've renamed the `AblyConfiguration` and `ably()` to `ConnectionConfiguration` and `connection()`.
I've taken the name from [Paddy's comment](https://github.com/ably/ably-asset-tracking-android/pull/43#discussion_r531799287) :wink: