### PR TITLE
Stop navigation trip session and cleanup Mapbox when stopping the Publisher

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -518,11 +518,11 @@ constructor(
                 }
                 clear()
             }
-            mapboxReplayer?.finish()
-            debugConfiguration?.locationHistoryHandler?.invoke(mapboxNavigation.retrieveHistory())
             mapboxNavigation.apply {
-                toggleHistory(false)
-                toggleHistory(true)
+                stopTripSession()
+                mapboxReplayer?.finish()
+                debugConfiguration?.locationHistoryHandler?.invoke(retrieveHistory())
+                onDestroy()
             }
         }
     }


### PR DESCRIPTION
Previously, we were just stopping location updates to the listeners, but the navigation (or trip session) was still ongoing. Now we're both stopping the trip session and clearing the Mapbox instance when we're stopping the Publisher.