### PR TITLE
Fix emitting trackable state in the publisher SDK

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -35,6 +35,7 @@ interface Ably {
 
     /**
      * Adds a listener for the channel state updates.
+     * After adding a listener it will emit the current state of the channel.
      * Should be called only when there's an existing channel for the [trackableId].
      * If a channel for the [trackableId] doesn't exist then nothing happens.
      *
@@ -143,7 +144,12 @@ class DefaultAbly(
     }
 
     override fun subscribeForChannelStateChange(trackableId: String, listener: (ConnectionStateChange) -> Unit) {
-        channels[trackableId]?.on { listener(it.toTracking()) }
+        channels[trackableId]?.let { channel ->
+            channel.state.toTracking().let { currentChannelState ->
+                listener(ConnectionStateChange(currentChannelState, currentChannelState, null))
+            }
+            channel.on { listener(it.toTracking()) }
+        }
     }
 
     override fun connect(

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -9,7 +9,7 @@ sealed class TrackableState {
     /**
      * Trackable state is [Online] when it's being actively tracked. This state can change to either [Offline] or [Failed].
      */
-    class Online : TrackableState()
+    object Online : TrackableState()
 
     /**
      * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This state can change to either [Online] or [Failed].

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -355,7 +355,7 @@ constructor(
         val newTrackableState = when (state.lastConnectionStateChange.state) {
             ConnectionState.ONLINE -> {
                 when (lastChannelConnectionStateChange.state) {
-                    ConnectionState.ONLINE -> if (hasSentAtLeastOneLocation) TrackableState.Online() else TrackableState.Offline()
+                    ConnectionState.ONLINE -> if (hasSentAtLeastOneLocation) TrackableState.Online else TrackableState.Offline()
                     ConnectionState.OFFLINE -> TrackableState.Offline()
                     ConnectionState.FAILED -> TrackableState.Failed(lastChannelConnectionStateChange.errorInformation!!) // are we sure error information will always be present?
                 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -134,7 +134,7 @@ private class DefaultCoreSubscriber(
     }
 
     private suspend fun notifyAssetIsOnline() {
-        _trackableStates.emit(TrackableState.Online())
+        _trackableStates.emit(TrackableState.Online)
     }
 
     private suspend fun notifyAssetIsOffline() {


### PR DESCRIPTION
Currently, we are attaching the channel state listener after a channel is created. Because of that we don't receive a "Offline->Online" state change because the channel is already online. In order to fix it I'm emitting the current channel state when we're attaching a channel state listener.

Additionally, I've changed the `Online` state to be an `object` instead of a `class`. This fixes states comparing and there are no unnecessary state updates (previously when the current state was `Online` and the new state was `Online` the comparision `newOnline == oldOnline` returned `false`).