### PR TITLE
Unify the way of parsing enums sent over Ably channels

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -160,7 +160,7 @@ class DefaultAbly(
             channel.apply {
                 try {
                     presence.enter(
-                        gson.toJson(presenceData),
+                        gson.toJson(presenceData.toMessage()),
                         object : CompletionListener {
                             override fun onSuccess() {
                                 channels[trackableId] = this@apply
@@ -188,7 +188,7 @@ class DefaultAbly(
             removedChannel.presence.unsubscribe()
             try {
                 removedChannel.presence.leave(
-                    gson.toJson(presenceData),
+                    gson.toJson(presenceData.toMessage()),
                     object : CompletionListener {
                         override fun onSuccess() {
                             callback(Result.success(Unit))
@@ -259,7 +259,7 @@ class DefaultAbly(
     override fun updatePresenceData(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
         try {
             channels[trackableId]?.presence?.update(
-                gson.toJson(presenceData),
+                gson.toJson(presenceData.toMessage()),
                 object : CompletionListener {
                     override fun onSuccess() {
                         callback(Result.success(Unit))

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -46,7 +46,7 @@ enum class AccuracyMessage {
     HIGH,
 
     @SerializedName("MAXIMUM")
-    MAXIMUM
+    MAXIMUM,
 }
 
 data class EnhancedLocationUpdateMessage(
@@ -61,5 +61,5 @@ enum class LocationUpdateTypeMessage {
     PREDICTED,
 
     @SerializedName("ACTUAL")
-    ACTUAL
+    ACTUAL,
 }

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -1,7 +1,6 @@
 package com.ably.tracking.common
 
 import com.ably.tracking.GeoJsonMessage
-import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.Resolution
 
 object GeoJsonTypes {
@@ -24,9 +23,35 @@ enum class PresenceAction {
 
 data class PresenceData(val type: String, val resolution: Resolution? = null)
 
+data class PresenceDataMessage(val type: String, val resolution: ResolutionMessage? = null)
+
+data class ResolutionMessage(
+    val accuracy: AccuracyMessage,
+    val desiredInterval: Long,
+    val minimumDisplacement: Double
+)
+
+enum class AccuracyMessage {
+    MINIMUM,
+
+    LOW,
+
+    BALANCED,
+
+    HIGH,
+
+    MAXIMUM
+}
+
 data class EnhancedLocationUpdateMessage(
     val location: GeoJsonMessage,
     val batteryLevel: Float?,
     val intermediateLocations: List<GeoJsonMessage>,
-    val type: LocationUpdateType
+    val type: LocationUpdateTypeMessage
 )
+
+enum class LocationUpdateTypeMessage {
+    PREDICTED,
+
+    ACTUAL
+}

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.common
 
 import com.ably.tracking.GeoJsonMessage
 import com.ably.tracking.Resolution
+import com.google.gson.annotations.SerializedName
 
 object GeoJsonTypes {
     const val FEATURE = "Feature"
@@ -32,14 +33,19 @@ data class ResolutionMessage(
 )
 
 enum class AccuracyMessage {
+    @SerializedName("MINIMUM")
     MINIMUM,
 
+    @SerializedName("LOW")
     LOW,
 
+    @SerializedName("BALANCED")
     BALANCED,
 
+    @SerializedName("HIGH")
     HIGH,
 
+    @SerializedName("MAXIMUM")
     MAXIMUM
 }
 
@@ -51,7 +57,9 @@ data class EnhancedLocationUpdateMessage(
 )
 
 enum class LocationUpdateTypeMessage {
+    @SerializedName("PREDICTED")
     PREDICTED,
 
+    @SerializedName("ACTUAL")
     ACTUAL
 }


### PR DESCRIPTION
I've created message models for all domain classes that are being sent through Ably channels. After that I was able to specify the format of enums to be in the `SCREAMING_CAMEL_CASE`