### PR TITLE
Fix failing check workflow due to a Jacoco issue

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -7,6 +7,8 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    // Fixes failing tests when running on JDK 9 or above https://github.com/gradle/gradle/issues/5184#issuecomment-457865951
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
All our `check` workflows in all PRs are failing (even that they were passing just a few days before). It seems that Github Actions were updated and use a newer version of the JDK and this introduces some issues with our test code coverage tool Jacoco.

See: https://github.com/gradle/gradle/issues/5184