### PR TITLE
Fix updating subscriber's resolution without passing the client ID

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -1,5 +1,7 @@
 package com.ably.tracking
 
+import io.ably.lib.types.ClientOptions
+
 /**
  * Extension converting Ably Realtime connection state to the equivalent [ConnectionState] API presented to users of
  * the Ably Asset Tracking SDKs.
@@ -44,3 +46,13 @@ fun io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange.toTrackin
         this.previous.toTracking(),
         this.reason?.toTracking()
     )
+
+/**
+ * Extension vending Ably client library ClientOptions from a [ConnectionConfiguration] instance.
+ */
+val ConnectionConfiguration.clientOptions: ClientOptions
+    get() {
+        val options = ClientOptions(this.apiKey)
+        options.clientId = this.clientId
+        return options
+    }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -15,6 +15,7 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.ResultHandler
 import com.ably.tracking.ResultListener
 import com.ably.tracking.SuccessResult
+import com.ably.tracking.clientOptions
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.MILLISECONDS_PER_SECOND
@@ -118,7 +119,7 @@ constructor(
             methods
         )
         locationEngineResolution = policy.resolve(emptySet())
-        ably = AblyRealtime(connectionConfiguration.apiKey)
+        ably = AblyRealtime(connectionConfiguration.clientOptions)
 
         Timber.w("Started.")
 
@@ -164,6 +165,7 @@ constructor(
     ) {
         mapboxBuilder.locationEngine(
             AblySimulationLocationEngine(
+                // TODO should there be a clientId in use here?
                 ClientOptions(connectionConfiguration.apiKey),
                 locationSource.simulationChannelName
             )
@@ -323,8 +325,7 @@ constructor(
             ably.channels.get(trackable.id).apply {
                 try {
                     presence.subscribe { enqueue(PresenceMessageEvent(trackable, it)) }
-                    presence.enterClient(
-                        connectionConfiguration.clientId,
+                    presence.enter(
                         gson.toJson(presenceData),
                         object : CompletionListener {
                             override fun onSuccess() {
@@ -379,8 +380,7 @@ constructor(
             // Leave Ably channel.
             removedChannel.presence.unsubscribe()
             try {
-                removedChannel.presence.leaveClient(
-                    connectionConfiguration.clientId,
+                removedChannel.presence.leave(
                     gson.toJson(presenceData),
                     object : CompletionListener {
                         override fun onSuccess() {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -10,6 +10,7 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.ResultHandler
 import com.ably.tracking.ResultListener
 import com.ably.tracking.SuccessResult
+import com.ably.tracking.clientOptions
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.PresenceData
@@ -51,7 +52,7 @@ internal class DefaultSubscriber(
 
     init {
         eventsChannel = createEventsChannel(scope)
-        ably = AblyRealtime(connectionConfiguration.apiKey)
+        ably = AblyRealtime(connectionConfiguration.clientOptions)
         channel = ably.channels.get(
             trackingId,
             ChannelOptions().apply { params = mapOf("rewind" to "1") }
@@ -91,8 +92,7 @@ internal class DefaultSubscriber(
 
     private fun performChangeResolution(event: ChangeResolutionEvent) {
         presenceData = presenceData.copy(resolution = event.resolution)
-        channel.presence.updateClient(
-            connectionConfiguration.clientId,
+        channel.presence.update(
             gson.toJson(presenceData),
             object : CompletionListener {
                 override fun onSuccess() {
@@ -119,8 +119,7 @@ internal class DefaultSubscriber(
         try {
             notifyAssetIsOffline()
             channel.presence.subscribe { enqueue(PresenceMessageEvent(it)) }
-            channel.presence.enterClient(
-                connectionConfiguration.clientId,
+            channel.presence.enter(
                 gson.toJson(presenceData),
                 object : CompletionListener {
                     override fun onSuccess() = Unit
@@ -143,8 +142,7 @@ internal class DefaultSubscriber(
         try {
             channel.presence.unsubscribe()
             notifyAssetIsOffline()
-            channel.presence.leaveClient(
-                connectionConfiguration.clientId,
+            channel.presence.leave(
                 gson.toJson(presenceData),
                 object : CompletionListener {
                     override fun onSuccess() = Unit


### PR DESCRIPTION
We were calling the `update` method which expects us to provide the client ID in the Ably object constructor. With current Ably object creation we should be using `updateClient` method instead. I've also created an issue for including the client ID in the Ably object constructor https://github.com/ably/ably-asset-tracking-android/issues/138.