### PR TITLE
Remove a check that doesn't allow to call `track()` method multiple times

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -284,14 +284,6 @@ constructor(
     }
 
     private fun performTrackTrackable(event: TrackTrackableEvent) {
-        if (active != null) {
-            callback(
-                event.handler,
-                ErrorInformation("For this preview version of the SDK, this method may only be called once for any given instance of this class.")
-            )
-            return
-        }
-
         createChannelForTrackableIfNotExisits(event.trackable) {
             if (it.isSuccess) {
                 enqueue(SetActiveTrackableEvent(event.trackable, event.handler))


### PR DESCRIPTION
I've removed a check that was added in the past when we didn't have a proper threading strategy and support for multiple assets tracking. With current implementation it should be safe to call `publisher.track()` multiple times.