### PR TITLE
Fix subscriber not receiving any location updates

### DIFF
--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -80,9 +80,9 @@ private class DefaultCoreSubscriber(
                 when (event) {
                     is StartEvent -> {
                         notifyAssetIsOffline()
-                        subscribeForEnhancedEvents()
-                        subscribeForPresenceMessages()
                         ably.connect(trackableId, presenceData, useRewind = true) {
+                            subscribeForEnhancedEvents()
+                            subscribeForPresenceMessages()
                             // TODO what should we do when connection fails?
                         }
                     }


### PR DESCRIPTION
During the recent changes I've mistakenly called `ably.connect()` after setting all listeners which caused no listeners to be attached.