### PR TITLE
Handle remaining Publisher actions with events queue

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -393,8 +393,11 @@ constructor(
         }
     }
 
-    // TODO define threading strategy: https://github.com/ably/ably-asset-tracking-android/issues/22
     private fun setDestination(destination: Destination) {
+        enqueue(SetDestinationEvent(destination))
+    }
+
+    private fun performSetDestination(event: SetDestinationEvent) {
         lastKnownLocation.let { currentLocation ->
             if (currentLocation != null) {
                 destinationToSet = null
@@ -402,11 +405,11 @@ constructor(
                     RouteOptions.builder()
                         .applyDefaultParams()
                         .accessToken(mapConfiguration.apiKey)
-                        .coordinates(getRouteCoordinates(currentLocation, destination))
+                        .coordinates(getRouteCoordinates(currentLocation, event.destination))
                         .build()
                 )
             } else {
-                destinationToSet = destination
+                destinationToSet = event.destination
             }
         }
     }
@@ -438,6 +441,7 @@ constructor(
                     is ClearActiveTrackableEvent -> performClearActiveTrackable(event)
                     is RawLocationChangedEvent -> performRawLocationChanged(event)
                     is EnhancedLocationChangedEvent -> performEnhancedLocationChanged(event)
+                    is SetDestinationEvent -> performSetDestination(event)
                 }
             }
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -62,3 +62,7 @@ internal data class EnhancedLocationChangedEvent(
     val location: Location,
     val geoJsonMessages: List<GeoJsonMessage>
 ) : PublisherEvent()
+
+internal data class SetDestinationEvent(
+    val destination: Destination
+) : PublisherEvent()


### PR DESCRIPTION
I've added events for location updates and setting destination.

I haven't changed the Ably state listener on purpose. The main problem is that when we're closing the Publisher then we're closing the `scope`. This cancels all running jobs and stops the events queue. So the state change from Ably isn't reaching the listener, because the scope is closed. In our example app it makes the Ably state to always show "ONLINE" even after stopping publisher :wink:
That listener is a debug feature and in order to make it work with our queue approach I would have to make a few changes and I don't think that's needed. Let me know if you disagree with me :wink: