### PR TITLE
Handle subscriber in the stopped state

### DIFF
--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 
 internal interface CoreSubscriber {
     fun enqueue(event: AdhocEvent)
-    fun request(request: Request)
+    fun request(request: Request<*>)
     val enhancedLocations: SharedFlow<LocationUpdate>
     val trackableStates: StateFlow<TrackableState>
 }
@@ -69,7 +69,7 @@ private class DefaultCoreSubscriber(
         scope.launch { sendEventChannel.send(event) }
     }
 
-    override fun request(request: Request) {
+    override fun request(request: Request<*>) {
         scope.launch { sendEventChannel.send(request) }
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
@@ -14,21 +14,21 @@ internal sealed class AdhocEvent : Event()
 /**
  * Represents an event that invokes an action that calls a callback when it completes.
  */
-internal sealed class Request : Event()
+internal sealed class Request<T>(val handler: ResultHandler<T>) : Event()
 
 internal class StartEvent(
-    val handler: ResultHandler<Unit>
-) : Request()
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)
 
 internal class StopEvent(
-    val handler: ResultHandler<Unit>
-) : Request()
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)
 
 internal data class PresenceMessageEvent(
     val presenceMessage: PresenceMessage
 ) : AdhocEvent()
 
-internal data class ChangeResolutionEvent(
+internal class ChangeResolutionEvent(
     val resolution: Resolution?,
-    val handler: ResultHandler<Unit>
-) : Request()
+    handler: ResultHandler<Unit>
+) : Request<Unit>(handler)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberStoppedException.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberStoppedException.kt
@@ -1,0 +1,3 @@
+package com.ably.tracking.subscriber
+
+class SubscriberStoppedException : Exception("Cannot perform this action when subscriber is stopped.")


### PR DESCRIPTION
After stopping the Subscriber we're setting its state to `isStopped` and after that any new event that isn't a `StopEvent` will be either ignored or the `SubscriberStoppedException` will be returned in its handler.