### PR TITLE
Remove redundant isStopped check in the CorePublisher

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -345,19 +345,15 @@ constructor(
                         state.currentDestination?.let { setDestination(it, state) }
                     }
                     is StopEvent -> {
-                        if (state.isStopped) {
+                        if (state.isTracking) {
+                            stopLocationUpdates(state)
+                        }
+                        try {
+                            ably.close(state.presenceData)
+                            state.isStopped = true
                             event.handler(Result.success(Unit))
-                        } else {
-                            if (state.isTracking) {
-                                stopLocationUpdates(state)
-                            }
-                            try {
-                                ably.close(state.presenceData)
-                                state.isStopped = true
-                                event.handler(Result.success(Unit))
-                            } catch (exception: ConnectionException) {
-                                event.handler(Result.failure(exception))
-                            }
+                        } catch (exception: ConnectionException) {
+                            event.handler(Result.failure(exception))
                         }
                     }
                     is AblyConnectionStateChangeEvent -> {


### PR DESCRIPTION
The `isStopped` check in the code processing `StopEvent` was redundant, because we're checking and handling the `isStopped` before we try to process any event.