### PR TITLE
Rename AblyException to ConnectionException

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.common
 
 import com.ably.tracking.ConnectionConfiguration
+import com.ably.tracking.ConnectionException
 import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
@@ -56,7 +57,7 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param listener The function that will be called each time a presence message is received.
      *
-     * @throws com.ably.tracking.AblyException if something goes wrong.
+     * @throws ConnectionException if something goes wrong.
      */
     fun subscribeForPresenceMessages(trackableId: String, listener: (PresenceMessage) -> Unit)
 
@@ -68,7 +69,7 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param locationUpdate The location update that is sent to the channel.
      *
-     * @throws com.ably.tracking.AblyException if something goes wrong.
+     * @throws ConnectionException if something goes wrong.
      */
     fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate)
 
@@ -79,7 +80,7 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param listener The function that will be called each time an enhanced location update event is received.
      *
-     * @throws com.ably.tracking.AblyException if something goes wrong.
+     * @throws ConnectionException if something goes wrong.
      */
     fun subscribeForEnhancedEvents(trackableId: String, listener: (LocationUpdate) -> Unit)
 
@@ -91,7 +92,7 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
      * @param useRewind If set to true then after connecting the channel will replay the last event that was sent in it.
-     * @param callback The function that will be called when connecting completes. If something goes wrong it will be called with [com.ably.tracking.AblyException].
+     * @param callback The function that will be called when connecting completes. If something goes wrong it will be called with [ConnectionException].
      */
     fun connect(
         trackableId: String,
@@ -107,7 +108,7 @@ interface Ably {
      *
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
-     * @param callback The function that will be called when updating presence data completes. If something goes wrong it will be called with [com.ably.tracking.AblyException].
+     * @param callback The function that will be called when updating presence data completes. If something goes wrong it will be called with [ConnectionException].
      */
     fun updatePresenceData(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit)
 
@@ -117,7 +118,7 @@ interface Ably {
      *
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
-     * @param callback The function that will be called when disconnecting completes. If something goes wrong it will be called with [com.ably.tracking.AblyException].
+     * @param callback The function that will be called when disconnecting completes. If something goes wrong it will be called with [ConnectionException].
      */
     fun disconnect(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit)
 
@@ -126,7 +127,7 @@ interface Ably {
      *
      * @param presenceData The data that will be send via the presence channels.
      *
-     * @throws com.ably.tracking.AblyException if something goes wrong.
+     * @throws ConnectionException if something goes wrong.
      */
     suspend fun close(presenceData: PresenceData)
 }
@@ -221,14 +222,14 @@ class DefaultAbly(
 
     /**
      * A suspend version of the [DefaultAbly.disconnect] method. It waits until disconnection is completed.
-     * @throws com.ably.tracking.AblyException if something goes wrong during disconnect.
+     * @throws ConnectionException if something goes wrong during disconnect.
      */
     private suspend fun disconnect(trackableId: String, presenceData: PresenceData) {
         suspendCoroutine<Unit> { continuation ->
             disconnect(trackableId, presenceData) {
                 try {
                     continuation.resume(it.getOrThrow())
-                } catch (exception: com.ably.tracking.AblyException) {
+                } catch (exception: ConnectionException) {
                     continuation.resumeWithException(exception)
                 }
             }
@@ -305,7 +306,7 @@ class DefaultAbly(
 
     /**
      * Closes [AblyRealtime] and waits until it's either closed or failed.
-     * @throws com.ably.tracking.AblyException if the [AblyRealtime] state changes to [ConnectionState.failed].
+     * @throws ConnectionException if the [AblyRealtime] state changes to [ConnectionState.failed].
      */
     private suspend fun closeConnection() {
         suspendCoroutine<Unit> { continuation ->

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -39,14 +39,14 @@ fun io.ably.lib.types.ErrorInfo.toTracking() =
     )
 
 /**
- * Extension converting Ably error info objects to the equivalent [AblyException] API presented to users of the Ably
+ * Extension converting Ably error info objects to the equivalent [ConnectionException] API presented to users of the Ably
  * Asset Tracking SDKs.
  *
  * The `requestId` field is yet to be implemented by ably-java, however even once it is available then the chances are
  * that it'll still not be exposed through to users of the Ably Asset Tracking SDKs in order to keep things simple.
  */
 fun io.ably.lib.types.ErrorInfo.toTrackingException() =
-    AblyException(
+    ConnectionException(
         ErrorInformation(
             this.code,
             this.statusCode,

--- a/core-sdk/src/main/java/com/ably/tracking/Exceptions.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/Exceptions.kt
@@ -3,4 +3,4 @@ package com.ably.tracking
 class BuilderConfigurationIncompleteException :
     Exception("Some of the required builder parameters are missing")
 
-class AblyException(val errorInformation: ErrorInformation) : Exception(errorInformation.message)
+class ConnectionException(val errorInformation: ErrorInformation) : Exception(errorInformation.message)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.publisher
 import android.Manifest
 import android.location.Location
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AblyException
+import com.ably.tracking.ConnectionException
 import com.ably.tracking.ConnectionState
 import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.EnhancedLocationUpdate
@@ -190,7 +190,7 @@ constructor(
                                     ably.sendEnhancedLocation(trackable.id, event.locationUpdate)
                                     state.lastSentEnhancedLocations[trackable.id] = event.locationUpdate.location
                                     updateTrackableState(state, trackable.id)
-                                } catch (exception: AblyException) {
+                                } catch (exception: ConnectionException) {
                                     // TODO - what to do here if sending enhanced location fails?
                                 }
                             }
@@ -340,7 +340,7 @@ constructor(
                                 ably.close(state.presenceData)
                                 state.isStopped = true
                                 event.handler(Result.success(Unit))
-                            } catch (exception: AblyException) {
+                            } catch (exception: ConnectionException) {
                                 event.handler(Result.failure(exception))
                             }
                         }
@@ -394,7 +394,7 @@ constructor(
     /**
      * Creates a [Channel] for the [Trackable], joins the channel's presence and enqueues [SuccessEvent].
      * If a [Channel] for the given [Trackable] exists then it just enqueues [SuccessEvent].
-     * If during channel creation and joining presence an error occurs then it enqueues [FailureEvent] with the [AblyException].
+     * If during channel creation and joining presence an error occurs then it enqueues [FailureEvent] with the [ConnectionException].
      */
     private fun createChannelForTrackableIfNotExisits(
         trackable: Trackable,
@@ -406,7 +406,7 @@ constructor(
                 result.getOrThrow()
                 try {
                     ably.subscribeForPresenceMessages(trackable.id) { enqueue(PresenceMessageEvent(trackable, it)) }
-                } catch (exception: AblyException) {
+                } catch (exception: ConnectionException) {
                     // TODO - what to do here? should we fail the whole process when subscribing for presence fails? or should it continue?
                 }
                 ably.subscribeForChannelStateChange(trackable.id) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -4,7 +4,7 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.AblyException
+import com.ably.tracking.ConnectionException
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.TrackableState
@@ -41,7 +41,7 @@ interface Publisher {
      * made the actively tracked object.
      * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
      *
-     * @throws AblyException when something goes wrong with the Ably connection
+     * @throws ConnectionException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
     suspend fun track(trackable: Trackable): StateFlow<TrackableState>
@@ -55,7 +55,7 @@ interface Publisher {
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
      * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
      *
-     * @throws AblyException when something goes wrong with the Ably connection
+     * @throws ConnectionException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
     suspend fun add(trackable: Trackable): StateFlow<TrackableState>
@@ -69,7 +69,7 @@ interface Publisher {
      * @param trackable The object to be removed from this publisher's tracked set, it it's there.
      *
      * @return `true` if the object was known to this publisher, otherise `false`.
-     * @throws AblyException when something goes wrong with the Ably connection
+     * @throws ConnectionException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
     suspend fun remove(trackable: Trackable): Boolean

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.subscriber
 
-import com.ably.tracking.AblyException
+import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
@@ -112,7 +112,7 @@ private class DefaultCoreSubscriber(
                         try {
                             ably.close(presenceData)
                             event.handler(Result.success(Unit))
-                        } catch (exception: AblyException) {
+                        } catch (exception: ConnectionException) {
                             event.handler(Result.failure(exception))
                         }
                     }


### PR DESCRIPTION
In order to avoid confusion between Ably's `AblyException` and Asset Tracking `AblyException`, we've renamed the latter to `ConnectionConfiguration`.