### PR TITLE
Change start to be an asynchronous function for Subscriber

### DIFF
--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -54,7 +54,10 @@ class PublisherAndSubscriberTests {
         val scope = CoroutineScope(Dispatchers.Default)
 
         // when
-        val subscriber = createAndStartSubscriber(trackableId)
+        var subscriber: Subscriber
+        runBlocking {
+            subscriber = createAndStartSubscriber(trackableId)
+        }
 
         subscriber.locations
             .onEach { receivedLocations.add(it) }
@@ -140,7 +143,7 @@ class PublisherAndSubscriberTests {
             .locationSource(LocationSourceRaw.create(locationData, onLocationDataEnded))
             .start()
 
-    private fun createAndStartSubscriber(
+    private suspend fun createAndStartSubscriber(
         trackingId: String,
         resolution: Resolution = Resolution(Accuracy.BALANCED, 1L, 0.0)
     ) =

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 // PLACEHOLDERS:
 
@@ -20,13 +21,16 @@ fun exampleUsage(trackingId: String) {
     // EXAMPLE SNIPPET FROM HERE, WITH EXCESS INDENT REMOVED:
 
     // Initialise and Start the Subscriber
-    val subscriber = Subscriber.subscribers() // Get an AssetSubscriber
-        .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID)) // provide Ably configuration with credentials
-        .resolution( // request a specific resolution to be considered by the publisher
-            Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
-        )
-        .trackingId(trackingId) // provide the tracking identifier for the asset that needs to be tracked
-        .start() // start listening for updates
+    var subscriber: Subscriber
+    runBlocking {
+        subscriber = Subscriber.subscribers() // Get an AssetSubscriber
+            .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID)) // provide Ably configuration with credentials
+            .resolution( // request a specific resolution to be considered by the publisher
+                Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
+            )
+            .trackingId(trackingId) // provide the tracking identifier for the asset that needs to be tracked
+            .start() // start listening for updates
+    }
 
     subscriber.locations
         .onEach {

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -78,19 +78,21 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun createAndStartAssetSubscriber(trackingId: String) {
-        subscriber = Subscriber.subscribers()
-            .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID))
-            .trackingId(trackingId)
-            .resolution(resolution)
-            .start()
-            .apply {
-                locations
-                    .onEach { showMarkerOnMap(it.location) }
-                    .launchIn(scope)
-                trackableStates
-                    .onEach { updateAssetState(it) }
-                    .launchIn(scope)
-            }
+        scope.launch {
+            subscriber = Subscriber.subscribers()
+                .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID))
+                .trackingId(trackingId)
+                .resolution(resolution)
+                .start()
+                .apply {
+                    locations
+                        .onEach { showMarkerOnMap(it.location) }
+                        .launchIn(scope)
+                    trackableStates
+                        .onEach { updateAssetState(it) }
+                        .launchIn(scope)
+                }
+        }
     }
 
     private fun updateResolutionBasedOnZoomLevel() {

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -35,7 +35,7 @@ public class UsageExamples {
         when(subscriberFacadeBuilder.startAsync()).thenReturn(CompletableFuture.completedFuture(subscriberFacade));
         subscriberFacade = mock(SubscriberFacade.class);
         when(subscriberFacade.sendChangeRequestAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
-        when(subscriberFacade.stopAsync()).thenReturn(CompletableFuture.completedFuture(any()));
+        when(subscriberFacade.stopAsync()).thenReturn(CompletableFuture.completedFuture(null));
     }
 
     @Test

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -4,7 +4,6 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.subscriber.Subscriber
-import com.ably.tracking.subscriber.Subscriber.Builder
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -52,13 +51,25 @@ interface SubscriberFacade : Subscriber {
      */
     fun stopAsync(): CompletableFuture<Void>
 
-    companion object {
-        /**
-         * Returns a facade for the given subscriber instance.
-         */
-        @JvmStatic
-        fun wrap(subscriber: Subscriber): SubscriberFacade {
-            return DefaultSubscriberFacade(subscriber)
+    /**
+     * Builder for providing [SubscriberFacade].
+     */
+    interface Builder {
+        companion object {
+            /**
+             * Returns a facade for the given subscriber builder instance.
+             */
+            @JvmStatic
+            fun wrap(builder: Subscriber.Builder): Builder {
+                return SubscriberFacadeBuilder(builder)
+            }
         }
+
+        /**
+         * Creates a [SubscriberFacade] and starts listening for location updates.
+         *
+         * @return A [CompletableFuture] with the created and started subscriber facade.
+         */
+        fun startAsync(): CompletableFuture<SubscriberFacade>
     }
 }

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacadeBuilder.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacadeBuilder.kt
@@ -1,0 +1,18 @@
+package com.ably.tracking.subscriber.java
+
+import com.ably.tracking.subscriber.Subscriber
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.future.future
+import java.util.concurrent.CompletableFuture
+
+class SubscriberFacadeBuilder(
+    private val builder: Subscriber.Builder
+) : SubscriberFacade.Builder, Subscriber.Builder by builder {
+    private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    override fun startAsync(): CompletableFuture<SubscriberFacade> {
+        return scope.future { DefaultSubscriberFacade(builder.start()) }
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -81,9 +81,11 @@ private class DefaultCoreSubscriber(
                     is StartEvent -> {
                         notifyAssetIsOffline()
                         ably.connect(trackableId, presenceData, useRewind = true) {
-                            subscribeForEnhancedEvents()
-                            subscribeForPresenceMessages()
-                            // TODO what should we do when connection fails?
+                            if (it.isSuccess) {
+                                subscribeForEnhancedEvents()
+                                subscribeForPresenceMessages()
+                            }
+                            event.handler(it)
                         }
                     }
                     is PresenceMessageEvent -> {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -28,7 +28,23 @@ internal class DefaultSubscriber(
         Timber.w("Started.")
 
         core = createCoreSubscriber(ably, resolution, trackableId)
-        core.enqueue(StartEvent())
+    }
+
+    /**
+     * This method must be run before running any other method from [DefaultSubscriber].
+     */
+    suspend fun start() {
+        suspendCoroutine<Unit> { continuation ->
+            core.request(
+                StartEvent {
+                    try {
+                        continuation.resume(it.getOrThrow())
+                    } catch (exception: Exception) {
+                        continuation.resumeWithException(exception)
+                    }
+                }
+            )
+        }
     }
 
     override suspend fun sendChangeRequest(resolution: Resolution) {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -102,6 +102,7 @@ interface Subscriber {
          * @return A new subscriber instance.
          * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
          */
+        @JvmSynthetic
         @Throws(BuilderConfigurationIncompleteException::class)
         suspend fun start(): Subscriber
     }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -103,6 +103,6 @@ interface Subscriber {
          * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
          */
         @Throws(BuilderConfigurationIncompleteException::class)
-        fun start(): Subscriber
+        suspend fun start(): Subscriber
     }
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -20,7 +20,7 @@ internal data class SubscriberBuilder(
     override fun trackingId(trackingId: String): Subscriber.Builder =
         this.copy(trackingId = trackingId)
 
-    override fun start(): Subscriber {
+    override suspend fun start(): Subscriber {
         if (isMissingRequiredFields()) {
             throw BuilderConfigurationIncompleteException()
         }
@@ -29,7 +29,9 @@ internal data class SubscriberBuilder(
             DefaultAbly(connectionConfiguration!!),
             resolution,
             trackingId!!
-        )
+        ).apply {
+            start()
+        }
     }
 
     private fun isMissingRequiredFields() =

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
@@ -16,7 +16,9 @@ internal sealed class AdhocEvent : Event()
  */
 internal sealed class Request : Event()
 
-internal class StartEvent : AdhocEvent()
+internal class StartEvent(
+    val handler: ResultHandler<Unit>
+) : Request()
 
 internal class StopEvent(
     val handler: ResultHandler<Unit>

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/FactoryUnitTests.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.Accuracy
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.Resolution
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 
@@ -104,7 +105,9 @@ class FactoryUnitTests {
     @SuppressLint("MissingPermission")
     @Test(expected = BuilderConfigurationIncompleteException::class)
     fun `calling start with missing required fields should throw BuilderConfigurationIncompleteException`() {
-        Subscriber.subscribers().start()
+        runBlocking {
+            Subscriber.subscribers().start()
+        }
     }
 
     private fun assertAllBuilderFieldsAreNull(builder: SubscriberBuilder) {


### PR DESCRIPTION
I've changed the `start()` method of the Subscriber's builder to be an asynchronous function. The Publisher's start method is fully synchronous therefore I've not changed it to an async one in order to keep things simple.

I had to adjust Java interface to adopt those new changes. Thus, the new `SubscriberFacade.Builder` interface was added. Because of adding a special builder for the facade I removed the `wrap()` function that allowed to get a `SubscriberFacade` from a `Subscriber`. Now the only way to create a `SubscriberFacade` is to use the `SubscriberFacade.Builder`'s `startAsync()` method.