### PR TITLE
Remove the metadata field from the Trackable class

### DIFF
--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -82,7 +82,7 @@ public class PublisherInterfaceUsageExamples {
 
     @Test
     public void publisherUsageExample() {
-        Trackable trackable = new Trackable("ID", null, null, null);
+        Trackable trackable = new Trackable("ID", null, null);
         Trackable activeTrackable = publisher.getActive();
         publisher.setRoutingProfile(RoutingProfile.CYCLING);
         RoutingProfile routingProfile = publisher.getRoutingProfile();
@@ -118,7 +118,6 @@ public class PublisherInterfaceUsageExamples {
     public void trackableCreationExample() {
         Trackable trackable = new Trackable(
             "ID",
-            "METADATA",
             new Destination(1.0, 1.0),
             new DefaultResolutionConstraints(
                 new DefaultResolutionSet(new Resolution(Accuracy.MAXIMUM, 1L, 1.0)),

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/Snippets.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/Snippets.java
@@ -46,7 +46,7 @@ public class Snippets {
 
         // Call the policy in the same manner that the Kotlin-based pubisher would.
         final Resolution resolutionsResult = policy.resolve(new HashSet<Resolution>());
-        final Resolution requestsResult = policy.resolve(new TrackableResolutionRequest(new Trackable("", null, null, null), Collections.emptySet()));
+        final Resolution requestsResult = policy.resolve(new TrackableResolutionRequest(new Trackable("", null, null), Collections.emptySet()));
 
         // Validate that our policy returned what we told it to above.
         Assert.assertEquals(Accuracy.MINIMUM, resolutionsResult.getAccuracy());
@@ -78,7 +78,7 @@ public class Snippets {
             3.0f
         );
 
-        final Trackable trackable = new Trackable("Foo", null, null, constraints);
+        final Trackable trackable = new Trackable("Foo", null, constraints);
 
         Assert.assertEquals("Foo", trackable.getId());
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -215,7 +215,6 @@ data class Destination(
 
 data class Trackable(
     val id: String,
-    val metadata: String? = null,
     val destination: Destination? = null,
     val constraints: ResolutionConstraints? = null
 ) {


### PR DESCRIPTION
Removed the unused `metadata` field and fixed tests.