### PR TITLE
Use only the Trackable ID when comparing trackables

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -218,7 +218,16 @@ data class Trackable(
     val metadata: String? = null,
     val destination: Destination? = null,
     val constraints: ResolutionConstraints? = null
-)
+) {
+    override fun equals(other: Any?): Boolean =
+        when (other) {
+            null -> false
+            is Trackable -> other.id == id
+            else -> false
+        }
+
+    override fun hashCode(): Int = id.hashCode()
+}
 
 data class Subscriber(val id: String, val trackable: Trackable)
 


### PR DESCRIPTION
Before that change a trackable was compared by all its fields. Some of those fields can change during its lifetime but it's still considered to be the same Trackable. That's why we should be comparing trackables only by their IDs.