### PR TITLE
Renaming a few classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ val subscriber = Subscriber.subscribers() // Get an AssetSubscriber
         Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
     )
     .trackingId(trackingId) // provide the tracking identifier for the asset that needs to be tracked
-    .assetStates { } // provide a function to be called when the asset changes its state
+    .trackableStates { } // provide a function to be called when the asset changes its state
     .start() // start listening for updates
 
 // Listen for location updates

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ val subscriber = Subscriber.subscribers() // Get an AssetSubscriber
         Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
     )
     .trackingId(trackingId) // provide the tracking identifier for the asset that needs to be tracked
-    .assetStatus { } // provide a function to be called when the asset changes online/offline status
+    .assetStates { } // provide a function to be called when the asset changes its state
     .start() // start listening for updates
 
 // Listen for location updates

--- a/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
+++ b/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.java
 
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
 
 /**
@@ -13,8 +13,8 @@ interface LocationUpdateListener {
 
 /**
  * Defines an interface, to be implemented in Java code utilising the Ably Asset Tracking SDKs, allowing that code to
- * handle events indicating the online status of an asset.
+ * handle events indicating the state of an asset.
  */
-interface AssetStatusListener {
-    fun onStatusChanged(assetStatus: AssetStatus)
+interface AssetStateListener {
+    fun onStateChanged(assetState: AssetState)
 }

--- a/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
+++ b/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.java
 
-import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.TrackableState
 
 /**
  * Defines an interface, to be implemented in Java code utilising the Ably Asset Tracking SDKs, allowing that code to
@@ -13,8 +13,8 @@ interface LocationUpdateListener {
 
 /**
  * Defines an interface, to be implemented in Java code utilising the Ably Asset Tracking SDKs, allowing that code to
- * handle events indicating the state of an asset.
+ * handle events indicating the state of a trackable.
  */
-interface AssetStateListener {
-    fun onStateChanged(assetState: AssetState)
+interface TrackableStateListener {
+    fun onStateChanged(trackableState: TrackableState)
 }

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -3,23 +3,23 @@ package com.ably.tracking
 data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
 /**
- * Represents a state of an asset that's being tracked by a publisher.
+ * Represents a state of a trackable that's being tracked by a publisher.
  */
-sealed class AssetState {
+sealed class TrackableState {
     /**
-     * Asset state is [Online] when it's being actively tracked. This state can change to either [Offline] or [Failed].
+     * Trackable state is [Online] when it's being actively tracked. This state can change to either [Offline] or [Failed].
      */
-    class Online : AssetState()
+    class Online : TrackableState()
 
     /**
-     * Asset state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This state can change to either [Online] or [Failed].
+     * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This state can change to either [Online] or [Failed].
      */
-    data class Offline(val errorInformation: ErrorInformation? = null) : AssetState()
+    data class Offline(val errorInformation: ErrorInformation? = null) : TrackableState()
 
     /**
-     * Asset state is [Failed] when there was an error from which we cannot recover. This is a final state.
+     * Trackable state is [Failed] when there was an error from which we cannot recover. This is a final state.
      */
-    data class Failed(val errorInformation: ErrorInformation) : AssetState()
+    data class Failed(val errorInformation: ErrorInformation) : TrackableState()
 }
 
 /**

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -3,23 +3,23 @@ package com.ably.tracking
 data class ConnectionConfiguration(val apiKey: String, val clientId: String)
 
 /**
- * Represents a status of an asset that's being tracked by a publisher.
+ * Represents a state of an asset that's being tracked by a publisher.
  */
-sealed class AssetStatus {
+sealed class AssetState {
     /**
-     * Asset status is [Online] when it's being actively tracked. This status can change to either [Offline] or [Failed].
+     * Asset state is [Online] when it's being actively tracked. This state can change to either [Offline] or [Failed].
      */
-    class Online : AssetStatus()
+    class Online : AssetState()
 
     /**
-     * Asset status is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This status can change to either [Online] or [Failed].
+     * Asset state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This state can change to either [Online] or [Failed].
      */
-    data class Offline(val errorInformation: ErrorInformation? = null) : AssetStatus()
+    data class Offline(val errorInformation: ErrorInformation? = null) : AssetState()
 
     /**
-     * Asset status is [Failed] when there was an error from which we cannot recover. This is a final status.
+     * Asset state is [Failed] when there was an error from which we cannot recover. This is a final state.
      */
-    data class Failed(val errorInformation: ErrorInformation) : AssetStatus()
+    data class Failed(val errorInformation: ErrorInformation) : AssetState()
 }
 
 /**

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.publisher.Trackable
 import kotlinx.android.synthetic.main.activity_trackable_details.*
 import kotlinx.coroutines.CoroutineScope
@@ -48,8 +48,8 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
 
     private fun listenForPublisherChanges(publisherService: PublisherService?) {
         publisherService?.publisher?.apply {
-            getAssetStatus(trackableId)
-                ?.onEach { updateAssetStatusInfo(it) }
+            getAssetState(trackableId)
+                ?.onEach { updateAssetStateInfo(it) }
                 ?.launchIn(scope)
             locations
                 .onEach { updateLocationInfo(it.location) }
@@ -88,26 +88,26 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
         bearingValueTextView.text = if (bearing.length > 7) bearing.substring(0, 7) else bearing
     }
 
-    private fun updateAssetStatusInfo(status: AssetStatus) {
+    private fun updateAssetStateInfo(state: AssetState) {
         val textId: Int
         val colorId: Int
-        when (status) {
-            is AssetStatus.Online -> {
+        when (state) {
+            is AssetState.Online -> {
                 textId = R.string.online
                 colorId = R.color.asset_status_online
             }
-            is AssetStatus.Offline -> {
+            is AssetState.Offline -> {
                 textId = R.string.offline
                 colorId = R.color.asset_status_offline
             }
-            is AssetStatus.Failed -> {
+            is AssetState.Failed -> {
                 textId = R.string.failed
                 colorId = R.color.asset_status_failed
             }
         }
-        assetStatusValueTextView.text = getString(textId)
+        assetStateValueTextView.text = getString(textId)
         ImageViewCompat.setImageTintList(
-            assetStatusImageView,
+            assetStateImageView,
             ColorStateList.valueOf(ContextCompat.getColor(this, colorId))
         )
     }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
-import com.ably.tracking.AssetState
+import com.ably.tracking.TrackableState
 import com.ably.tracking.publisher.Trackable
 import kotlinx.android.synthetic.main.activity_trackable_details.*
 import kotlinx.coroutines.CoroutineScope
@@ -48,7 +48,7 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
 
     private fun listenForPublisherChanges(publisherService: PublisherService?) {
         publisherService?.publisher?.apply {
-            getAssetState(trackableId)
+            getTrackableState(trackableId)
                 ?.onEach { updateAssetStateInfo(it) }
                 ?.launchIn(scope)
             locations
@@ -88,19 +88,19 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
         bearingValueTextView.text = if (bearing.length > 7) bearing.substring(0, 7) else bearing
     }
 
-    private fun updateAssetStateInfo(state: AssetState) {
+    private fun updateAssetStateInfo(state: TrackableState) {
         val textId: Int
         val colorId: Int
         when (state) {
-            is AssetState.Online -> {
+            is TrackableState.Online -> {
                 textId = R.string.online
                 colorId = R.color.asset_status_online
             }
-            is AssetState.Offline -> {
+            is TrackableState.Offline -> {
                 textId = R.string.offline
                 colorId = R.color.asset_status_offline
             }
-            is AssetState.Failed -> {
+            is TrackableState.Failed -> {
                 textId = R.string.failed
                 colorId = R.color.asset_status_failed
             }

--- a/publishing-example-app/src/main/res/layout/activity_trackable_details.xml
+++ b/publishing-example-app/src/main/res/layout/activity_trackable_details.xml
@@ -19,7 +19,7 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <ImageView
-    android:id="@+id/assetStatusImageView"
+    android:id="@+id/assetStateImageView"
     android:layout_width="100dp"
     android:layout_height="44dp"
     android:layout_marginTop="16dp"
@@ -30,7 +30,7 @@
     app:tint="@color/asset_status_offline" />
 
   <TextView
-    android:id="@+id/assetStatusValueTextView"
+    android:id="@+id/assetStateValueTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:text="@string/offline"
@@ -38,13 +38,13 @@
     android:textColor="@color/black"
     android:textSize="18sp"
     android:textStyle="bold"
-    app:layout_constraintBottom_toBottomOf="@id/assetStatusImageView"
-    app:layout_constraintEnd_toEndOf="@id/assetStatusImageView"
-    app:layout_constraintStart_toStartOf="@id/assetStatusImageView"
-    app:layout_constraintTop_toTopOf="@id/assetStatusImageView" />
+    app:layout_constraintBottom_toBottomOf="@id/assetStateImageView"
+    app:layout_constraintEnd_toEndOf="@id/assetStateImageView"
+    app:layout_constraintStart_toStartOf="@id/assetStateImageView"
+    app:layout_constraintTop_toTopOf="@id/assetStateImageView" />
 
   <TextView
-    android:id="@+id/ablyConnectionStatusLabelTextView"
+    android:id="@+id/ablyConnectionStateLabelTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"
@@ -52,9 +52,9 @@
     android:textColor="@color/black"
     android:textSize="16sp"
     android:textStyle="bold"
-    app:layout_constraintBottom_toBottomOf="@id/assetStatusImageView"
+    app:layout_constraintBottom_toBottomOf="@id/assetStateImageView"
     app:layout_constraintStart_toStartOf="@id/stopTrackingButton"
-    app:layout_constraintTop_toTopOf="@id/assetStatusImageView" />
+    app:layout_constraintTop_toTopOf="@id/assetStateImageView" />
 
   <TextView
     android:id="@+id/locationSourceLabelTextView"
@@ -66,8 +66,8 @@
     android:textColor="@color/black"
     android:textSize="16sp"
     android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="@+id/ablyConnectionStatusLabelTextView"
-    app:layout_constraintTop_toBottomOf="@+id/ablyConnectionStatusLabelTextView" />
+    app:layout_constraintStart_toStartOf="@+id/ablyConnectionStateLabelTextView"
+    app:layout_constraintTop_toBottomOf="@+id/ablyConnectionStateLabelTextView" />
 
   <TextView
     android:id="@+id/locationSourceMethodTextView"
@@ -77,8 +77,8 @@
     android:textSize="16sp"
     android:textStyle="bold"
     app:layout_constraintBottom_toBottomOf="@id/locationSourceLabelTextView"
-    app:layout_constraintEnd_toEndOf="@id/assetStatusImageView"
-    app:layout_constraintStart_toStartOf="@id/assetStatusImageView"
+    app:layout_constraintEnd_toEndOf="@id/assetStateImageView"
+    app:layout_constraintStart_toStartOf="@id/assetStateImageView"
     app:layout_constraintTop_toTopOf="@id/locationSourceLabelTextView"
     tools:text="PHONE" />
 

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -79,11 +79,11 @@ public class PublisherInterfaceUsageExamples {
         publisher.setRoutingProfile(RoutingProfile.CYCLING);
         RoutingProfile routingProfile = publisher.getRoutingProfile();
         try {
-            publisher.trackAsync(trackable, assetState -> {
-                // handle assetState
+            publisher.trackAsync(trackable, trackableState -> {
+                // handle trackableState
             }).get();
-            publisher.addAsync(trackable, assetState -> {
-                // handle assetState
+            publisher.addAsync(trackable, trackableState -> {
+                // handle trackableState
             }).get();
             Boolean wasRemoved = publisher.removeAsync(trackable).get();
             publisher.stopAsync().get();
@@ -101,8 +101,8 @@ public class PublisherInterfaceUsageExamples {
         publisher.addLocationHistoryListener(locationHistory -> {
             // handle locationHistory
         });
-        publisher.addTrackableStateListener("ID", assetState -> {
-            // handle assetState
+        publisher.addTrackableStateListener("ID", trackableState -> {
+            // handle trackableState
         });
     }
 

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -79,11 +79,11 @@ public class PublisherInterfaceUsageExamples {
         publisher.setRoutingProfile(RoutingProfile.CYCLING);
         RoutingProfile routingProfile = publisher.getRoutingProfile();
         try {
-            publisher.trackAsync(trackable, assetStatus -> {
-                // handle assetStatus
+            publisher.trackAsync(trackable, assetState -> {
+                // handle assetState
             }).get();
-            publisher.addAsync(trackable, assetStatus -> {
-                // handle assetStatus
+            publisher.addAsync(trackable, assetState -> {
+                // handle assetState
             }).get();
             Boolean wasRemoved = publisher.removeAsync(trackable).get();
             publisher.stopAsync().get();
@@ -101,8 +101,8 @@ public class PublisherInterfaceUsageExamples {
         publisher.addLocationHistoryListener(locationHistory -> {
             // handle locationHistory
         });
-        publisher.addTrackableStatusListener("ID", assetStatus -> {
-            // handle assetStatus
+        publisher.addTrackableStateListener("ID", assetState -> {
+            // handle assetState
         });
     }
 

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.publisher.java
 
-import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
+import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.Trackable
 import kotlinx.coroutines.CoroutineScope
@@ -17,21 +17,21 @@ class DefaultPublisherFacade(
 ) : PublisherFacade, Publisher by publisher {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-    override fun trackAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void> {
+    override fun trackAsync(trackable: Trackable, listener: TrackableStateListener?): CompletableFuture<Void> {
         return scope.future {
             val flow = publisher.track(trackable)
-            listener?.let { assetStateListener ->
-                flow.onEach { assetState -> assetStateListener.onStateChanged(assetState) }
+            listener?.let { trackableStateListener ->
+                flow.onEach { trackableState -> trackableStateListener.onStateChanged(trackableState) }
                     .launchIn(scope)
             }
         }.thenRun { }
     }
 
-    override fun addAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void> {
+    override fun addAsync(trackable: Trackable, listener: TrackableStateListener?): CompletableFuture<Void> {
         return scope.future {
             val flow = publisher.add(trackable)
-            listener?.let { assetStateListener ->
-                flow.onEach { assetState -> assetStateListener.onStateChanged(assetState) }
+            listener?.let { trackableStateListener ->
+                flow.onEach { trackableState -> trackableStateListener.onStateChanged(trackableState) }
                     .launchIn(scope)
             }
         }.thenRun { }
@@ -59,8 +59,8 @@ class DefaultPublisherFacade(
             .launchIn(scope)
     }
 
-    override fun addTrackableStateListener(trackableId: String, listener: AssetStateListener) {
-        publisher.getAssetState(trackableId)
+    override fun addTrackableStateListener(trackableId: String, listener: TrackableStateListener) {
+        publisher.getTrackableState(trackableId)
             ?.onEach { listener.onStateChanged(it) }
             ?.launchIn(scope)
     }

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/DefaultPublisherFacade.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.publisher.java
 
-import com.ably.tracking.java.AssetStatusListener
+import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.Trackable
@@ -17,21 +17,21 @@ class DefaultPublisherFacade(
 ) : PublisherFacade, Publisher by publisher {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-    override fun trackAsync(trackable: Trackable, listener: AssetStatusListener?): CompletableFuture<Void> {
+    override fun trackAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void> {
         return scope.future {
             val flow = publisher.track(trackable)
-            listener?.let { assetStatusListener ->
-                flow.onEach { assetStatus -> assetStatusListener.onStatusChanged(assetStatus) }
+            listener?.let { assetStateListener ->
+                flow.onEach { assetState -> assetStateListener.onStateChanged(assetState) }
                     .launchIn(scope)
             }
         }.thenRun { }
     }
 
-    override fun addAsync(trackable: Trackable, listener: AssetStatusListener?): CompletableFuture<Void> {
+    override fun addAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void> {
         return scope.future {
             val flow = publisher.add(trackable)
-            listener?.let { assetStatusListener ->
-                flow.onEach { assetStatus -> assetStatusListener.onStatusChanged(assetStatus) }
+            listener?.let { assetStateListener ->
+                flow.onEach { assetState -> assetStateListener.onStateChanged(assetState) }
                     .launchIn(scope)
             }
         }.thenRun { }
@@ -59,9 +59,9 @@ class DefaultPublisherFacade(
             .launchIn(scope)
     }
 
-    override fun addTrackableStatusListener(trackableId: String, listener: AssetStatusListener) {
-        publisher.getAssetStatus(trackableId)
-            ?.onEach { listener.onStatusChanged(it) }
+    override fun addTrackableStateListener(trackableId: String, listener: AssetStateListener) {
+        publisher.getAssetState(trackableId)
+            ?.onEach { listener.onStateChanged(it) }
             ?.launchIn(scope)
     }
 

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.publisher.java
 
-import com.ably.tracking.java.AssetStatusListener
+import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.Trackable
@@ -21,11 +21,11 @@ interface PublisherFacade : Publisher {
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there, and to be
      * made the actively tracked object.
-     * @param listener The listener to be notified when the added asset status changes.
+     * @param listener The listener to be notified when the added asset state changes.
      *
      * @return A [CompletableFuture] that completes when the object has been removed.
      */
-    fun trackAsync(trackable: Trackable, listener: AssetStatusListener?): CompletableFuture<Void>
+    fun trackAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void>
 
     /**
      * Adds a [Trackable] object, but does not make it the actively tracked object, meaning that the state of the
@@ -35,11 +35,11 @@ interface PublisherFacade : Publisher {
      * simply completing successfully.
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
-     * @param listener The listener to be notified when the added asset status changes.
+     * @param listener The listener to be notified when the added asset state changes.
      *
      * @return A [CompletableFuture] that completes when the object has been added.
      */
-    fun addAsync(trackable: Trackable, listener: AssetStatusListener?): CompletableFuture<Void>
+    fun addAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void>
 
     /**
      * Removes a [Trackable] object if it is known to this publisher, otherwise does nothing and returns false.
@@ -69,13 +69,13 @@ interface PublisherFacade : Publisher {
     fun addLocationHistoryListener(listener: LocationHistoryListener)
 
     /**
-     * Add a listener to receive an already added trackable's current status when it changes.
+     * Add a listener to receive an already added trackable's current state when it changes.
      * Does nothing if the trackable isn't currently tracked by the Publisher.
      *
      * @param trackableId The ID of the already added trackable.
-     * @param listener The listener to be notified when the specified trackable status changes.
+     * @param listener The listener to be notified when the specified trackable state changes.
      */
-    fun addTrackableStatusListener(trackableId: String, listener: AssetStatusListener)
+    fun addTrackableStateListener(trackableId: String, listener: AssetStateListener)
 
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.

--- a/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
+++ b/publishing-sdk-java/src/main/java/com/ably/tracking/publisher/java/PublisherFacade.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.publisher.java
 
-import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
+import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.Trackable
 import java.util.concurrent.CompletableFuture
@@ -21,11 +21,11 @@ interface PublisherFacade : Publisher {
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there, and to be
      * made the actively tracked object.
-     * @param listener The listener to be notified when the added asset state changes.
+     * @param listener The listener to be notified when the added trackable state changes.
      *
      * @return A [CompletableFuture] that completes when the object has been removed.
      */
-    fun trackAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void>
+    fun trackAsync(trackable: Trackable, listener: TrackableStateListener?): CompletableFuture<Void>
 
     /**
      * Adds a [Trackable] object, but does not make it the actively tracked object, meaning that the state of the
@@ -35,11 +35,11 @@ interface PublisherFacade : Publisher {
      * simply completing successfully.
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
-     * @param listener The listener to be notified when the added asset state changes.
+     * @param listener The listener to be notified when the added trackable state changes.
      *
      * @return A [CompletableFuture] that completes when the object has been added.
      */
-    fun addAsync(trackable: Trackable, listener: AssetStateListener?): CompletableFuture<Void>
+    fun addAsync(trackable: Trackable, listener: TrackableStateListener?): CompletableFuture<Void>
 
     /**
      * Removes a [Trackable] object if it is known to this publisher, otherwise does nothing and returns false.
@@ -75,7 +75,7 @@ interface PublisherFacade : Publisher {
      * @param trackableId The ID of the already added trackable.
      * @param listener The listener to be notified when the specified trackable state changes.
      */
-    fun addTrackableStateListener(trackableId: String, listener: AssetStateListener)
+    fun addTrackableStateListener(trackableId: String, listener: TrackableStateListener)
 
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -4,7 +4,7 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.annotation.SuppressLint
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,7 +43,7 @@ constructor(
         core.enqueue(StartEvent())
     }
 
-    override suspend fun track(trackable: Trackable): StateFlow<AssetStatus> {
+    override suspend fun track(trackable: Trackable): StateFlow<AssetState> {
         return suspendCoroutine { continuation ->
             core.request(
                 TrackTrackableEvent(trackable) {
@@ -57,7 +57,7 @@ constructor(
         }
     }
 
-    override suspend fun add(trackable: Trackable): StateFlow<AssetStatus> {
+    override suspend fun add(trackable: Trackable): StateFlow<AssetState> {
         return suspendCoroutine { continuation ->
             core.request(
                 AddTrackableEvent(trackable) {
@@ -99,5 +99,5 @@ constructor(
         }
     }
 
-    override fun getAssetStatus(trackableId: String): StateFlow<AssetStatus>? = core.assetStatusFlows[trackableId]
+    override fun getAssetState(trackableId: String): StateFlow<AssetState>? = core.assetStateFlows[trackableId]
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -4,8 +4,8 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.annotation.SuppressLint
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.TrackableState
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.coroutines.resume
@@ -43,7 +43,7 @@ constructor(
         core.enqueue(StartEvent())
     }
 
-    override suspend fun track(trackable: Trackable): StateFlow<AssetState> {
+    override suspend fun track(trackable: Trackable): StateFlow<TrackableState> {
         return suspendCoroutine { continuation ->
             core.request(
                 TrackTrackableEvent(trackable) {
@@ -57,7 +57,7 @@ constructor(
         }
     }
 
-    override suspend fun add(trackable: Trackable): StateFlow<AssetState> {
+    override suspend fun add(trackable: Trackable): StateFlow<TrackableState> {
         return suspendCoroutine { continuation ->
             core.request(
                 AddTrackableEvent(trackable) {
@@ -99,5 +99,5 @@ constructor(
         }
     }
 
-    override fun getAssetState(trackableId: String): StateFlow<AssetState>? = core.assetStateFlows[trackableId]
+    override fun getTrackableState(trackableId: String): StateFlow<TrackableState>? = core.trackableStateFlows[trackableId]
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -5,7 +5,7 @@ import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.AblyException
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import kotlinx.coroutines.flow.SharedFlow
@@ -39,12 +39,12 @@ interface Publisher {
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there, and to be
      * made the actively tracked object.
-     * @return [StateFlow] that represents the [AssetStatus] of the added [Trackable].
+     * @return [StateFlow] that represents the [AssetState] of the added [Trackable].
      *
      * @throws AblyException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
-    suspend fun track(trackable: Trackable): StateFlow<AssetStatus>
+    suspend fun track(trackable: Trackable): StateFlow<AssetState>
 
     /**
      * Adds a [Trackable] object, but does not make it the actively tracked object, meaning that the state of the
@@ -53,12 +53,12 @@ interface Publisher {
      * If this object was already in this publisher's tracked set then this method does nothing.
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
-     * @return [StateFlow] that represents the [AssetStatus] of the added [Trackable].
+     * @return [StateFlow] that represents the [AssetState] of the added [Trackable].
      *
      * @throws AblyException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
-    suspend fun add(trackable: Trackable): StateFlow<AssetStatus>
+    suspend fun add(trackable: Trackable): StateFlow<AssetState>
 
     /**
      * Removes a [Trackable] object if it is known to this publisher, otherwise does nothing and returns false.
@@ -106,13 +106,13 @@ interface Publisher {
         @JvmSynthetic get
 
     /**
-     * Returns an asset status flow representing the [AssetStatus] for an already added [Trackable].
+     * Returns an asset state flow representing the [AssetState] for an already added [Trackable].
      *
      * @param trackableId The ID of an already added trackable.
-     * @return [StateFlow] that represents the [AssetStatus] of the added [Trackable]. If the trackable doesn't exist it returns null.
+     * @return [StateFlow] that represents the [AssetState] of the added [Trackable]. If the trackable doesn't exist it returns null.
      */
     @JvmSynthetic
-    fun getAssetStatus(trackableId: String): StateFlow<AssetStatus>?
+    fun getAssetState(trackableId: String): StateFlow<AssetState>?
 
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -5,9 +5,9 @@ import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.AblyException
-import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.TrackableState
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -39,12 +39,12 @@ interface Publisher {
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there, and to be
      * made the actively tracked object.
-     * @return [StateFlow] that represents the [AssetState] of the added [Trackable].
+     * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
      *
      * @throws AblyException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
-    suspend fun track(trackable: Trackable): StateFlow<AssetState>
+    suspend fun track(trackable: Trackable): StateFlow<TrackableState>
 
     /**
      * Adds a [Trackable] object, but does not make it the actively tracked object, meaning that the state of the
@@ -53,12 +53,12 @@ interface Publisher {
      * If this object was already in this publisher's tracked set then this method does nothing.
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
-     * @return [StateFlow] that represents the [AssetState] of the added [Trackable].
+     * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
      *
      * @throws AblyException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
-    suspend fun add(trackable: Trackable): StateFlow<AssetState>
+    suspend fun add(trackable: Trackable): StateFlow<TrackableState>
 
     /**
      * Removes a [Trackable] object if it is known to this publisher, otherwise does nothing and returns false.
@@ -106,13 +106,13 @@ interface Publisher {
         @JvmSynthetic get
 
     /**
-     * Returns an asset state flow representing the [AssetState] for an already added [Trackable].
+     * Returns a trackable state flow representing the [TrackableState] for an already added [Trackable].
      *
      * @param trackableId The ID of an already added trackable.
-     * @return [StateFlow] that represents the [AssetState] of the added [Trackable]. If the trackable doesn't exist it returns null.
+     * @return [StateFlow] that represents the [TrackableState] of the added [Trackable]. If the trackable doesn't exist it returns null.
      */
     @JvmSynthetic
-    fun getAssetState(trackableId: String): StateFlow<AssetState>?
+    fun getTrackableState(trackableId: String): StateFlow<TrackableState>?
 
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.publisher
 
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
@@ -28,12 +28,12 @@ internal class StartEvent : AdhocEvent()
 
 internal data class AddTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetStatus>>
+    val handler: ResultHandler<StateFlow<AssetState>>
 ) : Request()
 
 internal data class TrackTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetStatus>>
+    val handler: ResultHandler<StateFlow<AssetState>>
 ) : Request()
 
 internal data class SetActiveTrackableEvent(
@@ -52,7 +52,7 @@ internal data class RemoveTrackableEvent(
 
 internal data class JoinPresenceSuccessEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetStatus>>
+    val handler: ResultHandler<StateFlow<AssetState>>
 ) : Request()
 
 internal data class RawLocationChangedEvent(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.publisher
 
-import com.ably.tracking.AssetState
+import com.ably.tracking.TrackableState
 import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
@@ -28,12 +28,12 @@ internal class StartEvent : AdhocEvent()
 
 internal data class AddTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetState>>
+    val handler: ResultHandler<StateFlow<TrackableState>>
 ) : Request()
 
 internal data class TrackTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetState>>
+    val handler: ResultHandler<StateFlow<TrackableState>>
 ) : Request()
 
 internal data class SetActiveTrackableEvent(
@@ -52,7 +52,7 @@ internal data class RemoveTrackableEvent(
 
 internal data class JoinPresenceSuccessEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<AssetState>>
+    val handler: ResultHandler<StateFlow<TrackableState>>
 ) : Request()
 
 internal data class RawLocationChangedEvent(

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -34,7 +34,7 @@ fun exampleUsage(trackingId: String) {
         }
         .launchIn(scope)
 
-    subscriber.assetStatuses
+    subscriber.assetStates
         .onEach {
             // provide a function to be called when the asset changes online/offline status
         }

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -34,7 +34,7 @@ fun exampleUsage(trackingId: String) {
         }
         .launchIn(scope)
 
-    subscriber.assetStates
+    subscriber.trackableStates
         .onEach {
             // provide a function to be called when the asset changes online/offline status
         }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.ably.tracking.Accuracy
-import com.ably.tracking.AssetState
+import com.ably.tracking.TrackableState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.Resolution
 import com.ably.tracking.subscriber.Subscriber
@@ -87,7 +87,7 @@ class MainActivity : AppCompatActivity() {
                 locations
                     .onEach { showMarkerOnMap(it.location) }
                     .launchIn(scope)
-                assetStates
+                trackableStates
                     .onEach { updateAssetState(it) }
                     .launchIn(scope)
             }
@@ -148,11 +148,11 @@ class MainActivity : AppCompatActivity() {
         resolutionIntervalTextView.text = ""
     }
 
-    private fun updateAssetState(assetState: AssetState) {
-        val textId = when (assetState) {
-            is AssetState.Online -> R.string.asset_status_online
-            is AssetState.Offline -> R.string.asset_status_offline
-            is AssetState.Failed -> R.string.asset_status_failed
+    private fun updateAssetState(trackableState: TrackableState) {
+        val textId = when (trackableState) {
+            is TrackableState.Online -> R.string.asset_status_online
+            is TrackableState.Offline -> R.string.asset_status_offline
+            is TrackableState.Failed -> R.string.asset_status_failed
         }
         assetStateTextView.text = getString(textId)
     }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.ably.tracking.Accuracy
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.Resolution
 import com.ably.tracking.subscriber.Subscriber
@@ -87,8 +87,8 @@ class MainActivity : AppCompatActivity() {
                 locations
                     .onEach { showMarkerOnMap(it.location) }
                     .launchIn(scope)
-                assetStatuses
-                    .onEach { updateAssetStatusInfo(it) }
+                assetStates
+                    .onEach { updateAssetState(it) }
                     .launchIn(scope)
             }
     }
@@ -148,13 +148,13 @@ class MainActivity : AppCompatActivity() {
         resolutionIntervalTextView.text = ""
     }
 
-    private fun updateAssetStatusInfo(assetStatus: AssetStatus) {
-        val textId = when (assetStatus) {
-            is AssetStatus.Online -> R.string.asset_status_online
-            is AssetStatus.Offline -> R.string.asset_status_offline
-            is AssetStatus.Failed -> R.string.asset_status_failed
+    private fun updateAssetState(assetState: AssetState) {
+        val textId = when (assetState) {
+            is AssetState.Online -> R.string.asset_status_online
+            is AssetState.Offline -> R.string.asset_status_offline
+            is AssetState.Failed -> R.string.asset_status_failed
         }
-        assetStatusTextView.text = getString(textId)
+        assetStateTextView.text = getString(textId)
     }
 
     private fun stopSubscribing() {

--- a/subscribing-example-app/src/main/res/layout/activity_main.xml
+++ b/subscribing-example-app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,7 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
-    android:id="@+id/assetStatusTextView"
+    android:id="@+id/assetStateTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="30dp"

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -49,8 +49,8 @@ public class UsageExamples {
 
     @Test
     public void subscriberFacadeUsageExample() {
-        subscriberFacade.addListener(assetStatus -> {
-            // handle assetStatus
+        subscriberFacade.addListener(assetState -> {
+            // handle assetState
         });
 
         subscriberFacade.addLocationListener(locationUpdate -> {

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
-import com.ably.tracking.java.AssetStatusListener
+import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.subscriber.Subscriber
 import kotlinx.coroutines.CoroutineScope
@@ -27,9 +27,9 @@ internal class DefaultSubscriberFacade(
             .launchIn(scope)
     }
 
-    override fun addListener(listener: AssetStatusListener) {
-        subscriber.assetStatuses
-            .onEach { listener.onStatusChanged(it) }
+    override fun addListener(listener: AssetStateListener) {
+        subscriber.assetStates
+            .onEach { listener.onStateChanged(it) }
             .launchIn(scope)
     }
 

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
-import com.ably.tracking.java.AssetStateListener
+import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.subscriber.Subscriber
 import kotlinx.coroutines.CoroutineScope
@@ -27,8 +27,8 @@ internal class DefaultSubscriberFacade(
             .launchIn(scope)
     }
 
-    override fun addListener(listener: AssetStateListener) {
-        subscriber.assetStates
+    override fun addListener(listener: TrackableStateListener) {
+        subscriber.trackableStates
             .onEach { listener.onStateChanged(it) }
             .launchIn(scope)
     }

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
-import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
+import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.subscriber.Subscriber
 import com.ably.tracking.subscriber.Subscriber.Builder
 import java.util.concurrent.CompletableFuture
@@ -38,11 +38,11 @@ interface SubscriberFacade : Subscriber {
     fun addLocationListener(listener: LocationUpdateListener)
 
     /**
-     * Adds a handler to be notified when the online state of the asset changes.
+     * Adds a handler to be notified when the online state of the trackable changes.
      *
      * @param listener the listening function to be notified.
      */
-    fun addListener(listener: AssetStateListener)
+    fun addListener(listener: TrackableStateListener)
 
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
-import com.ably.tracking.java.AssetStatusListener
+import com.ably.tracking.java.AssetStateListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.subscriber.Subscriber
 import com.ably.tracking.subscriber.Subscriber.Builder
@@ -38,11 +38,11 @@ interface SubscriberFacade : Subscriber {
     fun addLocationListener(listener: LocationUpdateListener)
 
     /**
-     * Adds a handler to be notified when the online status of the asset changes.
+     * Adds a handler to be notified when the online state of the asset changes.
      *
      * @param listener the listening function to be notified.
      */
-    fun addListener(listener: AssetStatusListener)
+    fun addListener(listener: AssetStateListener)
 
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
+import com.ably.tracking.TrackableState
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.PresenceAction
 import com.ably.tracking.common.PresenceData
@@ -25,7 +25,7 @@ internal interface CoreSubscriber {
     fun enqueue(event: AdhocEvent)
     fun request(request: Request)
     val enhancedLocations: SharedFlow<LocationUpdate>
-    val assetStates: StateFlow<AssetState>
+    val trackableStates: StateFlow<TrackableState>
 }
 
 internal fun createCoreSubscriber(
@@ -42,14 +42,14 @@ private class DefaultCoreSubscriber(
     CoreSubscriber {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val sendEventChannel: SendChannel<Event>
-    private val _assetStates: MutableStateFlow<AssetState> = MutableStateFlow(AssetState.Offline())
+    private val _trackableStates: MutableStateFlow<TrackableState> = MutableStateFlow(TrackableState.Offline())
     private val _enhancedLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
 
     override val enhancedLocations: SharedFlow<LocationUpdate>
         get() = _enhancedLocations.asSharedFlow()
 
-    override val assetStates: StateFlow<AssetState>
-        get() = _assetStates.asStateFlow()
+    override val trackableStates: StateFlow<TrackableState>
+        get() = _trackableStates.asStateFlow()
 
     init {
         val channel = Channel<Event>()
@@ -127,10 +127,10 @@ private class DefaultCoreSubscriber(
     }
 
     private suspend fun notifyAssetIsOnline() {
-        _assetStates.emit(AssetState.Online())
+        _trackableStates.emit(TrackableState.Online())
     }
 
     private suspend fun notifyAssetIsOffline() {
-        _assetStates.emit(AssetState.Offline())
+        _trackableStates.emit(TrackableState.Offline())
     }
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.ClientTypes
@@ -25,7 +25,7 @@ internal interface CoreSubscriber {
     fun enqueue(event: AdhocEvent)
     fun request(request: Request)
     val enhancedLocations: SharedFlow<LocationUpdate>
-    val assetStatuses: StateFlow<AssetStatus>
+    val assetStates: StateFlow<AssetState>
 }
 
 internal fun createCoreSubscriber(
@@ -42,14 +42,14 @@ private class DefaultCoreSubscriber(
     CoreSubscriber {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val sendEventChannel: SendChannel<Event>
-    private val _assetStatuses: MutableStateFlow<AssetStatus> = MutableStateFlow(AssetStatus.Offline())
+    private val _assetStates: MutableStateFlow<AssetState> = MutableStateFlow(AssetState.Offline())
     private val _enhancedLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
 
     override val enhancedLocations: SharedFlow<LocationUpdate>
         get() = _enhancedLocations.asSharedFlow()
 
-    override val assetStatuses: StateFlow<AssetStatus>
-        get() = _assetStatuses.asStateFlow()
+    override val assetStates: StateFlow<AssetState>
+        get() = _assetStates.asStateFlow()
 
     init {
         val channel = Channel<Event>()
@@ -127,10 +127,10 @@ private class DefaultCoreSubscriber(
     }
 
     private suspend fun notifyAssetIsOnline() {
-        _assetStatuses.emit(AssetStatus.Online())
+        _assetStates.emit(AssetState.Online())
     }
 
     private suspend fun notifyAssetIsOffline() {
-        _assetStatuses.emit(AssetStatus.Offline())
+        _assetStates.emit(AssetState.Offline())
     }
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetState
+import com.ably.tracking.TrackableState
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import kotlinx.coroutines.flow.SharedFlow
@@ -19,8 +19,8 @@ internal class DefaultSubscriber(
     override val locations: SharedFlow<LocationUpdate>
         get() = core.enhancedLocations
 
-    override val assetStates: StateFlow<AssetState>
-        get() = core.assetStates
+    override val trackableStates: StateFlow<TrackableState>
+        get() = core.trackableStates
 
     init {
         Timber.w("Started.")

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import kotlinx.coroutines.flow.SharedFlow
@@ -19,8 +19,8 @@ internal class DefaultSubscriber(
     override val locations: SharedFlow<LocationUpdate>
         get() = core.enhancedLocations
 
-    override val assetStatuses: StateFlow<AssetStatus>
-        get() = core.assetStatuses
+    override val assetStates: StateFlow<AssetState>
+        get() = core.assetStates
 
     init {
         Timber.w("Started.")

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetStatus
+import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
@@ -49,9 +49,9 @@ interface Subscriber {
         @JvmSynthetic get
 
     /**
-     * The shared flow emitting values when the online status of the asset changes.
+     * The shared flow emitting values when the state of the asset changes.
      */
-    val assetStatuses: StateFlow<AssetStatus>
+    val assetStates: StateFlow<AssetState>
         @JvmSynthetic get
 
     /**

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -1,9 +1,9 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AssetState
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
+import com.ably.tracking.TrackableState
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -49,9 +49,9 @@ interface Subscriber {
         @JvmSynthetic get
 
     /**
-     * The shared flow emitting values when the state of the asset changes.
+     * The shared flow emitting values when the state of the trackable changes.
      */
-    val assetStates: StateFlow<AssetState>
+    val trackableStates: StateFlow<TrackableState>
         @JvmSynthetic get
 
     /**


### PR DESCRIPTION
I renamed the `PublisherState` to simply `State` in order to close https://github.com/ably/ably-asset-tracking-android/issues/196

I renamed the `AssetStatus` to `TrackableState` in order to close https://github.com/ably/ably-asset-tracking-android/issues/197