### PR TITLE
Fix wrong ably state change events

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -40,7 +40,7 @@ fun io.ably.lib.types.ErrorInfo.toTracking() =
  */
 fun io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange.toTracking() =
     ConnectionStateChange(
-        this.previous.toTracking(),
         this.current.toTracking(),
+        this.previous.toTracking(),
         this.reason?.toTracking()
     )


### PR DESCRIPTION
The current and previous states were switched and the received state was wrong. I've changed the order and now the state should be correct.