### PR TITLE
Setting resolution for publisher and trackables in the publisher example app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ subprojects {
                               'LockedOrientationActivity',
                               'IconLocation',
                               'StopShip',
+                              'DefaultLocale',
                               'ObsoleteSdkInt'
 
                 // Lint rules which are disabled by default (see: lint --show), but which we would

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -15,7 +15,7 @@ android {
 dependencies {
     implementation project(":publishing-sdk")
     implementation 'io.ably:ably-android:1.2.2'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'com.amplifyframework:aws-storage-s3:1.4.1'
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -108,6 +108,14 @@ class AddTrackableActivity : PublisherServiceActivity() {
         addTrackableToThePublisher(trackableId)
     }
 
+    private fun createResolution(): Resolution {
+        return Resolution(
+            accuracySpinner.selectedItem as Accuracy,
+            desiredIntervalEditText.text.toString().toLong(),
+            minimumDisplacementEditText.text.toString().toDouble()
+        )
+    }
+
     private fun addTrackableToThePublisher(trackableId: String) {
         publisherService?.publisher?.apply {
             scope.launch {
@@ -116,13 +124,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                         Trackable(
                             trackableId,
                             constraints = DefaultResolutionConstraints(
-                                DefaultResolutionSet(
-                                    Resolution(
-                                        Accuracy.BALANCED,
-                                        desiredInterval = 1000L,
-                                        minimumDisplacement = 1.0
-                                    )
-                                ),
+                                DefaultResolutionSet(createResolution()),
                                 DefaultProximity(spatial = 1.0),
                                 batteryLevelThreshold = 10.0f,
                                 lowBatteryMultiplier = 2.0f

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.Accuracy
@@ -35,8 +36,18 @@ class AddTrackableActivity : PublisherServiceActivity() {
         setContentView(R.layout.activity_add_trackable)
         appPreferences = AppPreferences(this) // TODO - Add some DI (Koin)?
 
+        setupResolutionFields()
         addTrackableButton.setOnClickListener { beginAddingTrackable() }
         setupTrackableInputAction()
+    }
+
+    private fun setupResolutionFields() {
+        accuracySpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, Accuracy.values()).apply {
+            setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        }
+        accuracySpinner.setSelection(appPreferences.getResolutionAccuracy().ordinal)
+        desiredIntervalEditText.setText(appPreferences.getResolutionDesiredInterval().toString())
+        minimumDisplacementEditText.setText(appPreferences.getResolutionMinimumDisplacement().toString())
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -92,10 +92,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     private fun startPublisherAndAddTrackable(trackableId: String, historyData: LocationHistoryData? = null) {
         if (publisherService?.publisher == null) {
-            publisherService?.startPublisher(
-                defaultResolution = Resolution(Accuracy.MINIMUM, 1000L, 1.0),
-                locationSource = createLocationSource(historyData)
-            )
+            publisherService?.startPublisher(createLocationSource(historyData))
         }
         addTrackableToThePublisher(trackableId)
     }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.example.publisher
 
 import android.content.Context
 import androidx.preference.PreferenceManager
+import com.ably.tracking.Accuracy
 
 class AppPreferences(context: Context) {
     private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -9,9 +10,17 @@ class AppPreferences(context: Context) {
     private val SIMULATION_CHANNEL_KEY =
         context.getString(R.string.preferences_simulation_channel_name_key)
     private val S3_FILE_KEY = context.getString(R.string.preferences_s3_file_key)
+    private val RESOLUTION_ACCURACY_KEY = context.getString(R.string.preferences_resolution_accuracy_key)
+    private val RESOLUTION_DESIRED_INTERVAL_KEY =
+        context.getString(R.string.preferences_resolution_desired_interval_key)
+    private val RESOLUTION_MINIMUM_DISPLACEMENT_KEY =
+        context.getString(R.string.preferences_resolution_minimum_displacement_key)
     private val DEFAULT_LOCATION_SOURCE = context.getString(R.string.default_location_source)
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
+    private val DEFAULT_RESULTION_ACCURACY = Accuracy.BALANCED.name
+    private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
+    private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
 
     fun getLocationSource(): String =
         preferences.getString(LOCATION_SOURCE_KEY, DEFAULT_LOCATION_SOURCE)!!
@@ -21,4 +30,15 @@ class AppPreferences(context: Context) {
 
     fun getS3File() =
         preferences.getString(S3_FILE_KEY, DEFAULT_S3_FILE)!!
+
+    fun getResolutionAccuracy(): Accuracy =
+        preferences.getString(RESOLUTION_ACCURACY_KEY, DEFAULT_RESULTION_ACCURACY)!!.let { Accuracy.valueOf(it) }
+
+    fun getResolutionDesiredInterval(): Long =
+        preferences.getString(RESOLUTION_DESIRED_INTERVAL_KEY, null)?.toLong()
+            ?: DEFAULT_RESULTION_DESIRED_INTERVAL
+
+    fun getResolutionMinimumDisplacement(): Float =
+        preferences.getString(RESOLUTION_MINIMUM_DISPLACEMENT_KEY, null)?.toFloat()
+            ?: DEFAULT_RESULTION_MINIMUM_DISPLACEMENT
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PreferenceExtensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PreferenceExtensions.kt
@@ -1,0 +1,16 @@
+package com.ably.tracking.example.publisher
+
+import android.text.InputType
+import androidx.preference.EditTextPreference
+
+fun EditTextPreference.setIntNumberInputType() {
+    setOnBindEditTextListener {
+        it.inputType = InputType.TYPE_CLASS_NUMBER
+    }
+}
+
+fun EditTextPreference.setFloatNumberInputType() {
+    setOnBindEditTextListener {
+        it.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+    }
+}

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -62,15 +62,12 @@ class PublisherService : Service() {
      * Creates and starts the [Publisher].
      */
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
-    fun startPublisher(
-        defaultResolution: Resolution = DEFAULT_RESOLUTION,
-        locationSource: LocationSource? = null
-    ) {
+    fun startPublisher(locationSource: LocationSource? = null) {
         publisher = Publisher.publishers()
             .connection(ConnectionConfiguration(ABLY_API_KEY, CLIENT_ID))
             .map(MapConfiguration(MAPBOX_ACCESS_TOKEN))
             .locationSource(locationSource)
-            .resolutionPolicy(DefaultResolutionPolicyFactory(defaultResolution, this))
+            .resolutionPolicy(DefaultResolutionPolicyFactory(createDefaultResolution(), this))
             .androidContext(this)
             .profile(RoutingProfile.DRIVING)
             .start().apply {
@@ -79,6 +76,13 @@ class PublisherService : Service() {
                     .launchIn(scope)
             }
     }
+
+    private fun createDefaultResolution(): Resolution =
+        Resolution(
+            appPreferences.getResolutionAccuracy(),
+            appPreferences.getResolutionDesiredInterval(),
+            appPreferences.getResolutionMinimumDisplacement().toDouble()
+        )
 
     private fun uploadLocationHistoryData(historyData: LocationHistoryData) {
         if (getLocationSourceType() == LocationSourceType.PHONE) {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -3,8 +3,10 @@ package com.ably.tracking.example.publisher
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
+import com.ably.tracking.Accuracy
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,6 +21,11 @@ class SettingsActivity : AppCompatActivity() {
 class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.settings_preferences)
+        setupResolutionPreferences()
+        setupS3Preference()
+    }
+
+    private fun setupS3Preference() {
         (findPreference(getString(R.string.preferences_s3_file_key)) as ListPreference?)?.let { s3Preference ->
             S3Helper.fetchLocationHistoryFilenames(
                 onListLoaded = { filenamesWithSizes, filenames ->
@@ -33,6 +40,23 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     ).show()
                 }
             )
+        }
+    }
+
+    private fun setupResolutionPreferences() {
+        val appPreferences = AppPreferences(requireContext())
+        (findPreference(getString(R.string.preferences_resolution_accuracy_key)) as ListPreference?)?.apply {
+            entries = Accuracy.values().map { it.name.toLowerCase().capitalize() }.toTypedArray()
+            entryValues = Accuracy.values().map { it.name }.toTypedArray()
+            value = appPreferences.getResolutionAccuracy().name
+        }
+        (findPreference(getString(R.string.preferences_resolution_desired_interval_key)) as EditTextPreference?)?.apply {
+            text = appPreferences.getResolutionDesiredInterval().toString()
+            setIntNumberInputType()
+        }
+        (findPreference(getString(R.string.preferences_resolution_minimum_displacement_key)) as EditTextPreference?)?.apply {
+            text = appPreferences.getResolutionMinimumDisplacement().toString()
+            setFloatNumberInputType()
         }
     }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -7,6 +7,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import com.ably.tracking.Accuracy
+import java.util.Locale
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,7 +47,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun setupResolutionPreferences() {
         val appPreferences = AppPreferences(requireContext())
         (findPreference(getString(R.string.preferences_resolution_accuracy_key)) as ListPreference?)?.apply {
-            entries = Accuracy.values().map { it.name.toLowerCase().capitalize() }.toTypedArray()
+            entries = Accuracy.values()
+                .map { it.name.toLowerCase(Locale.getDefault()).capitalize(Locale.getDefault()) }
+                .toTypedArray()
             entryValues = Accuracy.values().map { it.name }.toTypedArray()
             value = appPreferences.getResolutionAccuracy().name
         }

--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -18,7 +18,88 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
+  <!-- Resolution -->
   <TextView
+    android:id="@+id/resolutionSectionLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="20dp"
+    android:text="@string/resolution_section_label"
+    android:textSize="16sp"
+    android:textStyle="bold"
+    app:layout_constraintStart_toStartOf="@+id/trackableIdEditText"
+    app:layout_constraintTop_toBottomOf="@id/appTitleTextView" />
+
+  <TextView
+    android:id="@+id/accuracyLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:text="@string/accuracy_label"
+    app:layout_constraintStart_toStartOf="@+id/trackableIdEditText"
+    app:layout_constraintTop_toBottomOf="@id/resolutionSectionLabelTextView" />
+
+  <androidx.appcompat.widget.AppCompatSpinner
+    android:id="@+id/accuracySpinner"
+    android:layout_width="match_parent"
+    android:layout_height="70dp"
+    android:layout_marginStart="32dp"
+    android:layout_marginEnd="32dp"
+    android:layout_marginBottom="32dp"
+    app:layout_constraintTop_toBottomOf="@id/accuracyLabelTextView" />
+
+  <TextView
+    android:id="@+id/desiredIntervalLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/desired_interval_label"
+    app:layout_constraintStart_toStartOf="@+id/trackableIdEditText"
+    app:layout_constraintTop_toBottomOf="@id/accuracySpinner" />
+
+  <androidx.appcompat.widget.AppCompatEditText
+    android:id="@+id/desiredIntervalEditText"
+    android:layout_width="match_parent"
+    android:layout_height="70dp"
+    android:layout_marginStart="32dp"
+    android:layout_marginEnd="32dp"
+    android:layout_marginBottom="32dp"
+    android:inputType="number"
+    app:layout_constraintTop_toBottomOf="@id/desiredIntervalLabelTextView"
+    tools:text="1000" />
+
+  <TextView
+    android:id="@+id/minimumDisplacementLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/minimum_displacement_label"
+    app:layout_constraintStart_toStartOf="@+id/trackableIdEditText"
+    app:layout_constraintTop_toBottomOf="@id/desiredIntervalEditText" />
+
+  <androidx.appcompat.widget.AppCompatEditText
+    android:id="@+id/minimumDisplacementEditText"
+    android:layout_width="match_parent"
+    android:layout_height="70dp"
+    android:layout_marginStart="32dp"
+    android:layout_marginEnd="32dp"
+    android:layout_marginBottom="32dp"
+    android:inputType="numberDecimal"
+    app:layout_constraintTop_toBottomOf="@id/minimumDisplacementLabelTextView"
+    tools:text="1.0" />
+
+  <!-- Trackable -->
+  <TextView
+    android:id="@+id/TrackableSectionLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="5dp"
+    android:text="@string/trackable_section_label"
+    android:textSize="16sp"
+    android:textStyle="bold"
+    app:layout_constraintBottom_toTopOf="@id/trackableIdLabelTextView"
+    app:layout_constraintStart_toStartOf="@+id/trackableIdEditText" />
+
+  <TextView
+    android:id="@+id/trackableIdLabelTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:text="@string/tracking_id"
@@ -53,9 +134,9 @@
 
   <ProgressBar
     android:id="@+id/progressIndicator"
-    android:visibility="gone"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:visibility="gone"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -88,7 +88,6 @@
 
   <!-- Trackable -->
   <TextView
-    android:id="@+id/TrackableSectionLabelTextView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="5dp"

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -22,6 +22,11 @@
   <string name="dialog_positive_button">OK</string>
   <string name="dialog_negative_button">Cancel</string>
   <string name="trackable_list">Trackable List</string>
+  <string name="resolution_section_label">Resolution</string>
+  <string name="accuracy_label">Accuracy</string>
+  <string name="desired_interval_label">Desired Interval [ms]</string>
+  <string name="minimum_displacement_label">Minimum Displacement [m]</string>
+  <string name="trackable_section_label">Trackable</string>
 
   <string name="preferences_general_category_title">Navigation Settings</string>
   <string name="preferences_location_source_key">location_source</string>

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -36,4 +36,15 @@
   <string name="default_simulation_channel">simulation_test</string>
   <string name="preferences_s3_file_key">s3_file</string>
   <string name="preferences_s3_file_label">S3 File</string>
+  <string name="preferences_resolution_category_title">Default resolution</string>
+  <string name="preferences_resolution_accuracy_key">default_resolution_accuracy</string>
+  <string name="preferences_resolution_accuracy_label">Accuracy</string>
+  <string name="preferences_resolution_desired_interval_key">default_resolution_desired_interval</string>
+  <string name="preferences_resolution_desired_interval_label">Desired interval</string>
+  <string name="preferences_update_resolution_desired_interval_message">Desired Interval [ms]</string>
+  <string name="preferences_update_resolution_desired_interval_title">Set Desired Interval</string>
+  <string name="preferences_resolution_minimum_displacement_key">default_resolution_minimum_displacement</string>
+  <string name="preferences_resolution_minimum_displacement_label">Minimum displacement</string>
+  <string name="preferences_update_resolution_minimum_displacement_message">Minimum Displacement [m]</string>
+  <string name="preferences_update_resolution_minimum_displacement_title">Set Minimum Displacement</string>
 </resources>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -31,4 +31,29 @@
 
   </PreferenceCategory>
 
+  <PreferenceCategory android:title="@string/preferences_resolution_category_title">
+
+    <ListPreference
+      android:entries="@array/location_source_entries"
+      android:entryValues="@array/location_source_values"
+      android:key="@string/preferences_resolution_accuracy_key"
+      android:title="@string/preferences_resolution_accuracy_label"
+      app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference
+      android:dialogMessage="@string/preferences_update_resolution_desired_interval_message"
+      android:dialogTitle="@string/preferences_update_resolution_desired_interval_title"
+      android:key="@string/preferences_resolution_desired_interval_key"
+      android:title="@string/preferences_resolution_desired_interval_label"
+      app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference
+      android:dialogMessage="@string/preferences_update_resolution_minimum_displacement_message"
+      android:dialogTitle="@string/preferences_update_resolution_minimum_displacement_title"
+      android:key="@string/preferences_resolution_minimum_displacement_key"
+      android:title="@string/preferences_resolution_minimum_displacement_label"
+      app:useSimpleSummaryProvider="true" />
+
+  </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
I added fields for setting the default publisher resolution in the settings screen.
![Screenshot from 2021-04-08 15-24-23](https://user-images.githubusercontent.com/62378170/114034598-9a7b3880-987e-11eb-94e6-e02ccb258d3f.png)

I added fields for setting the trackable resolution in the add trackable screen. The default values for those fields are set from the default resolution from the settings screen.
![Screenshot from 2021-04-08 15-24-36](https://user-images.githubusercontent.com/62378170/114034612-9d762900-987e-11eb-9fec-713475aec4de.png)

For some reason I kept getting a lint issue about not specifying the locale. I wasn't able to resolve it even if I was specifying a locale like `Locale.ENGLISH`. Therefore, I've added that lint rule to the `informational` so its still logged but won't fail the build.