### PR TITLE
Change actions order when disconnecting from Ably channel

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -203,15 +203,16 @@ constructor(
     }
 
     override fun disconnect(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
-        val removedChannel = channels.remove(trackableId)
-        if (removedChannel != null) {
-            removedChannel.unsubscribe()
-            removedChannel.presence.unsubscribe()
+        if (channels.contains(trackableId)) {
+            val channelToRemove = channels[trackableId]!!
             try {
-                removedChannel.presence.leave(
+                channelToRemove.presence.leave(
                     gson.toJson(presenceData.toMessage()),
                     object : CompletionListener {
                         override fun onSuccess() {
+                            channelToRemove.unsubscribe()
+                            channelToRemove.presence.unsubscribe()
+                            channels.remove(trackableId)
                             callback(Result.success(Unit))
                         }
 


### PR DESCRIPTION
I changed the order of actions in the `disconnect()` method of the Ably wrapper. Now it will clear the channel listeners and remove it from the channels collection only after it successfully leaves its presence.