### PR TITLE
Allow the Subscriber to request no resolution from the Publisher

### DIFF
--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -47,7 +47,7 @@ fun exampleUsage(trackingId: String) {
     // Request a different resolution when needed.
     scope.launch {
         try {
-            subscriber.sendChangeRequest(
+            subscriber.resolutionPreference(
                 Resolution(Accuracy.MAXIMUM, desiredInterval = 100L, minimumDisplacement = 2.0)
             )
             // TODO change request submitted successfully

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -108,7 +108,7 @@ class MainActivity : AppCompatActivity() {
         // TODO - is this try/catch the best way to do it? maybe we should return the Result and let clients handle it their way?
         subscriber?.let {
             try {
-                it.sendChangeRequest(newResolution)
+                it.resolutionPreference(newResolution)
                 resolution = newResolution
                 updateResolutionInfo(newResolution)
             } catch (exception: Exception) {

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -1,7 +1,6 @@
 package com.ably.tracking.example.javasubscriber;
 
 import com.ably.tracking.Accuracy;
-import com.ably.tracking.BuilderConfigurationIncompleteException;
 import com.ably.tracking.ConnectionConfiguration;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.subscriber.Subscriber;
@@ -9,7 +8,6 @@ import com.ably.tracking.subscriber.java.SubscriberFacade;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockedStatic;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -34,7 +32,7 @@ public class UsageExamples {
         subscriberFacadeBuilder = mock(SubscriberFacade.Builder.class, withSettings().defaultAnswer(RETURNS_SELF));
         when(subscriberFacadeBuilder.startAsync()).thenReturn(CompletableFuture.completedFuture(subscriberFacade));
         subscriberFacade = mock(SubscriberFacade.class);
-        when(subscriberFacade.sendChangeRequestAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(subscriberFacade.resolutionPreferenceAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(subscriberFacade.stopAsync()).thenReturn(CompletableFuture.completedFuture(null));
     }
 
@@ -72,7 +70,7 @@ public class UsageExamples {
 
         try {
 //        // use methods that return a completable future
-            subscriberFacade.sendChangeRequestAsync(new Resolution(Accuracy.MAXIMUM, 1L, 1.0)).get();
+            subscriberFacade.resolutionPreferenceAsync(new Resolution(Accuracy.MAXIMUM, 1L, 1.0)).get();
             subscriberFacade.stopAsync().get();
         } catch (ExecutionException e) {
             // handle execution exception

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
-import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.java.LocationUpdateListener
+import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.subscriber.Subscriber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,8 +17,8 @@ internal class DefaultSubscriberFacade(
 ) : SubscriberFacade, Subscriber by subscriber {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-    override fun sendChangeRequestAsync(resolution: Resolution): CompletableFuture<Void> {
-        return scope.future { subscriber.sendChangeRequest(resolution) }.thenRun { }
+    override fun resolutionPreferenceAsync(resolution: Resolution?): CompletableFuture<Void> {
+        return scope.future { subscriber.resolutionPreference(resolution) }.thenRun { }
     }
 
     override fun addLocationListener(listener: LocationUpdateListener) {

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture
  */
 interface SubscriberFacade : Subscriber {
     /**
-     * Sends the desired resolution for updates, to be requested from the remote publisher.
+     * Sends the preferred resolution for updates, to be requested from the remote publisher.
      *
      * An initial resolution may be defined from the outset of a [Subscriber]'s lifespan by using the
      * [resolution][Builder.resolution] method on the [Builder] instance used to [start][Builder.start] it.
@@ -23,11 +23,11 @@ interface SubscriberFacade : Subscriber {
      * The returned [CompletableFuture] will complete once the request has been successfully registered with the server,
      * however this does not necessarily mean that the request has been received and actioned by the publisher.
      *
-     * @param resolution The resolution to request.
+     * @param resolution The preferred resolution or null if has no resolution preference.
      *
-     * @return A [CompletableFuture] that completes when the object has been removed.
+     * @return A [CompletableFuture] that completes when the request has been completed.
      */
-    fun sendChangeRequestAsync(resolution: Resolution): CompletableFuture<Void>
+    fun resolutionPreferenceAsync(resolution: Resolution?): CompletableFuture<Void>
 
     /**
      * Adds a handler to be notified when an enhanced location update is available.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -47,7 +47,7 @@ internal class DefaultSubscriber(
         }
     }
 
-    override suspend fun sendChangeRequest(resolution: Resolution) {
+    override suspend fun resolutionPreference(resolution: Resolution?) {
         // send change request over channel and wait for the result
         suspendCoroutine<Unit> { continuation ->
             core.request(

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -29,7 +29,7 @@ interface Subscriber {
     }
 
     /**
-     * Sends the desired resolution for updates, to be requested from the remote publisher.
+     * Sends the preferred resolution for updates, to be requested from the remote publisher.
      *
      * An initial resolution may be defined from the outset of a [Subscriber]'s lifespan by using the
      * [resolution][Builder.resolution] method on the [Builder] instance used to [start][Builder.start] it.
@@ -39,10 +39,10 @@ interface Subscriber {
      * The [handler] will be called once the request has been successfully registered with the server,
      * however this does not necessarily mean that the request has been received and actioned by the publisher.
      *
-     * @param resolution The resolution to request.
+     * @param resolution The preferred resolution or null if has no resolution preference.
      */
     @JvmSynthetic
-    suspend fun sendChangeRequest(resolution: Resolution)
+    suspend fun resolutionPreference(resolution: Resolution?)
 
     /**
      * The shared flow emitting enhanced location values when they become available.
@@ -81,7 +81,7 @@ interface Subscriber {
         fun connection(configuration: ConnectionConfiguration): Builder
 
         /**
-         * **OPTIONAL** Sets the desired resolution of updates, to be requested from the remote publisher.
+         * **OPTIONAL** Sets the preferred resolution of updates, to be requested from the remote publisher.
          *
          * @param resolution An indication of how often to this subscriber would like the publisher to sample locations,
          * at what level of positional accuracy, and how often to send them back.


### PR DESCRIPTION
The `sendChangeRequest()` method was renamed to `resolutionPreference()` to make it more explicit that the requested resolution is just a preference.
Changed the`resolution` param from that method to accept `null` values which allow the Subscriber to request no resolution from the Publisher.