### PR TITLE
Add proguard configuration

### DIFF
--- a/core-sdk/build.gradle
+++ b/core-sdk/build.gradle
@@ -4,4 +4,10 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
 }
 
+android {
+    defaultConfig {
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+}
+
 apply from: '../jacoco.gradle'

--- a/core-sdk/consumer-rules.pro
+++ b/core-sdk/consumer-rules.pro
@@ -1,0 +1,13 @@
+# Rules that are shared in both Subscribing and Publishing SDKs
+
+# Keep all annotations (needed in order to properly handle JSON names with @SerializedName annotation) and signatures
+-keepattributes *Annotation*
+-keepattributes Signature
+
+# Keep GeoJSON classes (without it Subscriber couldn't parse messages from Publisher)
+-keep class com.ably.tracking.common.GeoJsonMessage { *; }
+-keep class com.ably.tracking.common.GeoJsonGeometry { *; }
+-keep class com.ably.tracking.common.GeoJsonProperties { *; }
+
+# Keep all enum values (if those enums are used) for enums that are in com.ably.tracking or any of its subpackages.
+-keepclassmembers enum com.ably.tracking.** { *; }

--- a/core-sdk/consumer-rules.pro
+++ b/core-sdk/consumer-rules.pro
@@ -4,10 +4,14 @@
 -keepattributes *Annotation*
 -keepattributes Signature
 
-# Keep GeoJSON classes (without it Subscriber couldn't parse messages from Publisher)
+# TODO when common module is ready put all those classes into a package and replace below lines with one that keeps all inside the package
+# Keep message classes that are sent over Ably (without it Subscriber couldn't parse messages from Publisher)
 -keep class com.ably.tracking.common.GeoJsonMessage { *; }
 -keep class com.ably.tracking.common.GeoJsonGeometry { *; }
 -keep class com.ably.tracking.common.GeoJsonProperties { *; }
+-keep class com.ably.tracking.common.EnhancedLocationUpdateMessage { *; }
+-keep class com.ably.tracking.common.PresenceData { *; }
+-keep class com.ably.tracking.common.ResolutionRequest { *; }
 
 # Keep all enum values (if those enums are used) for enums that are in com.ably.tracking or any of its subpackages.
 -keepclassmembers enum com.ably.tracking.** { *; }

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -1,5 +1,7 @@
 package com.ably.tracking
 
+import com.google.gson.annotations.SerializedName
+
 data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
 data class LogConfiguration(val enabled: Boolean) // TODO - specify config
@@ -63,6 +65,7 @@ data class Resolution(
      * significantly increased power usage. Conversely, the lowest power usage will be achieved by specifying
      * [Accuracy.MINIMUM] but at the expense of significantly decreased positional accuracy.
      */
+    @SerializedName("accuracy")
     val accuracy: Accuracy,
 
     /**
@@ -74,6 +77,7 @@ data class Resolution(
      * Used to govern the frequency of updates requested from the underlying location provider, as well as the frequency
      * of messages broadcast to subscribers.
      */
+    @SerializedName("desiredInterval")
     val desiredInterval: Long,
 
     /**
@@ -84,5 +88,6 @@ data class Resolution(
      *
      * Used to configure the underlying location provider, as well as to filter the broadcast of updates to subscribers.
      */
+    @SerializedName("minimumDisplacement")
     val minimumDisplacement: Double
 )

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -1,7 +1,5 @@
 package com.ably.tracking
 
-import com.google.gson.annotations.SerializedName
-
 data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
 data class LogConfiguration(val enabled: Boolean) // TODO - specify config
@@ -65,7 +63,6 @@ data class Resolution(
      * significantly increased power usage. Conversely, the lowest power usage will be achieved by specifying
      * [Accuracy.MINIMUM] but at the expense of significantly decreased positional accuracy.
      */
-    @SerializedName("accuracy")
     val accuracy: Accuracy,
 
     /**
@@ -77,7 +74,6 @@ data class Resolution(
      * Used to govern the frequency of updates requested from the underlying location provider, as well as the frequency
      * of messages broadcast to subscribers.
      */
-    @SerializedName("desiredInterval")
     val desiredInterval: Long,
 
     /**
@@ -88,6 +84,5 @@ data class Resolution(
      *
      * Used to configure the underlying location provider, as well as to filter the broadcast of updates to subscribers.
      */
-    @SerializedName("minimumDisplacement")
     val minimumDisplacement: Double
 )

--- a/core-sdk/src/main/java/com/ably/tracking/common/MessageMappers.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/MessageMappers.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.common
 
 import com.ably.tracking.EnhancedLocationUpdate
+import com.ably.tracking.Resolution
 import com.google.gson.Gson
 import io.ably.lib.types.Message
 import io.ably.lib.types.PresenceMessage
@@ -20,3 +21,7 @@ fun Message.getEnhancedLocationUpdate(gson: Gson): EnhancedLocationUpdate =
                 message.type
             )
         }
+
+fun Resolution.toRequest(): ResolutionRequest = ResolutionRequest(accuracy, desiredInterval, minimumDisplacement)
+
+fun ResolutionRequest.toResolution(): Resolution = Resolution(accuracy, desiredInterval, minimumDisplacement)

--- a/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -48,7 +48,7 @@ data class ResolutionRequest(
 )
 
 data class EnhancedLocationUpdateMessage(
-    val location: GeoJsonMessage,
-    val intermediateLocations: List<GeoJsonMessage>,
-    val type: LocationUpdateType
+    @SerializedName("location") val location: GeoJsonMessage,
+    @SerializedName("intermediateLocations") val intermediateLocations: List<GeoJsonMessage>,
+    @SerializedName("type") val type: LocationUpdateType
 )

--- a/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -26,7 +26,7 @@ data class GeoJsonMessage(
 data class GeoJsonGeometry(
     @SerializedName("type") val type: String,
     @SerializedName("coordinates") val coordinates: List<Double>
-    )
+)
 
 data class GeoJsonProperties(
     @SerializedName("accuracyHorizontal") val accuracyHorizontal: Float,

--- a/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.common
 
 import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.Resolution
+import com.google.gson.annotations.SerializedName
 
 object GeoJsonTypes {
     const val FEATURE = "Feature"
@@ -12,9 +13,9 @@ const val GEOMETRY_LONG_INDEX = 0
 const val GEOMETRY_LAT_INDEX = 1
 
 data class GeoJsonMessage(
-    val type: String,
-    val geometry: GeoJsonGeometry,
-    val properties: GeoJsonProperties
+    @SerializedName("type") val type: String,
+    @SerializedName("geometry") val geometry: GeoJsonGeometry,
+    @SerializedName("properties") val properties: GeoJsonProperties
 ) {
     // WARNING: Don't add fields to this class because they will be serialized and present in JSON
 
@@ -22,17 +23,23 @@ data class GeoJsonMessage(
         "[time:${properties.time}; lon:${geometry.coordinates[GEOMETRY_LONG_INDEX]} lat:${geometry.coordinates[GEOMETRY_LAT_INDEX]}; brg:${properties.bearing}]"
 }
 
-data class GeoJsonGeometry(val type: String, val coordinates: List<Double>)
+data class GeoJsonGeometry(
+    @SerializedName("type") val type: String,
+    @SerializedName("coordinates") val coordinates: List<Double>
+    )
 
 data class GeoJsonProperties(
-    val accuracyHorizontal: Float,
-    val altitude: Double,
-    val bearing: Float,
-    val speed: Float,
-    val time: Double
+    @SerializedName("accuracyHorizontal") val accuracyHorizontal: Float,
+    @SerializedName("altitude") val altitude: Double,
+    @SerializedName("bearing") val bearing: Float,
+    @SerializedName("speed") val speed: Float,
+    @SerializedName("time") val time: Double
 )
 
-data class PresenceData(val type: String, val resolution: Resolution? = null)
+data class PresenceData(
+    @SerializedName("type") val type: String,
+    @SerializedName("resolution") val resolution: Resolution? = null
+)
 
 data class EnhancedLocationUpdateMessage(
     val location: GeoJsonMessage,

--- a/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.common
 
+import com.ably.tracking.Accuracy
 import com.ably.tracking.LocationUpdateType
-import com.ably.tracking.Resolution
 import com.google.gson.annotations.SerializedName
 
 object GeoJsonTypes {
@@ -38,7 +38,13 @@ data class GeoJsonProperties(
 
 data class PresenceData(
     @SerializedName("type") val type: String,
-    @SerializedName("resolution") val resolution: Resolution? = null
+    @SerializedName("resolution") val resolutionRequest: ResolutionRequest? = null
+)
+
+data class ResolutionRequest(
+    @SerializedName("accuracy") val accuracy: Accuracy,
+    @SerializedName("desiredInterval") val desiredInterval: Long,
+    @SerializedName("minimumDisplacement") val minimumDisplacement: Double
 )
 
 data class EnhancedLocationUpdateMessage(

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true
         applicationId "com.ably.tracking.example.publisher"
+        proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
 }
 

--- a/publishing-example-app/proguard-rules.pro
+++ b/publishing-example-app/proguard-rules.pro
@@ -19,3 +19,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep all enum values (if those enums are used) for enums that are in com.amplifyframework or any of its subpackages.
+# Needed for Amplify library.
+-keepclassmembers enum com.amplifyframework.** { *; }
+
+# Keep all enum values (if those enums are used) for enums that are in com.amazonaws or any of its subpackages.
+# Needed for Amplify library.
+-keepclassmembers enum com.amazonaws.** { *; }

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -6,6 +6,12 @@ plugins {
 
 apply from: '../jacoco.gradle'
 
+android {
+    defaultConfig {
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+}
+
 dependencies {
     api project(':core-sdk')
 

--- a/publishing-sdk/consumer-rules.pro
+++ b/publishing-sdk/consumer-rules.pro
@@ -1,0 +1,6 @@
+# Keep all enum values (if those enums are used) for enums that are in com.ably.tracking or any of its subpackages.
+-keepclassmembers enum com.ably.tracking.** { *; }
+
+# Keep all classes from com.mapbox.navigation.core.replay.history package (without subpackages).
+# They're needed for replaying history location events in the Publisher.
+-keep class com.mapbox.navigation.core.replay.history.* {*;}

--- a/publishing-sdk/consumer-rules.pro
+++ b/publishing-sdk/consumer-rules.pro
@@ -1,5 +1,4 @@
-# Keep all enum values (if those enums are used) for enums that are in com.ably.tracking or any of its subpackages.
--keepclassmembers enum com.ably.tracking.** { *; }
+# Publishing SDK specific rules
 
 # Keep all classes from com.mapbox.navigation.core.replay.history package (without subpackages).
 # They're needed for replaying history location events in the Publisher.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -26,6 +26,7 @@ import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.getPresenceData
 import com.ably.tracking.common.toJava
 import com.ably.tracking.common.toJson
+import com.ably.tracking.common.toResolution
 import com.ably.tracking.publisher.debug.AblySimulationLocationEngine
 import com.ably.tracking.publisher.locationengine.FusedAndroidLocationEngine
 import com.ably.tracking.publisher.locationengine.GoogleLocationEngine
@@ -463,7 +464,7 @@ constructor(
             subscribers[trackable] = mutableSetOf()
         }
         subscribers[trackable]?.add(subscriber)
-        saveOrRemoveResolutionRequest(data.resolution, trackable, subscriber)
+        saveOrRemoveResolutionRequest(data.resolutionRequest?.toResolution(), trackable, subscriber)
         hooks.subscribers?.onSubscriberAdded(subscriber)
         resolveResolution(trackable)
     }
@@ -471,8 +472,8 @@ constructor(
     private fun updateSubscriber(id: String, trackable: Trackable, data: PresenceData) {
         subscribers[trackable]?.let { subscribers ->
             subscribers.find { it.id == id }?.let { subscriber ->
-                data.resolution.let { resolution ->
-                    saveOrRemoveResolutionRequest(resolution, trackable, subscriber)
+                data.resolutionRequest.let { resolution ->
+                    saveOrRemoveResolutionRequest(resolution?.toResolution(), trackable, subscriber)
                     resolveResolution(trackable)
                 }
             }

--- a/subscribing-example-app/build.gradle
+++ b/subscribing-example-app/build.gradle
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         applicationId "com.ably.tracking.example.subscriber"
         resValue "string", "google_maps_api_key", "${property('GOOGLE_MAPS_API_KEY')}"
+        proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
 }
 

--- a/subscribing-sdk/build.gradle
+++ b/subscribing-sdk/build.gradle
@@ -6,6 +6,12 @@ plugins {
 
 apply from: '../jacoco.gradle'
 
+android {
+    defaultConfig {
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+}
+
 dependencies {
     api project(':core-sdk')
 }

--- a/subscribing-sdk/consumer-rules.pro
+++ b/subscribing-sdk/consumer-rules.pro
@@ -1,0 +1,1 @@
+# Subscribing SDK specific rules

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -17,6 +17,7 @@ import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.getEnhancedLocationUpdate
 import com.ably.tracking.common.getPresenceData
 import com.ably.tracking.common.toJava
+import com.ably.tracking.common.toRequest
 import com.ably.tracking.toTracking
 import com.google.gson.Gson
 import io.ably.lib.realtime.AblyRealtime
@@ -45,7 +46,7 @@ internal class DefaultSubscriber(
     private val ably: AblyRealtime
     private val channel: Channel
     private val gson = Gson()
-    private var presenceData = PresenceData(ClientTypes.SUBSCRIBER, resolution)
+    private var presenceData = PresenceData(ClientTypes.SUBSCRIBER, resolution?.toRequest())
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val eventsChannel: SendChannel<Event>
 
@@ -89,7 +90,7 @@ internal class DefaultSubscriber(
     }
 
     private fun performChangeResolution(event: ChangeResolutionEvent) {
-        presenceData = presenceData.copy(resolution = event.resolution)
+        presenceData = presenceData.copy(resolutionRequest = event.resolution?.toRequest())
         channel.presence.update(
             gson.toJson(presenceData),
             object : CompletionListener {


### PR DESCRIPTION
I've prepared a Proguard configuration so the SDKs users will not have to worry about configuring Proguard for our SDK.
I've had to add `@SerializedName` annotations so fields that are parsed to JSON won't get obfuscated. Because of that I also had to add that annotations to the `Resolution` class which I don't like TBH. Maybe we should introduce some other class that will be a container for Resolution that will be then parsed to JSON? :thinking: