### PR TITLE
Add @Throws annotation to inform Java users about thrown exceptions

### DIFF
--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 
 import com.ably.tracking.Accuracy;
+import com.ably.tracking.BuilderConfigurationIncompleteException;
 import com.ably.tracking.ConnectionConfiguration;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.publisher.DefaultProximity;
@@ -42,7 +43,7 @@ public class PublisherInterfaceUsageExamples {
     PublisherFacade publisher;
 
     @Before
-    public void beforeEach() {
+    public void beforeEach() throws BuilderConfigurationIncompleteException {
         context = mock(Context.class);
         nativePublisher = mock(Publisher.class);
         publisherBuilder = mock(Publisher.Builder.class, withSettings().defaultAnswer(RETURNS_SELF));
@@ -57,14 +58,18 @@ public class PublisherInterfaceUsageExamples {
 
     @Test
     public void publisherBuilderUsageExample() {
-        publisherBuilder
-            .androidContext(context)
-            .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
-            .map(new MapConfiguration("API_KEY"))
-            .resolutionPolicy(resolutionPolicyFactory)
-            .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData(new ArrayList<>()), null))
-            .locationSource(LocationSourceAbly.create("CHANNEL_ID"))
-            .start();
+        try {
+            publisherBuilder
+                .androidContext(context)
+                .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
+                .map(new MapConfiguration("API_KEY"))
+                .resolutionPolicy(resolutionPolicyFactory)
+                .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData(new ArrayList<>()), null))
+                .locationSource(LocationSourceAbly.create("CHANNEL_ID"))
+                .start();
+        } catch (BuilderConfigurationIncompleteException e) {
+            // handle publisher start error
+        }
     }
 
     @Test

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -4,8 +4,9 @@ import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
-import com.ably.tracking.ConnectionException
+import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
+import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.TrackableState
 import kotlinx.coroutines.flow.SharedFlow
@@ -192,6 +193,7 @@ interface Publisher {
          * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
          */
         @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
+        @Throws(BuilderConfigurationIncompleteException::class)
         fun start(): Publisher
     }
 }

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -1,6 +1,7 @@
 package com.ably.tracking.example.javasubscriber;
 
 import com.ably.tracking.Accuracy;
+import com.ably.tracking.BuilderConfigurationIncompleteException;
 import com.ably.tracking.ConnectionConfiguration;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.subscriber.Subscriber;
@@ -24,7 +25,7 @@ public class UsageExamples {
     Subscriber.Builder subscriberBuilder;
 
     @Before
-    public void beforeEach() {
+    public void beforeEach() throws BuilderConfigurationIncompleteException {
         nativeSubscriber = mock(Subscriber.class);
         subscriberBuilder = mock(Subscriber.Builder.class, withSettings().defaultAnswer(RETURNS_SELF));
         when(subscriberBuilder.start()).thenReturn(nativeSubscriber);
@@ -35,11 +36,15 @@ public class UsageExamples {
 
     @Test
     public void subscriberBuilderUsageExample() {
-        Subscriber nativeSubscriber = subscriberBuilder
-            .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
-            .trackingId("TRACKING_ID")
-            .resolution(new Resolution(Accuracy.BALANCED, 1000L, 1.0))
-            .start();
+        try {
+            Subscriber nativeSubscriber = subscriberBuilder
+                .connection(new ConnectionConfiguration("API_KEY", "CLIENT_ID"))
+                .trackingId("TRACKING_ID")
+                .resolution(new Resolution(Accuracy.BALANCED, 1000L, 1.0))
+                .start();
+        } catch (BuilderConfigurationIncompleteException e) {
+            // handle subscriber start error
+        }
     }
 
     @Test

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -1,5 +1,6 @@
 package com.ably.tracking.subscriber
 
+import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
@@ -101,6 +102,7 @@ interface Subscriber {
          * @return A new subscriber instance.
          * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
          */
+        @Throws(BuilderConfigurationIncompleteException::class)
         fun start(): Subscriber
     }
 }


### PR DESCRIPTION
I've added the `@Throws` annotation to Kotlin API methods so Java users will be explicitly informed which methods can throw exceptions and should be surrounded with `try / catch` blocks.