### PR TITLE
Implement stopping strategy for Publisher SDK

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -184,10 +184,15 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun stopTracking() {
-        publisher?.stop()
-        publisher = null
-
-        changeNavigationButtonState(false)
+        publisher?.stop {
+            when (it) {
+                is SuccessResult -> {
+                    publisher = null
+                    changeNavigationButtonState(false)
+                }
+                is FailureResult -> showToast("Stopping Publisher has failed")
+            }
+        }
     }
 
     private fun updateLocationInfo(location: Location) {

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -94,7 +94,15 @@ public class PublisherInterfaceUsageExamples {
         TransportationMode transportationMode = new TransportationMode("TBC");
         publisher.setTransportationMode(transportationMode);
         transportationMode = publisher.getTransportationMode();
-        publisher.stop();
+        publisher.stop(
+            result -> {
+                if (result.isSuccess()) {
+                    Timber.d("Success");
+                } else {
+                    Timber.e(result.exception());
+                }
+            }
+        );
     }
 
     @Test

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -588,6 +588,7 @@ constructor(
                 debugConfiguration?.locationHistoryHandler?.invoke(retrieveHistory())
                 onDestroy()
             }
+            enqueue(MapboxStoppedEvent())
         }
     }
 
@@ -675,6 +676,9 @@ constructor(
         isStopped = true
     }
 
+    private fun performMapboxStopped() {
+    }
+
     private fun performAblyStopped() {
     }
 
@@ -708,6 +712,7 @@ constructor(
                     is PresenceMessageEvent -> performPresenceMessage(event)
                     is ChangeLocationEngineResolutionEvent -> performChangeLocationEngineResolution()
                     is AblyStoppedEvent -> performAblyStopped()
+                    is MapboxStoppedEvent -> performMapboxStopped()
                     is PublisherStoppedEvent -> performPublisherStopped()
                 }
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -113,6 +113,12 @@ constructor(
      **/
     private var isStopping = false
 
+    /**
+     * Initially this field is set to false. It will be set to true when the publisher is stopped.
+     * After set to true this field shouldn't be ever changed to false.
+     **/
+    private var isStopped = false
+
     init {
         eventsChannel = createEventsChannel(scope)
         policy = resolutionPolicyFactory.createResolutionPolicy(
@@ -661,6 +667,10 @@ constructor(
         }
     }
 
+    private fun performPublisherStopped() {
+        isStopped = true
+    }
+
     private fun postToMainThread(operation: () -> Unit) {
         Handler(getLooperForMainThread()).post(operation)
     }
@@ -690,6 +700,7 @@ constructor(
                     is SetDestinationSuccessEvent -> performSetDestinationSuccess(event)
                     is PresenceMessageEvent -> performPresenceMessage(event)
                     is ChangeLocationEngineResolutionEvent -> performChangeLocationEngineResolution()
+                    is PublisherStoppedEvent -> performPublisherStopped()
                 }
             }
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -42,6 +42,7 @@ import com.mapbox.navigation.core.trip.session.LocationObserver
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.types.ErrorInfo
@@ -150,6 +151,9 @@ constructor(
             ably.connection.on { state ->
                 postToMainThread {
                     handler(state.toTracking())
+                }
+                if (state.current == ConnectionState.closed) {
+                    enqueue(AblyStoppedEvent())
                 }
             }
         }
@@ -671,6 +675,9 @@ constructor(
         isStopped = true
     }
 
+    private fun performAblyStopped() {
+    }
+
     private fun postToMainThread(operation: () -> Unit) {
         Handler(getLooperForMainThread()).post(operation)
     }
@@ -700,6 +707,7 @@ constructor(
                     is SetDestinationSuccessEvent -> performSetDestinationSuccess(event)
                     is PresenceMessageEvent -> performPresenceMessage(event)
                     is ChangeLocationEngineResolutionEvent -> performChangeLocationEngineResolution()
+                    is AblyStoppedEvent -> performAblyStopped()
                     is PublisherStoppedEvent -> performPublisherStopped()
                 }
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.launch
@@ -577,7 +576,6 @@ constructor(
         stopLocationUpdates()
         leavePresenceChannels()
         ably.close()
-        scope.cancel()
     }
 
     private fun stopLocationUpdates() {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -107,6 +107,12 @@ constructor(
      **/
     private var destinationToSet: Destination? = null
 
+    /**
+     * Initially this field is set to false. It will be set to true when the first [StopPublisherEvent] is being processed.
+     * After set to true this field shouldn't be ever changed to false.
+     **/
+    private var isStopping = false
+
     init {
         eventsChannel = createEventsChannel(scope)
         policy = resolutionPolicyFactory.createResolutionPolicy(
@@ -556,6 +562,7 @@ constructor(
     }
 
     private fun performStopPublisher() {
+        isStopping = true
         stopLocationUpdates()
         ably.close()
         scope.cancel()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -706,6 +706,10 @@ constructor(
     private fun createEventsChannel(scope: CoroutineScope) =
         scope.actor<PublisherEvent> {
             for (event in channel) {
+                if ((isStopping || isStopped) && event is IgnorablePublisherEvent) {
+                    Timber.d("Ignoring event $event")
+                    continue
+                }
                 when (event) {
                     is AddTrackableEvent -> performAddTrackable(event)
                     is TrackTrackableEvent -> performTrackTrackable(event)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -106,9 +106,14 @@ interface Publisher {
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      *
-     * It is strongly suggested to call this method from the main thread.
+     * @param handler Called when the publisher is successfully stopped or an error occurs.
      */
-    fun stop()
+    fun stop(handler: ResultHandler)
+
+    /**
+     * This method overload is provided for the convenience of those calling from Java.
+     */
+    fun stop(listener: ResultListener)
 
     /**
      * The methods implemented by builders capable of starting [Publisher] instances.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,6 +1,8 @@
 package com.ably.tracking.publisher
 
 import android.location.Location
+import com.ably.tracking.ConnectionStateChange
+import com.ably.tracking.ConnectionStateChangeHandler
 import com.ably.tracking.ResultHandler
 import com.ably.tracking.common.GeoJsonMessage
 import io.ably.lib.realtime.Channel
@@ -89,3 +91,8 @@ internal data class PresenceMessageEvent(
 ) : PublisherEvent()
 
 internal class ChangeLocationEngineResolutionEvent : PublisherEvent()
+
+internal data class AblyStatusChangedEvent(
+    val connectionState: ConnectionStateChange,
+    val handler: ConnectionStateChangeHandler?
+) : PublisherEvent()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -16,9 +16,13 @@ internal data class StopPublisherEvent(
     val handler: ResultHandler
 ) : PublisherEvent()
 
-internal class PublisherStoppedEvent : PublisherEvent()
+internal data class PublisherStoppedEvent(
+    val exception: Exception? = null
+) : PublisherEvent()
 
-internal class AblyStoppedEvent : PublisherEvent()
+internal data class AblyStoppedEvent(
+    val hasFailed: Boolean
+) : PublisherEvent()
 
 internal class MapboxStoppedEvent : PublisherEvent()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -9,6 +9,8 @@ internal sealed class PublisherEvent
 
 internal class StopPublisherEvent : PublisherEvent()
 
+internal class PublisherStoppedEvent(): PublisherEvent()
+
 internal class StartPublisherEvent : PublisherEvent()
 
 internal data class SuccessEvent(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -11,6 +11,8 @@ internal class StopPublisherEvent : PublisherEvent()
 
 internal class PublisherStoppedEvent(): PublisherEvent()
 
+internal class AblyStoppedEvent(): PublisherEvent()
+
 internal class StartPublisherEvent : PublisherEvent()
 
 internal data class SuccessEvent(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -10,6 +10,8 @@ import io.ably.lib.types.PresenceMessage
 
 internal sealed class PublisherEvent
 
+internal sealed class IgnorablePublisherEvent : PublisherEvent()
+
 internal data class StopPublisherEvent(
     val handler: ResultHandler
 ) : PublisherEvent()
@@ -35,62 +37,62 @@ internal data class AddTrackableEvent(
     val trackable: Trackable,
     val onSuccess: () -> Unit,
     val onError: (Exception) -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class TrackTrackableEvent(
     val trackable: Trackable,
     val onSuccess: () -> Unit,
     val onError: (Exception) -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class RemoveTrackableEvent(
     val trackable: Trackable,
     val onSuccess: (wasPresent: Boolean) -> Unit,
     val onError: (Exception) -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class JoinPresenceSuccessEvent(
     val trackable: Trackable,
     val channel: Channel,
     val onSuccess: () -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class TrackableReadyToTrackEvent(
     val trackable: Trackable,
     val onSuccess: () -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class ClearActiveTrackableEvent(
     val trackable: Trackable,
     val onSuccess: () -> Unit
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class RawLocationChangedEvent(
     val location: Location,
     val geoJsonMessage: GeoJsonMessage
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class EnhancedLocationChangedEvent(
     val location: Location,
     val geoJsonMessages: List<GeoJsonMessage>
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class SetDestinationEvent(
     val destination: Destination
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
-internal class RefreshResolutionPolicyEvent : PublisherEvent()
+internal class RefreshResolutionPolicyEvent : IgnorablePublisherEvent()
 
 internal data class SetDestinationSuccessEvent(
     val routeDurationInMilliseconds: Long
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
 internal data class PresenceMessageEvent(
     val trackable: Trackable,
     val presenceMessage: PresenceMessage
-) : PublisherEvent()
+) : IgnorablePublisherEvent()
 
-internal class ChangeLocationEngineResolutionEvent : PublisherEvent()
+internal class ChangeLocationEngineResolutionEvent : IgnorablePublisherEvent()
 
 internal data class AblyStatusChangedEvent(
     val connectionState: ConnectionStateChange,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -14,11 +14,11 @@ internal data class StopPublisherEvent(
     val handler: ResultHandler
 ) : PublisherEvent()
 
-internal class PublisherStoppedEvent() : PublisherEvent()
+internal class PublisherStoppedEvent : PublisherEvent()
 
-internal class AblyStoppedEvent() : PublisherEvent()
+internal class AblyStoppedEvent : PublisherEvent()
 
-internal class MapboxStoppedEvent() : PublisherEvent()
+internal class MapboxStoppedEvent : PublisherEvent()
 
 internal class StartPublisherEvent : PublisherEvent()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,19 +1,22 @@
 package com.ably.tracking.publisher
 
 import android.location.Location
+import com.ably.tracking.ResultHandler
 import com.ably.tracking.common.GeoJsonMessage
 import io.ably.lib.realtime.Channel
 import io.ably.lib.types.PresenceMessage
 
 internal sealed class PublisherEvent
 
-internal class StopPublisherEvent : PublisherEvent()
+internal data class StopPublisherEvent(
+    val handler: ResultHandler
+) : PublisherEvent()
 
-internal class PublisherStoppedEvent(): PublisherEvent()
+internal class PublisherStoppedEvent() : PublisherEvent()
 
-internal class AblyStoppedEvent(): PublisherEvent()
+internal class AblyStoppedEvent() : PublisherEvent()
 
-internal class MapboxStoppedEvent(): PublisherEvent()
+internal class MapboxStoppedEvent() : PublisherEvent()
 
 internal class StartPublisherEvent : PublisherEvent()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -13,6 +13,8 @@ internal class PublisherStoppedEvent(): PublisherEvent()
 
 internal class AblyStoppedEvent(): PublisherEvent()
 
+internal class MapboxStoppedEvent(): PublisherEvent()
+
 internal class StartPublisherEvent : PublisherEvent()
 
 internal data class SuccessEvent(


### PR DESCRIPTION
The new stopping strategy makes the `stop()` method work in an asynchronous way. Now it accepts a callback that returns either a success or failure. Whatever the result is,after calling `stop()` no further action should be called on the Publisher. Additionally, we're handling multiple calls to `stop()`, each of the callers will receive an appropriate callback.

In order to stop the publisher we're performing 3 major actions:
- leaving all trackable channels (asynchronous, but we're blocking queue until it's done)
- stopping Mapbox (synchronous)
- stopping Ably (asynchronous)

Calling `stop()` sets a flag `isStopping` which signalizes that the stopping process is ongoing and no events that aren't connected to the stopping procedure should be processed. In order to not lose track of those events we're logging each of the ignored event.
When stopping is finished then the `isStopped` flag is set.
Those flags help us react to `stop()` calls when the stopping procedure is ongoing or finished.

I've spotted a problem (which is fixed in this PR) with Mapbox not stopping the location updates after stopping our SDK. There was always a notification on the device that was saying that the trip is ongoing. This was because we were only removing location listeners, but we weren't stopping the navigation trip. Currently, the whole Mapbox is being cleaned and this fixes that issue.

FYI: I've started this branch on top of the new interface PR in order to be able to use that interface. The new interface is almost done and needs just some minor adjustments that shouldn't affect that PR.