### PR TITLE
Use batteryLevel when comparing location updates

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
@@ -5,7 +5,7 @@ import android.location.Location
 open class LocationUpdate(val location: Location, val batteryLevel: Float?) {
     override fun equals(other: Any?): Boolean =
         when (other) {
-            is LocationUpdate -> location == other.location
+            is LocationUpdate -> location == other.location && batteryLevel == other.batteryLevel
             else -> false
         }
 }


### PR DESCRIPTION
Now we're using both `location` and `batteryLevel` when comparing `LocationUpdate`s.