### PR TITLE
Add native API methods to the facade interfaces

### DIFF
--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -77,9 +77,9 @@ public class PublisherInterfaceUsageExamples {
     @Test
     public void publisherUsageExample() {
         Trackable trackable = new Trackable("ID", null, null, null);
-        Trackable activeTrackable = nativePublisher.getActive();
-        nativePublisher.setRoutingProfile(RoutingProfile.CYCLING);
-        RoutingProfile routingProfile = nativePublisher.getRoutingProfile();
+        Trackable activeTrackable = publisher.getActive();
+        publisher.setRoutingProfile(RoutingProfile.CYCLING);
+        RoutingProfile routingProfile = publisher.getRoutingProfile();
         try {
             publisher.trackAsync(trackable, assetStatus -> {
                 // handle assetStatus

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture
 
 class DefaultPublisherFacade(
     private val publisher: Publisher
-) : PublisherFacade {
+) : PublisherFacade, Publisher by publisher {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     override fun trackAsync(trackable: Trackable, listener: AssetStatusListener?): CompletableFuture<Void> {

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture
  *
  * Kotlin users will generally prefer to directly use the interfaces offered by [Publisher].
  */
-interface PublisherFacade {
+interface PublisherFacade : Publisher {
     /**
      * Adds a [Trackable] object and makes it the actively tracked object, meaning that the state of the [active] field
      * will be updated to this object, if that wasn't already the case.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -86,6 +86,7 @@ interface Publisher {
      * The shared flow emitting location values when they become available.
      */
     val locations: SharedFlow<LocationUpdate>
+        @JvmSynthetic get
 
     /**
      * The shared flow emitting all trackables tracked by the publisher.

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture
 
 internal class DefaultSubscriberFacade(
     private val subscriber: Subscriber
-) : SubscriberFacade {
+) : SubscriberFacade, Subscriber by subscriber {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     override fun sendChangeRequestAsync(resolution: Resolution): CompletableFuture<Void> {

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture
  *
  * Kotlin users will generally prefer to directly use the interfaces offered by [Subscriber].
  */
-interface SubscriberFacade {
+interface SubscriberFacade : Subscriber {
     /**
      * Sends the desired resolution for updates, to be requested from the remote publisher.
      *

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -47,11 +47,13 @@ interface Subscriber {
      * The shared flow emitting enhanced location values when they become available.
      */
     val locations: SharedFlow<LocationUpdate>
+        @JvmSynthetic get
 
     /**
      * The shared flow emitting values when the online status of the asset changes.
      */
     val assetStatuses: StateFlow<AssetStatus>
+        @JvmSynthetic get
 
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be


### PR DESCRIPTION
I've used the Kotlin's native support for composition and [delegating](https://kotlinlang.org/docs/reference/delegation.html). The facade interfaces inherit from the Kotlin's interfaces and then in the implementation by saying i.e. `Publisher by publisher` we specify that all the methods of the `Publisher` interface should be handled by the `publisher` object.