### PR TITLE
Remove the secret variant / buildType.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,43 +129,29 @@ subprojects {
             }
 
             def applySecretBuildConfigFields = { buildType ->
-                // Configuration that must not be applied to SDK project main source set builds.
-                // This configuration is, however, required for Android's connectedCheck task (which uses the androidTest source set) - which is why
-                // we use it for that scenario using the android.testBuildType configuration.
+                // Configuration that must not be applied to SDK project main source set builds for the release variant/buildType.
+                // This configuration is, however, required for Android's connectedCheck task (which uses the androidTest source set
+                // with the debug variant/buildType).
                 // TODO drop buildType param by using closure delegate, which might be cleaner, or find alternative
                 // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/VariantDimension#buildConfigField(kotlin.String,%20kotlin.String,%20kotlin.String)
                 buildType.buildConfigField 'String', 'ABLY_API_KEY', "\"${property('ABLY_API_KEY')}\""
                 buildType.buildConfigField 'String', 'MAPBOX_ACCESS_TOKEN', "\"${property('MAPBOX_ACCESS_TOKEN')}\""
             }
 
-            // Override the default "debug" BuildType used by the `connectedCheck` Android task.
-            testBuildType "secret" // see android.buildTypes.secret
-
             // https://developer.android.com/studio/build/build-variants#build-types
             buildTypes {
-                secret {
-                    initWith debug
-
-                    // We need secrets to be injected into the generated BuildConfig class when integration testing,
-                    // across all projects, including SDKs.
-                    // This is being done under this new BuildType in order to make it impossible for the secrets to
-                    // be accidentally injected into debug or release builds when they don't generate example apps.
+                debug {
                     applySecretBuildConfigFields delegate
                 }
 
-                debug {
-                    // Secrets must not be injected into SDK builds - they are only for example apps or SDK
-                    // integration tests (via Android's `connectedCheck` task), in which case they are injected
-                    // by using the `secret` BuildType and used by Android tests using `testBuildType`.
-                    if (evaluatedSubProjectIsAnApp) {
-                        applySecretBuildConfigFields delegate
-                    }
-                }
-
                 release {
+                    // Secrets must not be injected into SDK builds - they are only for example apps or SDK
+                    // integration tests (via Android's `connectedCheck` task), which are testing using the debug
+                    // variant/buildType.
                     if (evaluatedSubProjectIsAnApp) {
                         applySecretBuildConfigFields delegate
                     }
+
                     minifyEnabled false
                     proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
                 }


### PR DESCRIPTION
Sorry, I found the wrong solution for the problem [previously](https://github.com/ably/ably-asset-tracking-android/pull/123).

This pull request reverts that mess.

See [discussion in Slack](https://ably-real-time.slack.com/archives/C01EPJENRD0/p1611068662093800).