### PR TITLE
Replace jCenter repository with maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 plugins {
     id 'org.jlleitschuh.gradle.ktlint' version '9.4.1'
-    id 'org.jetbrains.dokka' version '1.4.30'
+    id 'org.jetbrains.dokka' version '1.4.32'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = '1.4.32'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
@@ -27,7 +27,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
             authentication {
@@ -198,7 +198,7 @@ subprojects {
             if (evaluatedSubProjectIsAnApp) {
                 implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
                 implementation 'androidx.multidex:multidex:2.0.1'
-                implementation 'pub.devrel:easypermissions:2.0.1'
+                implementation 'pub.devrel:easypermissions:3.0.0'
             }
 
             testImplementation 'junit:junit:4.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,6 @@ subprojects {
             if (evaluatedSubProjectIsAnApp) {
                 implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
                 implementation 'androidx.multidex:multidex:2.0.1'
-                implementation 'pub.devrel:easypermissions:3.0.0'
             }
 
             testImplementation 'junit:junit:4.13.1'

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'com.amplifyframework:aws-storage-s3:1.4.1'
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
+    implementation 'pub.devrel:easypermissions:3.0.0'
 
     if (useCrashlytics) {
         // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
This PR is in draft for now because it's generating new lint errors which I can't explain.

I'm seeing locally:

```
> Task :subscribing-example-app:lint FAILED
Ran lint on variant debug: 13 issues found
Ran lint on variant release: 13 issues found
/Users/quintinwillison/code/ably/ably-asset-tracking-android/subscribing-example-app/src/main/res/layout/activity_main.xml:137: Error: Replace the <fragment> tag with FragmentContainerView. [FragmentTagUsage]
  <fragment
   ~~~~~~~~
```

I suspect it may relate to #313.