### PR TITLE
Require only one of the two resolution checks to be passed in order to send a location update

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -525,7 +525,7 @@ constructor(
         return if (resolution != null && lastSentLocation != null) {
             val timeSinceLastSentLocation = currentLocation.timeFrom(lastSentLocation)
             val distanceFromLastSentLocation = currentLocation.distanceInMetersFrom(lastSentLocation)
-            return distanceFromLastSentLocation >= resolution.minimumDisplacement &&
+            return distanceFromLastSentLocation >= resolution.minimumDisplacement ||
                 timeSinceLastSentLocation >= resolution.desiredInterval
         } else {
             true


### PR DESCRIPTION
We've spotted a difference in the logic of `shouldSendLocation()` between iOS and Android. I've adjusted our implementation to only require one of the two `Resolution` requirements to be met in order to allow the Publisher to send a new location update for a trackable.