### PR TITLE
Update Mapbox to version 2.0

### DIFF
--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -13,12 +13,12 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation 'com.mapbox.navigation:core:1.1.0'
+    implementation 'com.mapbox.navigation:core:2.0.0-beta.4'
 
     // Only the Core SDK portion of the MapBox Maps SDK for Android.
     // https://docs.mapbox.com/android/maps/overview/
     // https://docs.mapbox.com/android/core/overview/
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:3.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:3.1.1'
 
     // Advanced geospatial analysis - used i.e. for calculating distance between points.
     // https://docs.mapbox.com/android/java/guides/turf/

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -108,11 +108,9 @@ internal class DefaultMapbox(
     private var locationHistoryListener: (LocationHistoryListener)? = null
 
     init {
-        val mapboxBuilder = MapboxNavigation.defaultNavigationOptionsBuilder(
-            context,
-            mapConfiguration.apiKey
-        )
-        mapboxBuilder.locationEngine(getBestLocationEngine(context))
+        val mapboxBuilder = NavigationOptions.Builder(context)
+            .accessToken(mapConfiguration.apiKey)
+            .locationEngine(getBestLocationEngine(context))
         locationSource?.let {
             when (it) {
                 is LocationSourceAbly -> {


### PR DESCRIPTION
Luckily, the update didn't cause a lot of troubles. I only had to change the `NavigationOptions.Builder` creation code.

Please note that the v2.0 of the Mapbox is still in the `beta` phase so we should consider if we want to update it right now or wait for it to become stable.