### PR TITLE
Allow to add trackable from the trackable id input keyboard

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.Accuracy
@@ -35,6 +36,20 @@ class AddTrackableActivity : PublisherServiceActivity() {
         appPreferences = AppPreferences(this) // TODO - Add some DI (Koin)?
 
         addTrackableButton.setOnClickListener { beginAddingTrackable() }
+        setupTrackableInputAction()
+    }
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    private fun setupTrackableInputAction() {
+        trackableIdEditText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                hideKeyboard(trackableIdEditText)
+                beginAddingTrackable()
+                true
+            } else {
+                false
+            }
+        }
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -1,0 +1,12 @@
+package com.ably.tracking.example.publisher
+
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+fun Context.hideKeyboard(view: View) {
+    (getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.hideSoftInputFromWindow(
+        view.windowToken,
+        0
+    )
+}

--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -32,6 +32,8 @@
     android:layout_marginStart="32dp"
     android:layout_marginEnd="32dp"
     android:layout_marginBottom="32dp"
+    android:imeOptions="actionDone"
+    android:inputType="text"
     app:layout_constraintBottom_toTopOf="@+id/addTrackableButton"
     tools:text="Here goes test ID" />
 


### PR DESCRIPTION
As suggested in the https://github.com/ably/ably-asset-tracking-android/issues/209 I replaced the "Enter" key with a "done" key. If a user presses that "done" key then it acts just as if he has clicked on the "Add trackable" button.