### PR TITLE
Add skipped location updates to the LocationUpdate

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
@@ -44,6 +44,7 @@ fun EnhancedLocationUpdate.toJson(gson: Gson): String =
         EnhancedLocationUpdateMessage(
             location.toGeoJson(),
             batteryLevel,
+            skippedLocations.map { it.toGeoJson() },
             intermediateLocations.map { it.toGeoJson() },
             type.toMessage()
         )
@@ -55,6 +56,7 @@ fun Message.getEnhancedLocationUpdate(gson: Gson): EnhancedLocationUpdate =
             EnhancedLocationUpdate(
                 message.location.toLocation(),
                 message.batteryLevel,
+                message.skippedLocations.map { it.toLocation() },
                 message.intermediateLocations.map { it.toLocation() },
                 message.type.toTracking()
             )

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -52,6 +52,7 @@ enum class AccuracyMessage {
 data class EnhancedLocationUpdateMessage(
     val location: GeoJsonMessage,
     val batteryLevel: Float?,
+    val skippedLocations: List<GeoJsonMessage>,
     val intermediateLocations: List<GeoJsonMessage>,
     val type: LocationUpdateTypeMessage
 )

--- a/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
@@ -2,10 +2,10 @@ package com.ably.tracking
 
 import android.location.Location
 
-open class LocationUpdate(val location: Location, val batteryLevel: Float?) {
+open class LocationUpdate(val location: Location, val batteryLevel: Float?, val skippedLocations: List<Location>) {
     override fun equals(other: Any?): Boolean =
         when (other) {
-            is LocationUpdate -> location == other.location && batteryLevel == other.batteryLevel
+            is LocationUpdate -> location == other.location && batteryLevel == other.batteryLevel && skippedLocations == other.skippedLocations
             else -> false
         }
 }
@@ -13,9 +13,10 @@ open class LocationUpdate(val location: Location, val batteryLevel: Float?) {
 class EnhancedLocationUpdate(
     location: Location,
     batteryLevel: Float?,
+    skippedLocations: List<Location>,
     val intermediateLocations: List<Location>,
     val type: LocationUpdateType
-) : LocationUpdate(location, batteryLevel) {
+) : LocationUpdate(location, batteryLevel, skippedLocations) {
     override fun equals(other: Any?): Boolean =
         when (other) {
             !super.equals(other) -> false

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.publisher
 
+import android.location.Location
 import com.ably.tracking.ConnectionStateChange
-import com.ably.tracking.EnhancedLocationUpdate
-import com.ably.tracking.LocationUpdate
+import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.ResultHandler
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.PresenceMessage
@@ -59,11 +59,15 @@ internal class ConnectionForTrackableCreatedEvent(
 ) : Request<StateFlow<TrackableState>>(handler)
 
 internal data class RawLocationChangedEvent(
-    val locationUpdate: LocationUpdate
+    val location: Location,
+    val batteryLevel: Float?
 ) : AdhocEvent()
 
 internal data class EnhancedLocationChangedEvent(
-    val locationUpdate: EnhancedLocationUpdate
+    val location: Location,
+    val batteryLevel: Float?,
+    val intermediateLocations: List<Location>,
+    val type: LocationUpdateType
 ) : AdhocEvent()
 
 internal class RefreshResolutionPolicyEvent : AdhocEvent()


### PR DESCRIPTION
I added the skipped location updates to the `LocationUpdate` class. Those locations are the ones that aren't sent because of the trackable's resolution. After successfully sending a location update the skipped location updates for the trackable are cleared.