### PR TITLE
Expose publisher trackables set to the SDK users

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -33,6 +33,8 @@ constructor(
         get() = core.locations
     override val connectionStates: SharedFlow<ConnectionStateChange>
         get() = core.connectionStates
+    override val trackables: SharedFlow<Set<Trackable>>
+        get() = core.trackables
 
     init {
         Timber.w("Started.")

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -90,6 +90,11 @@ interface Publisher {
     val connectionStates: SharedFlow<ConnectionStateChange>
 
     /**
+     * The shared flow emitting all trackables tracked by the publisher.
+     */
+    val trackables: SharedFlow<Set<Trackable>>
+
+    /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      */
     @JvmSynthetic


### PR DESCRIPTION
I've exposed the trackables that are present in the Publisher in order to make it easier for the users to use our SDK. The set is exposed as a `SharedFlow` which should guarantee that it always reflects the newest state of the Publisher.