### PR TITLE
Automatically center the camera on the marker position in subscriber example app

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -178,18 +178,21 @@ class MainActivity : AppCompatActivity() {
         googleMap?.apply {
             LatLng(location.latitude, location.longitude).let { position ->
                 marker.let { currentMarker ->
+                    val cameraPosition = CameraUpdateFactory.newLatLngZoom(position, ZOOM_LEVEL_STREETS)
                     if (currentMarker == null) {
                         marker = addMarker(
                             MarkerOptions()
                                 .position(position)
                                 .icon(getMarkerIcon(location.bearing))
                         )
-                        moveCamera(CameraUpdateFactory.newLatLngZoom(position, ZOOM_LEVEL_STREETS))
+                        moveCamera(cameraPosition)
                     } else {
                         currentMarker.setIcon(getMarkerIcon(location.bearing))
                         if (animationSwitch.isChecked) {
+                            animateCamera(cameraPosition)
                             animateMarkerMovement(currentMarker, position)
                         } else {
+                            moveCamera(cameraPosition)
                             currentMarker.position = position
                         }
                     }


### PR DESCRIPTION
The camera follows the position of the car marker on the map. 
If the marker movement is animated the camera movement is also animated. 
If the animation is off and the marker is jumping from one place to another then the camera also jumps with him.