### PR TITLE
Unify approach of GPS location updates

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -163,12 +163,6 @@ constructor(
                     }
                 }
                 when (event) {
-                    is StartEvent -> {
-                        if (!state.isTracking) {
-                            state.isTracking = true
-                            mapbox.startTrip()
-                        }
-                    }
                     is SetDestinationSuccessEvent -> {
                         state.estimatedArrivalTimeInMilliseconds =
                             System.currentTimeMillis() + event.routeDurationInMilliseconds
@@ -272,6 +266,10 @@ constructor(
                         }
                     }
                     is ConnectionForTrackableCreatedEvent -> {
+                        if (!state.isTracking) {
+                            state.isTracking = true
+                            mapbox.startTrip()
+                        }
                         state.trackables.add(event.trackable)
                         scope.launch { _trackables.emit(state.trackables) }
                         resolveResolution(event.trackable, state)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -236,7 +236,7 @@ constructor(
                                 ably.subscribeForChannelStateChange(event.trackable.id) {
                                     enqueue(ChannelConnectionStateChangeEvent(it, event.trackable.id))
                                 }
-                                request(JoinPresenceSuccessEvent(event.trackable, event.handler))
+                                request(ConnectionForTrackableCreatedEvent(event.trackable, event.handler))
                             } catch (exception: ConnectionException) {
                                 event.handler(Result.failure(exception))
                             }
@@ -271,7 +271,7 @@ constructor(
                             }
                         }
                     }
-                    is JoinPresenceSuccessEvent -> {
+                    is ConnectionForTrackableCreatedEvent -> {
                         state.trackables.add(event.trackable)
                         scope.launch { _trackables.emit(state.trackables) }
                         resolveResolution(event.trackable, state)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -307,6 +307,11 @@ constructor(
                                 hooks.trackables?.onActiveTrackableChanged(null)
                             }
 
+                            // When we remove the last trackable then we should stop location updates
+                            if (state.trackables.isEmpty() && state.isTracking) {
+                                stopLocationUpdates(state)
+                            }
+
                             // Leave Ably channel.
                             ably.disconnect(event.trackable.id, state.presenceData) { result ->
                                 if (result.isSuccess) {
@@ -344,9 +349,7 @@ constructor(
                             event.handler(Result.success(Unit))
                         } else {
                             if (state.isTracking) {
-                                state.isTracking = false
-                                mapbox.unregisterLocationObserver(locationObserver)
-                                mapbox.stopAndClose()
+                                stopLocationUpdates(state)
                             }
                             try {
                                 ably.close(state.presenceData)
@@ -370,6 +373,12 @@ constructor(
                 }
             }
         }
+    }
+
+    private fun stopLocationUpdates(state: State) {
+        state.isTracking = false
+        mapbox.unregisterLocationObserver(locationObserver)
+        mapbox.stopAndClose()
     }
 
     private fun updateTrackableState(state: State, trackableId: String) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -40,8 +40,6 @@ constructor(
 
     init {
         core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, batteryDataProvider)
-
-        core.enqueue(StartEvent())
     }
 
     override suspend fun track(trackable: Trackable): StateFlow<TrackableState> {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -55,7 +55,7 @@ internal class DisconnectSuccessEvent(
     handler: ResultHandler<Unit>
 ) : Request<Unit>(handler)
 
-internal class JoinPresenceSuccessEvent(
+internal class ConnectionForTrackableCreatedEvent(
     val trackable: Trackable,
     handler: ResultHandler<StateFlow<TrackableState>>
 ) : Request<StateFlow<TrackableState>>(handler)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -24,8 +24,6 @@ internal class StopEvent(
     handler: ResultHandler<Unit>
 ) : Request<Unit>(handler)
 
-internal class StartEvent : AdhocEvent()
-
 internal class AddTrackableEvent(
     val trackable: Trackable,
     handler: ResultHandler<StateFlow<TrackableState>>


### PR DESCRIPTION
I've changed our logic of starting and stopping location updates to work in the same way it works on iOS.
- The location updates are started when the first trackable is added to the Publisher
- The location updates are stopped when the last trackable is removed from the Publisher