### PR TITLE
Upgrade to Kotlin 1.4

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/common/Expectations.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/common/Expectations.kt
@@ -55,10 +55,10 @@ open class Expectation<T>(
         result ?: throw AssertionError("Expectation '$description' unfulfilled.")
 }
 
-class UnitResultExpectation(label: String) : Expectation<Result<Unit>>(label) {
+class BooleanExpectation(label: String) : Expectation<Boolean>(label) {
     fun assertSuccess() {
         assertFulfilled().let {
-            if (!it.isSuccess) {
+            if (!it) {
                 throw AssertionError("Expectation '$description' did not result in success.")
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.4.32"
     repositories {
         google()
         jcenter()

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -16,8 +16,8 @@ import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.RoutingProfile
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.subscriber.Subscriber
+import com.ably.tracking.test.common.BooleanExpectation
 import com.ably.tracking.test.common.UnitExpectation
-import com.ably.tracking.test.common.UnitResultExpectation
 import com.ably.tracking.test.common.testLogD
 import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
@@ -50,7 +50,7 @@ class PublisherAndSubscriberTests {
         val locationData = getLocationData(context)
         val publishedLocations = mutableListOf<LocationUpdate>()
         val receivedLocations = mutableListOf<LocationUpdate>()
-        val trackResultExpectation = UnitResultExpectation("track response")
+        val trackExpectation = BooleanExpectation("track response")
         val scope = CoroutineScope(Dispatchers.Default)
 
         // when
@@ -82,9 +82,10 @@ class PublisherAndSubscriberTests {
             try {
                 publisher.track(Trackable(trackableId))
                 testLogD("track success")
-                trackResultExpectation.fulfill(Result.success(Unit))
+                trackExpectation.fulfill(true)
             } catch (e: Exception) {
                 testLogD("track failed")
+                trackExpectation.fulfill(false)
             }
         }
 
@@ -111,7 +112,7 @@ class PublisherAndSubscriberTests {
 
         // then
         dataEndedExpectation.assertFulfilled()
-        trackResultExpectation.assertSuccess()
+        trackExpectation.assertSuccess()
         publisherStoppedExpectation.assertFulfilled()
         subscriberStoppedExpectation.assertFulfilled()
         Assert.assertTrue(

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
@@ -7,8 +7,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.ably.tracking.Accuracy
 import com.ably.tracking.ConnectionConfiguration
 import com.ably.tracking.Resolution
+import com.ably.tracking.test.common.BooleanExpectation
 import com.ably.tracking.test.common.UnitExpectation
-import com.ably.tracking.test.common.UnitResultExpectation
 import com.ably.tracking.test.common.testLogD
 import com.google.gson.Gson
 import kotlinx.coroutines.runBlocking
@@ -30,7 +30,7 @@ class PublisherIntegrationTests {
         // given
         testLogD("GIVEN")
         val dataEndedExpectation = UnitExpectation("data ended")
-        val trackResultExpectation = UnitResultExpectation("track response")
+        val trackExpectation = BooleanExpectation("track response")
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val locationData = getLocationData(context)
 
@@ -48,36 +48,38 @@ class PublisherIntegrationTests {
             try {
                 publisher.track(Trackable("ID"))
                 testLogD("track success")
-                trackResultExpectation.fulfill(Result.success(Unit))
+                trackExpectation.fulfill(true)
             } catch (e: Exception) {
                 testLogD("track failed")
+                trackExpectation.fulfill(false)
             }
         }
 
         // await asynchronous events
         testLogD("AWAIT")
         dataEndedExpectation.await()
-        trackResultExpectation.await()
+        trackExpectation.await()
 
         // cleanup
         testLogD("CLEANUP")
-        val stopResultExpectation = UnitResultExpectation("stop response")
+        val stopExpectation = BooleanExpectation("stop response")
         runBlocking {
             try {
                 publisher.stop()
                 testLogD("stop succes")
-                stopResultExpectation.fulfill(Result.success(Unit))
+                stopExpectation.fulfill(true)
             } catch (e: Exception) {
                 testLogD("stop failed")
+                stopExpectation.fulfill(true)
             }
         }
-        stopResultExpectation.await()
+        stopExpectation.await()
 
         // then
         testLogD("THEN")
         dataEndedExpectation.assertFulfilled()
-        trackResultExpectation.assertSuccess()
-        stopResultExpectation.assertSuccess()
+        trackExpectation.assertSuccess()
+        stopExpectation.assertSuccess()
     }
 
     @SuppressLint("MissingPermission")


### PR DESCRIPTION
I upgraded the Kotlin version to `1.4.32` which is the currently newest version.

As I've mentioned in [this comment](https://github.com/ably/ably-asset-tracking-android/issues/163#issuecomment-806826160), there is a problem with inline classes used in generics. Therefore, I've changed the `Expection<Result<Unit>>` to an `Expection<Boolean>` in order to make our tests work.