### PR TITLE
Decide which builder fields are required

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -2,8 +2,6 @@ package com.ably.tracking
 
 data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
-data class LogConfiguration(val enabled: Boolean) // TODO - specify config
-
 /**
  * Represents a status of an asset that's being tracked by a publisher.
  */

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -5,7 +5,6 @@ import android.content.Context;
 
 import com.ably.tracking.Accuracy;
 import com.ably.tracking.ConnectionConfiguration;
-import com.ably.tracking.LogConfiguration;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.publisher.DefaultProximity;
 import com.ably.tracking.publisher.DefaultResolutionConstraints;
@@ -61,7 +60,6 @@ public class PublisherInterfaceUsageExamples {
         publisherBuilder
             .androidContext(context)
             .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
-            .log(new LogConfiguration(true))
             .map(new MapConfiguration("API_KEY"))
             .resolutionPolicy(resolutionPolicyFactory)
             .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData("1.0", new ArrayList<>()), null))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -8,7 +8,6 @@ import com.ably.tracking.AssetStatus
 import com.ably.tracking.AblyException
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
-import com.ably.tracking.LogConfiguration
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -145,14 +144,6 @@ interface Publisher {
          * @return A new instance of the builder with this property changed.
          */
         fun map(configuration: MapConfiguration): Builder
-
-        /**
-         * Sets the logging configuration.
-         *
-         * @param configuration The configuration to be used for logging.
-         * @return A new instance of the builder with this property changed.
-         */
-        fun log(configuration: LogConfiguration): Builder
 
         /**
          * Sets the Android Context.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -4,8 +4,8 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AssetStatus
 import com.ably.tracking.AblyException
+import com.ably.tracking.AssetStatus
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import kotlinx.coroutines.flow.SharedFlow
@@ -130,7 +130,7 @@ interface Publisher {
      */
     interface Builder {
         /**
-         * Sets the Ably connection configuration.
+         * **REQUIRED** Sets the Ably connection configuration.
          *
          * @param configuration The configuration to be used for Ably connection.
          * @return A new instance of the builder with this property changed.
@@ -138,7 +138,7 @@ interface Publisher {
         fun connection(configuration: ConnectionConfiguration): Builder
 
         /**
-         * Sets the maps configuration.
+         * **REQUIRED** Sets the maps configuration.
          *
          * @param configuration The configuration to be used for maps.
          * @return A new instance of the builder with this property changed.
@@ -146,7 +146,7 @@ interface Publisher {
         fun map(configuration: MapConfiguration): Builder
 
         /**
-         * Sets the Android Context.
+         * **REQUIRED** Sets the Android Context.
          *
          * @param context The context of the application.
          * @return A new instance of the builder with this property changed.
@@ -154,7 +154,8 @@ interface Publisher {
         fun androidContext(context: Context): Builder
 
         /**
-         * Set the means of transport being used for the initial state of publishers created from this builder.
+         * **OPTIONAL** Set the means of transport being used for the initial state of publishers created from this builder.
+         * If not set then the default value is [RoutingProfile.DRIVING].
          *
          * @param profile The means of transport.
          * @return A new instance of the builder with this property changed.
@@ -162,7 +163,7 @@ interface Publisher {
         fun profile(profile: RoutingProfile): Builder
 
         /**
-         * Sets the policy factory to be used to define the target resolution for publishers created from this builder.
+         * **REQUIRED** Sets the policy factory to be used to define the target resolution for publishers created from this builder.
          *
          * @param factory The factory, whose [createResolutionPolicy][ResolutionPolicy.Factory.createResolutionPolicy]
          * method will be called exactly once when [start] is called.
@@ -171,7 +172,7 @@ interface Publisher {
         fun resolutionPolicy(factory: ResolutionPolicy.Factory): Builder
 
         /**
-         * Sets the location source to be used instead of the GPS.
+         * **OPTIONAL** Sets the location source to be used instead of the GPS.
          * The location source will be providing location updates for the [Publisher].
          *
          * @param locationSource The location source from which location updates will be received.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -6,12 +6,10 @@ import android.content.Context
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
-import com.ably.tracking.LogConfiguration
 
 internal data class PublisherBuilder(
     val connectionConfiguration: ConnectionConfiguration? = null,
     val mapConfiguration: MapConfiguration? = null,
-    val logConfiguration: LogConfiguration? = null,
     val androidContext: Context? = null,
     val routingProfile: RoutingProfile = RoutingProfile.DRIVING,
     val resolutionPolicyFactory: ResolutionPolicy.Factory? = null,
@@ -23,9 +21,6 @@ internal data class PublisherBuilder(
 
     override fun map(configuration: MapConfiguration): Publisher.Builder =
         this.copy(mapConfiguration = configuration)
-
-    override fun log(configuration: LogConfiguration): Publisher.Builder =
-        this.copy(logConfiguration = configuration)
 
     override fun androidContext(context: Context): Publisher.Builder =
         this.copy(androidContext = context)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -49,7 +49,6 @@ internal data class PublisherBuilder(
         )
     }
 
-    // TODO - define which fields are required and which are optional (for now: only fields needed to create Publisher)
     private fun isMissingRequiredFields() =
         connectionConfiguration == null ||
             mapConfiguration == null ||

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.location.Location
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
-import com.ably.tracking.LogConfiguration
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Test
@@ -65,31 +64,6 @@ class FactoryUnitTests {
     }
 
     @Test
-    fun `setting logging config updates builder field`() {
-        // given
-        val configuration = LogConfiguration(true)
-
-        // when
-        val builder = Publisher.publishers().log(configuration) as PublisherBuilder
-
-        // then
-        Assert.assertEquals(configuration, builder.logConfiguration)
-    }
-
-    @Test
-    fun `setting logging config returns a new copy of builder`() {
-        // given
-        val configuration = LogConfiguration(true)
-        val originalBuilder = Publisher.publishers()
-
-        // when
-        val newBuilder = originalBuilder.log(configuration)
-
-        // then
-        Assert.assertNotEquals(newBuilder, originalBuilder)
-    }
-
-    @Test
     fun `setting location source returns a new copy of builder`() {
         // given
         val locationSource = LocationSourceRaw.create(LocationHistoryData("1.0", emptyList()))
@@ -139,7 +113,6 @@ class FactoryUnitTests {
         val updatedBuilder = builder
             .connection(ConnectionConfiguration("", ""))
             .map(MapConfiguration(""))
-            .log(LogConfiguration(true))
             .androidContext(mockedContext)
 
         // then
@@ -155,14 +128,12 @@ class FactoryUnitTests {
     private fun assertAllBuilderFieldsAreNull(builder: PublisherBuilder) {
         Assert.assertNull(builder.connectionConfiguration)
         Assert.assertNull(builder.mapConfiguration)
-        Assert.assertNull(builder.logConfiguration)
         Assert.assertNull(builder.androidContext)
     }
 
     private fun assertAllBuilderFieldsAreNotNull(builder: PublisherBuilder) {
         Assert.assertNotNull(builder.connectionConfiguration)
         Assert.assertNotNull(builder.mapConfiguration)
-        Assert.assertNotNull(builder.logConfiguration)
         Assert.assertNotNull(builder.androidContext)
     }
 

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -2,7 +2,6 @@ package com.ably.tracking.example.javasubscriber;
 
 import com.ably.tracking.Accuracy;
 import com.ably.tracking.ConnectionConfiguration;
-import com.ably.tracking.LogConfiguration;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.subscriber.Subscriber;
 import com.ably.tracking.subscriber.java.SubscriberFacade;
@@ -38,7 +37,6 @@ public class UsageExamples {
     public void subscriberBuilderUsageExample() {
         Subscriber nativeSubscriber = subscriberBuilder
             .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
-            .log(new LogConfiguration(true))
             .trackingId("TRACKING_ID")
             .resolution(new Resolution(Accuracy.BALANCED, 1000L, 1.0))
             .start();

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -71,7 +71,7 @@ interface Subscriber {
      */
     interface Builder {
         /**
-         * Sets the Ably connection configuration.
+         * **REQUIRED** Sets the Ably connection configuration.
          *
          * @param configuration The configuration to be used for Ably connection.
          * @return A new instance of the builder with this property changed.
@@ -79,7 +79,7 @@ interface Subscriber {
         fun connection(configuration: ConnectionConfiguration): Builder
 
         /**
-         * Sets the desired resolution of updates, to be requested from the remote publisher.
+         * **OPTIONAL** Sets the desired resolution of updates, to be requested from the remote publisher.
          *
          * @param resolution An indication of how often to this subscriber would like the publisher to sample locations,
          * at what level of positional accuracy, and how often to send them back.
@@ -88,7 +88,7 @@ interface Subscriber {
         fun resolution(resolution: Resolution): Builder
 
         /**
-         * Sets the asset to be tracked, using its unique tracking identifier.
+         * **REQUIRED** Sets the asset to be tracked, using its unique tracking identifier.
          *
          * @param trackingId The unique tracking identifier for the asset.
          * @return A new instance of the builder with this property changed.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -3,7 +3,6 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.AssetStatus
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
-import com.ably.tracking.LogConfiguration
 import com.ably.tracking.Resolution
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,14 +77,6 @@ interface Subscriber {
          * @return A new instance of the builder with this property changed.
          */
         fun connection(configuration: ConnectionConfiguration): Builder
-
-        /**
-         * Sets the logging configuration.
-         *
-         * @param configuration Logging configuration object [LogConfiguration]
-         * @return A new instance of the builder with this property changed.
-         */
-        fun log(configuration: LogConfiguration): Builder
 
         /**
          * Sets the desired resolution of updates, to be requested from the remote publisher.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -2,21 +2,16 @@ package com.ably.tracking.subscriber
 
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
-import com.ably.tracking.LogConfiguration
 import com.ably.tracking.Resolution
 
 internal data class SubscriberBuilder(
     val connectionConfiguration: ConnectionConfiguration? = null,
-    val logConfiguration: LogConfiguration? = null,
     val resolution: Resolution? = null,
     val trackingId: String? = null
 ) : Subscriber.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Subscriber.Builder =
         this.copy(connectionConfiguration = configuration)
-
-    override fun log(configuration: LogConfiguration): Subscriber.Builder =
-        this.copy(logConfiguration = configuration)
 
     override fun resolution(resolution: Resolution): Subscriber.Builder =
         this.copy(resolution = resolution)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -30,7 +30,6 @@ internal data class SubscriberBuilder(
         )
     }
 
-    // TODO - define which fields are required and which are optional (for now: only fields needed to create AssetSubscriber)
     private fun isMissingRequiredFields() =
         connectionConfiguration == null ||
             trackingId == null

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import com.ably.tracking.Accuracy
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
-import com.ably.tracking.LogConfiguration
 import com.ably.tracking.Resolution
 import org.junit.Assert
 import org.junit.Test
@@ -31,32 +30,6 @@ class FactoryUnitTests {
 
         // when
         val newBuilder = originalBuilder.connection(configuration)
-
-        // then
-        Assert.assertNotEquals(newBuilder, originalBuilder)
-    }
-
-    @Test
-    fun `setting logging config updates builder field`() {
-        // given
-        val configuration = LogConfiguration(true)
-
-        // when
-        val builder =
-            Subscriber.subscribers().log(configuration) as SubscriberBuilder
-
-        // then
-        Assert.assertEquals(configuration, builder.logConfiguration)
-    }
-
-    @Test
-    fun `setting logging config returns a new copy of builder`() {
-        // given
-        val configuration = LogConfiguration(true)
-        val originalBuilder = Subscriber.subscribers()
-
-        // when
-        val newBuilder = originalBuilder.log(configuration)
 
         // then
         Assert.assertNotEquals(newBuilder, originalBuilder)
@@ -121,7 +94,6 @@ class FactoryUnitTests {
         // when
         val updatedBuilder = builder
             .connection(ConnectionConfiguration("", ""))
-            .log(LogConfiguration(true))
             .resolution(Resolution(Accuracy.BALANCED, 333, 666.6))
             .trackingId("")
 
@@ -137,14 +109,12 @@ class FactoryUnitTests {
 
     private fun assertAllBuilderFieldsAreNull(builder: SubscriberBuilder) {
         Assert.assertNull(builder.connectionConfiguration)
-        Assert.assertNull(builder.logConfiguration)
         Assert.assertNull(builder.resolution)
         Assert.assertNull(builder.trackingId)
     }
 
     private fun assertAllBuilderFieldsAreNotNull(builder: SubscriberBuilder) {
         Assert.assertNotNull(builder.connectionConfiguration)
-        Assert.assertNotNull(builder.logConfiguration)
         Assert.assertNotNull(builder.resolution)
         Assert.assertNotNull(builder.trackingId)
     }


### PR DESCRIPTION
I removed the `LogConfiguration` class as it was never used anywhere.
Then I marked the required and optional fields of both builders.