### PR TITLE
Add optional Firebase Crashlytics integration to the publisher example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 
 
 publishing-example-app/src/main/res/raw/amplifyconfiguration.json
+
+google-services.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,3 @@ local.properties
 .idea/
 .DS_Store
 build/
-
-
-publishing-example-app/src/main/res/raw/amplifyconfiguration.json
-
-google-services.json

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Firebase Crashlytics
+        // see: https://firebase.google.com/docs/crashlytics/get-started?platform=android
         classpath 'com.google.gms:google-services:4.3.5'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
+        // Firebase Crashlytics
+        classpath 'com.google.gms:google-services:4.3.5'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/publishing-example-app/.gitignore
+++ b/publishing-example-app/.gitignore
@@ -1,1 +1,3 @@
-/build
+# Secrets which should never be committed
+/src/main/res/raw/amplifyconfiguration.json
+/google-services.json

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id 'kotlin-android-extensions'
     id 'org.jlleitschuh.gradle.ktlint'
 }
+// Use Firebase plugins if the configuration file is present
+if (project.file('google-services.json').exists()) {
+    apply plugin: 'com.google.gms.google-services'
+    apply plugin: 'com.google.firebase.crashlytics'
+}
 
 android {
     defaultConfig {
@@ -18,4 +23,11 @@ dependencies {
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'com.amplifyframework:aws-storage-s3:1.4.1'
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
+
+    if (project.file('google-services.json').exists()) {
+        // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies)
+        implementation platform('com.google.firebase:firebase-bom:26.8.0')
+        // Firebase Crashlytics
+        implementation 'com.google.firebase:firebase-crashlytics'
+    }
 }

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'kotlin-android-extensions'
     id 'org.jlleitschuh.gradle.ktlint'
 }
-// Use Firebase plugins if the configuration file is present
-if (project.file('google-services.json').exists()) {
+
+final useCrashlytics = project.file('google-services.json').exists();
+if (useCrashlytics) {
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.google.firebase.crashlytics'
 }
@@ -24,10 +25,13 @@ dependencies {
     implementation 'com.amplifyframework:aws-storage-s3:1.4.1'
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
 
-    if (project.file('google-services.json').exists()) {
-        // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies)
+    if (useCrashlytics) {
+        // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).
         implementation platform('com.google.firebase:firebase-bom:26.8.0')
-        // Firebase Crashlytics
+
+        // Firebase dependencies, which should not specifies versions as those are provided
+        // for us because we're including the BoM above.
+        // see: https://firebase.google.com/docs/crashlytics/get-started?platform=android
         implementation 'com.google.firebase:firebase-crashlytics'
     }
 }


### PR DESCRIPTION
I integrated the Firebase Crashlytics into the project. In order to make it work we'll need a `google-services.json` file placed in the `publishing-example-app` directory. 

It is optional to provide this file, if the file is provided then Crashlytics are enabled. If the file is not present then we're not using the Crashlytics.

@QuintinWillison the `google-services.json` isn't required to build the project so I'm wondering if it's worth putting that file in the secrets of this repo, WDYT?