### PR TITLE
Fix modifying Publisher state from the Ably's disconnect callback

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -50,6 +50,11 @@ internal class RemoveTrackableEvent(
     handler: ResultHandler<Boolean>
 ) : Request<Boolean>(handler)
 
+internal class DisconnectSuccessEvent(
+    val trackable: Trackable,
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)
+
 internal class JoinPresenceSuccessEvent(
     val trackable: Trackable,
     handler: ResultHandler<StateFlow<TrackableState>>


### PR DESCRIPTION
We shouldn't modify Publisher state from outside of the events queue "thread". Therefore I've added a new event that's used when removing a trackable from the publisher.