### PR TITLE
Add missing android coroutines dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,7 @@ subprojects {
             if (evaluatedSubProjectIsALibrary) {
                 implementation 'io.ably:ably-android:1.2.2'
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
+
                 // Projects that use our SDK projects will crash when dispatching to the Main thread on
                 // the Android runtime unless we include this dependency. See:
                 // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html


### PR DESCRIPTION
It turns out that we need to add an Android coroutines dependency in order to be able to use `Dispatchers.Main` with coroutines. 
I've stumbled upon that error when I've tried to use Subscriber example app. In Publisher everything was working probably because one of its dependencies (most likely Mapbox) already uses that library. But now it's explicitly listed in our dependencies.