### PR TITLE
Stopping strategy for the Publisher

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Ably.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Ably.kt
@@ -16,8 +16,8 @@ import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ErrorInfo
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import timber.log.Timber
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -241,8 +241,7 @@ internal class DefaultAbly(
 
     override suspend fun close(presenceData: PresenceData) {
         // launches closing of all channels in parallel but waits for all channels to be closed
-        // TODO If any suspend function throws inside coroutineScope it will fail the whole scope, is it OK? If not we should use supervisorScope.
-        coroutineScope {
+        supervisorScope {
             channels.keys.forEach { trackableId ->
                 launch { disconnect(trackableId, presenceData) }
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
 
 internal interface CorePublisher {
     fun enqueue(event: AdhocEvent)
-    fun request(request: Request)
+    fun request(request: Request<*>)
     val locations: SharedFlow<LocationUpdate>
     val trackables: SharedFlow<Set<Trackable>>
     val locationHistory: SharedFlow<LocationHistoryData>
@@ -133,7 +133,7 @@ constructor(
         scope.launch { sendEventChannel.send(event) }
     }
 
-    override fun request(request: Request) {
+    override fun request(request: Request<*>) {
         scope.launch { sendEventChannel.send(request) }
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -148,6 +148,20 @@ constructor(
 
             // processing
             for (event in receiveEventChannel) {
+                // handle events after the publisher is stopped
+                if (state.isStopped) {
+                    if (event is Request<*>) {
+                        // when the event is a request then call its handler
+                        when (event) {
+                            is StopEvent -> event.handler(Result.success(Unit))
+                            else -> event.handler(Result.failure(PublisherStoppedException()))
+                        }
+                        continue
+                    } else if (event is AdhocEvent) {
+                        // when the event is an adhoc event then just ignore it
+                        continue
+                    }
+                }
                 when (event) {
                     is StartEvent -> {
                         if (!state.isTracking) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,10 +1,10 @@
 package com.ably.tracking.publisher
 
-import com.ably.tracking.TrackableState
 import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.ResultHandler
+import com.ably.tracking.TrackableState
 import com.ably.tracking.common.PresenceMessage
 import kotlinx.coroutines.flow.StateFlow
 
@@ -18,42 +18,42 @@ internal sealed class AdhocEvent : Event()
 /**
  * Represents an event that invokes an action that calls a callback when it completes.
  */
-internal sealed class Request : Event()
+internal sealed class Request<T>(val handler: ResultHandler<T>) : Event()
 
 internal class StopEvent(
-    val handler: ResultHandler<Unit>
-) : Request()
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)
 
 internal class StartEvent : AdhocEvent()
 
-internal data class AddTrackableEvent(
+internal class AddTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<TrackableState>>
-) : Request()
+    handler: ResultHandler<StateFlow<TrackableState>>
+) : Request<StateFlow<TrackableState>>(handler)
 
-internal data class TrackTrackableEvent(
+internal class TrackTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<TrackableState>>
-) : Request()
+    handler: ResultHandler<StateFlow<TrackableState>>
+) : Request<StateFlow<TrackableState>>(handler)
 
-internal data class SetActiveTrackableEvent(
+internal class SetActiveTrackableEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<Unit>
-) : Request()
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)
 
-internal data class RemoveTrackableEvent(
+internal class RemoveTrackableEvent(
     val trackable: Trackable,
 
     /**
      * On success, the handler is supplied `true` if the [Trackable] was already present.
      */
-    val handler: ResultHandler<Boolean>
-) : Request()
+    handler: ResultHandler<Boolean>
+) : Request<Boolean>(handler)
 
-internal data class JoinPresenceSuccessEvent(
+internal class JoinPresenceSuccessEvent(
     val trackable: Trackable,
-    val handler: ResultHandler<StateFlow<TrackableState>>
-) : Request()
+    handler: ResultHandler<StateFlow<TrackableState>>
+) : Request<StateFlow<TrackableState>>(handler)
 
 internal data class RawLocationChangedEvent(
     val locationUpdate: LocationUpdate

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherStoppedException.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherStoppedException.kt
@@ -1,0 +1,3 @@
+package com.ably.tracking.publisher
+
+class PublisherStoppedException : Exception("Cannot perform this action when publisher is stopped.")


### PR DESCRIPTION
I've implemented the stopping of the Publisher which blocks the queue and events processing until the stopping is done.
Handling events and API calls when Publisher is in the "stopped" state isn't yet ready.
I'm preparing a draft PR so we can discuss if this is the right direction.