### PR TITLE
Use Ably and channel state when determining the trackable state in Subscriber SDK

### DIFF
--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberEvents.kt
@@ -1,5 +1,6 @@
 package com.ably.tracking.subscriber
 
+import com.ably.tracking.ConnectionStateChange
 import com.ably.tracking.Resolution
 import com.ably.tracking.ResultHandler
 import com.ably.tracking.common.PresenceMessage
@@ -32,3 +33,7 @@ internal class ChangeResolutionEvent(
     val resolution: Resolution?,
     handler: ResultHandler<Unit>
 ) : Request<Unit>(handler)
+
+internal data class AblyConnectionStateChangeEvent(val connectionStateChange: ConnectionStateChange) : AdhocEvent()
+
+internal data class ChannelConnectionStateChangeEvent(val connectionStateChange: ConnectionStateChange) : AdhocEvent()


### PR DESCRIPTION
Like in the Publisher SDK, in order to decide if a trackable is online, offline or failed we're now using the Ably and channel state together with the presence of the Publisher in the channel.