### PR TITLE
Prototype algorithm for the default resolution policy implementation

### DIFF
--- a/decision-tree-exploration/ResolutionPolicyDecisionTree/src/Main.kt
+++ b/decision-tree-exploration/ResolutionPolicyDecisionTree/src/Main.kt
@@ -93,8 +93,9 @@ fun computeNetworkingResolution(trackable: Trackable, deviceBatteryLevel: Batter
         trackable.resolutionParameters[state] ?:
         trackable.defaultResolution
     else {
+        val fallbackState = ResolutionsParametersState(ProximityThresholdState.ABOVE, SubscribersPresenceState.NOT_PRESENT)
         trackable.resolutionParameters[state] ?:
-        trackable.resolutionParameters[ResolutionsParametersState(ProximityThresholdState.ABOVE, SubscribersPresenceState.NOT_PRESENT)] ?:
+        trackable.resolutionParameters[fallbackState] ?:
         trackable.defaultResolution
     }
 


### PR DESCRIPTION
## This is not intended to be merged - just a place to discuss the logic

The logic of the policy is presented in a form of Kotlin function. 
Assumptions are listed in the bottom of the Main.kt file

This is currently a very naive logic, also with significant drawbacks as it requires a lot of parameters, and this can (and will be) simplified. 