### PR TITLE
Simplify location history version field

### DIFF
--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -62,7 +62,7 @@ public class PublisherInterfaceUsageExamples {
             .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
             .map(new MapConfiguration("API_KEY"))
             .resolutionPolicy(resolutionPolicyFactory)
-            .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData("1.0", new ArrayList<>()), null))
+            .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData(new ArrayList<>()), null))
             .locationSource(LocationSourceAbly.create("CHANNEL_ID"))
             .start();
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -402,7 +402,7 @@ class LocationSourceRaw private constructor(
             LocationSourceRaw(historyData, callback)
     }
 
-    private constructor() : this(historyData = LocationHistoryData("", emptyList()), onDataEnded = null)
+    private constructor() : this(historyData = LocationHistoryData(emptyList()), onDataEnded = null)
     private constructor(historyData: LocationHistoryData, callback: (DataEndedCallback)? = null) : this(
         historyData,
         { callback?.onDataEnded() }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationHistoryModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationHistoryModels.kt
@@ -11,12 +11,13 @@ import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventLocation
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
 
-val LOCATION_HISTORY_VERSION = "1.0"
+val LOCATION_HISTORY_VERSION = 1
 
 data class LocationHistoryData(
-    val version: String,
     val events: List<GeoJsonMessage>
-)
+) {
+    val version: Int = LOCATION_HISTORY_VERSION
+}
 
 fun List<ReplayEventBase>.toGeoJsonMessages(): List<GeoJsonMessage> =
     filterIsInstance<ReplayEventUpdateLocation>()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -138,7 +138,7 @@ internal class DefaultMapbox(
             mapboxReplayer?.finish()
             val tripHistoryString = retrieveHistory()
             val historyEvents = ReplayHistoryMapper().mapToReplayEvents(tripHistoryString)
-            locationHistoryListener?.invoke(LocationHistoryData(LOCATION_HISTORY_VERSION, historyEvents.toGeoJsonMessages()))
+            locationHistoryListener?.invoke(LocationHistoryData(historyEvents.toGeoJsonMessages()))
             onDestroy()
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/FactoryUnitTests.kt
@@ -66,7 +66,7 @@ class FactoryUnitTests {
     @Test
     fun `setting location source returns a new copy of builder`() {
         // given
-        val locationSource = LocationSourceRaw.create(LocationHistoryData("1.0", emptyList()))
+        val locationSource = LocationSourceRaw.create(LocationHistoryData(emptyList()))
         val originalBuilder = Publisher.publishers()
 
         // when


### PR DESCRIPTION
I've changed the version field from string (i.e. "1.0") to simple integer (i.e. 1).
After landing of this PR the files on the S3 should be updated in order to make them work.