### PR TITLE
Handle error when subscribing for presence messages fails

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -244,7 +244,10 @@ constructor(
                                         enqueue(PresenceMessageEvent(event.trackable, it))
                                     }
                                 } catch (exception: ConnectionException) {
-                                    // TODO - what to do here? should we fail the whole process when subscribing for presence fails? or should it continue?
+                                    ably.disconnect(event.trackable.id, state.presenceData) {
+                                        event.handler(Result.failure(exception))
+                                    }
+                                    return@connect
                                 }
                                 ably.subscribeForChannelStateChange(event.trackable.id) {
                                     enqueue(ChannelConnectionStateChangeEvent(it, event.trackable.id))

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -1,0 +1,67 @@
+package com.ably.tracking.publisher
+
+import android.annotation.SuppressLint
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.common.Ably
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockDisconnectSuccess
+import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.UUID
+
+class DefaultPublisherTest {
+    private val ably = mockk<Ably>(relaxed = true)
+    private val mapbox = mockk<Mapbox>(relaxed = true)
+    private val resolutionPolicy = mockk<ResolutionPolicy>(relaxed = true)
+    private val resolutionPolicyFactory = object : ResolutionPolicy.Factory {
+        override fun createResolutionPolicy(hooks: ResolutionPolicy.Hooks, methods: ResolutionPolicy.Methods) =
+            resolutionPolicy
+    }
+    private val batteryDataProvider = mockk<BatteryDataProvider>(relaxed = true)
+
+    @SuppressLint("MissingPermission")
+    private val publisher: Publisher =
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, batteryDataProvider)
+
+    @Test(expected = ConnectionException::class)
+    fun `should return an error when adding a trackable with subscribing to presence error`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        ably.mockConnectSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceError(trackableId)
+
+        // when
+        runBlocking {
+            publisher.add(Trackable(trackableId))
+        }
+
+        // then
+    }
+
+    @Test()
+    fun `should disconnect from the channel when adding a trackable with subscribing to presence error`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        ably.mockConnectSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceError(trackableId)
+
+        // when
+        runBlocking {
+            try {
+                publisher.add(Trackable(trackableId))
+            } catch (exception: ConnectionException) {
+                // ignoring exception in this test
+            }
+        }
+
+        // then
+        verify(exactly = 1) {
+            ably.disconnect(trackableId, any(), any())
+        }
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -103,7 +103,14 @@ private class DefaultCoreSubscriber(
                         ably.connect(trackableId, state.presenceData, useRewind = true) {
                             if (it.isSuccess) {
                                 subscribeForEnhancedEvents()
-                                subscribeForPresenceMessages()
+                                try {
+                                    subscribeForPresenceMessages()
+                                } catch (exception: ConnectionException) {
+                                    ably.disconnect(trackableId, state.presenceData) {
+                                        event.handler(Result.failure(exception))
+                                    }
+                                    return@connect
+                                }
                                 subscribeForChannelState()
                             }
                             event.handler(it)

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
@@ -1,0 +1,55 @@
+package com.ably.tracking.subscriber
+
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.common.Ably
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockDisconnectSuccess
+import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.UUID
+
+class DefaultSubscriberTest {
+    private val ably = mockk<Ably>(relaxed = true)
+    private val trackableId = UUID.randomUUID().toString()
+    private val subscriber = DefaultSubscriber(ably, null, trackableId)
+
+    @Test(expected = ConnectionException::class)
+    fun `should return an error when starting the subscriber with subscribing to presence error`() {
+        // given
+        ably.mockConnectSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceError(trackableId)
+
+        // when
+        runBlocking {
+            subscriber.start()
+        }
+
+        // then
+    }
+
+    @Test()
+    fun `should disconnect from the channel when starting the subscriber with subscribing to presence error`() {
+        // given
+        ably.mockConnectSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceError(trackableId)
+
+        // when
+        runBlocking {
+            try {
+                subscriber.start()
+            } catch (exception: ConnectionException) {
+                // ignoring exception in this test
+            }
+        }
+
+        // then
+        verify(exactly = 1) {
+            ably.disconnect(trackableId, any(), any())
+        }
+    }
+}

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -1,5 +1,7 @@
 package com.ably.tracking.test.common
 
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.ErrorInformation
 import com.ably.tracking.common.Ably
 import io.mockk.every
 import io.mockk.slot
@@ -8,6 +10,19 @@ fun Ably.mockConnectSuccess(trackableId: String) {
     val callbackSlot = slot<(Result<Unit>) -> Unit>()
     every {
         connect(trackableId, any(), any(), capture(callbackSlot))
+    } answers {
+        callbackSlot.captured(Result.success(Unit))
+    }
+}
+
+fun Ably.mockSubscribeToPresenceError(trackableId: String) {
+    every { subscribeForPresenceMessages(trackableId, any()) } throws ConnectionException(ErrorInformation(""))
+}
+
+fun Ably.mockDisconnectSuccess(trackableId: String) {
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every {
+        disconnect(trackableId, any(), capture(callbackSlot))
     } answers {
         callbackSlot.captured(Result.success(Unit))
     }


### PR DESCRIPTION
I decided that we should fail right away when subscribing for presence messages fails as otherwise it will cause the Publisher and Subscriber to malfunction.