### PR TITLE
Add slf4j logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ This repository also contains example apps that showcase how the Ably Asset Trac
 
 To build these apps you will need to specify [credentials](#api-keys-and-access-tokens) in Gradle properties.
 
+## Logging
+
+The SDKs use `slf4j` for logging. By default the logs aren't visible anywhere. In order to see logs, users have to include a library that implements the `slf4j-api` interface.
+In the example apps we are using `logback-android` which allows to easily log to the Logcat and create custom log handlers.
+For information on how to add `logback-android` to your project please check its [github page](https://github.com/tony19/logback-android).
+
+### Custom log handler
+
+To create your custom log handler you have to create a class that implements the `Appender` interface.
+There are a few base classes that you can extend to make things easier, two most important of them are `AppenderBase` and `UnsynchronizedAppenderBase`.
+For more detailed information about appenders check the [official logback docs](http://logback.qos.ch/manual/appenders.html).
+A sample [custom log handler](publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt) is implemented in the publishing example app.
+After creating your custom log handler you need to include it in the [logback configuration file](publishing-example-app/src/main/assets/logback.xml).
+The `name` attribute of the `appender` tag can be anything but it must match the `ref` attribute of the `appender-ref` tag.
+
 ## Android Runtime Requirements
 
 ### Kotlin Users

--- a/README.md
+++ b/README.md
@@ -114,18 +114,18 @@ To build these apps you will need to specify [credentials](#api-keys-and-access-
 
 ## Logging
 
-The SDKs use `slf4j` for logging. By default the logs aren't visible anywhere. In order to see logs, users have to include a library that implements the `slf4j-api` interface.
-In the example apps we are using `logback-android` which allows to easily log to the Logcat and create custom log handlers.
-For information on how to add `logback-android` to your project please check its [github page](https://github.com/tony19/logback-android).
+The SDKs use [SLF4J](http://www.slf4j.org/) for logging, which by default has a
+no-operation implementation meaning that logs will not be visible anywhere at runtime.
+An SLF4J implementation (the "binding") needs to be included on your app's class path for logs to be
+seen or otherwise consumed somewhere. The example apps in this repository use [logback-android]((https://github.com/tony19/logback-android)) as their implementation.
 
-### Custom log handler
+### Writing Your Own Log Implementation
 
-To create your custom log handler you have to create a class that implements the `Appender` interface.
-There are a few base classes that you can extend to make things easier, two most important of them are `AppenderBase` and `UnsynchronizedAppenderBase`.
-For more detailed information about appenders check the [official logback docs](http://logback.qos.ch/manual/appenders.html).
-A sample [custom log handler](publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt) is implemented in the publishing example app.
-After creating your custom log handler you need to include it in the [logback configuration file](publishing-example-app/src/main/assets/logback.xml).
-The `name` attribute of the `appender` tag can be anything but it must match the `ref` attribute of the `appender-ref` tag.
+To create your own custom log handler, based on the approach we've taken in our example apps, we suggest you create a class implementing [Logback](http://logback.qos.ch/)'s [Appender](http://logback.qos.ch/apidocs/ch/qos/logback/core/Appender.html) interface. There are a few base classes that you can extend to make things easier. The most important of them are `AppenderBase` and `UnsynchronizedAppenderBase`.
+
+Our publishing example app provides a reference [custom log handler](publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt) implementation.
+
+Your custom log handler needs to be included in the [logback configuration file](publishing-example-app/src/main/assets/logback.xml). The `name` attribute of the `appender` tag can be anything but it must match the `ref` attribute of the `appender-ref` tag.
 
 ## Android Runtime Requirements
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To build these apps you will need to specify [credentials](#api-keys-and-access-
 The SDKs use [SLF4J](http://www.slf4j.org/) for logging, which by default has a
 no-operation implementation meaning that logs will not be visible anywhere at runtime.
 An SLF4J implementation (the "binding") needs to be included on your app's class path for logs to be
-seen or otherwise consumed somewhere. The example apps in this repository use [logback-android]((https://github.com/tony19/logback-android)) as their implementation.
+seen or otherwise consumed somewhere. The example apps in this repository use [logback-android](https://github.com/tony19/logback-android) as their implementation.
 
 ### Writing Your Own Log Implementation
 

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Logging.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Logging.kt
@@ -7,7 +7,7 @@ import android.util.Log
 private val TAG = "PUBLISHING SDK IT"
 private val encounteredThreadIds = HashSet<Long>()
 
-@SuppressLint("LogNotTimber", "LogConditional")
+@SuppressLint("LogConditional")
 fun testLogD(message: String) {
     val thread = Thread.currentThread()
     val currentThreadId = thread.id

--- a/build.gradle
+++ b/build.gradle
@@ -181,9 +181,9 @@ subprojects {
         dependencies {
             implementation 'androidx.appcompat:appcompat:1.2.0'
             implementation 'com.google.android.material:material:1.2.1'
-            implementation 'org.slf4j:slf4j-api:1.7.30'
 
             if (evaluatedSubProjectIsKotlin) {
+                implementation 'io.github.microutils:kotlin-logging-jvm:2.0.6' // Kotlin wrapper for slf4j
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
                 implementation 'androidx.core:core-ktx:1.3.2'
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ subprojects {
             if (evaluatedSubProjectIsAnApp) {
                 implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
                 implementation 'androidx.multidex:multidex:2.0.1'
+                implementation 'com.github.tony19:logback-android:2.0.0'
             }
 
             testImplementation 'junit:junit:4.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,6 @@ subprojects {
             implementation 'com.google.android.material:material:1.2.1'
 
             if (evaluatedSubProjectIsKotlin) {
-                implementation 'io.github.microutils:kotlin-logging-jvm:2.0.6' // Kotlin wrapper for slf4j
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
                 implementation 'androidx.core:core-ktx:1.3.2'
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
@@ -200,6 +199,7 @@ subprojects {
 
             if (evaluatedSubProjectIsALibrary) {
                 implementation 'io.ably:ably-android:1.2.2'
+                implementation 'org.slf4j:slf4j-api:1.7.30'
             }
 
             if (evaluatedSubProjectIsAnApp) {

--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ subprojects {
         dependencies {
             implementation 'androidx.appcompat:appcompat:1.2.0'
             implementation 'com.google.android.material:material:1.2.1'
-            implementation 'com.jakewharton.timber:timber:4.7.1'
+            implementation 'org.slf4j:slf4j-api:1.7.30'
 
             if (evaluatedSubProjectIsKotlin) {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -140,7 +140,7 @@ constructor(
     private val ably: AblyRealtime
     private val channels: MutableMap<String, Channel> = mutableMapOf()
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val logger = KotlinLogging.logger { }
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     init {
         try {
@@ -157,10 +157,10 @@ constructor(
     private fun logMessage(severity: Int, tag: String?, message: String?, throwable: Throwable?) {
         val messageToLog = "$tag: $message"
         when (severity) {
-            Log.DEBUG -> logger.debug(throwable) { messageToLog }
-            Log.INFO -> logger.info(throwable) { messageToLog }
-            Log.WARN -> logger.warn(throwable) { messageToLog }
-            Log.ERROR -> logger.error(throwable) { messageToLog }
+            Log.DEBUG -> logger.debug(messageToLog, throwable)
+            Log.INFO -> logger.info(messageToLog, throwable)
+            Log.WARN -> logger.warn(messageToLog, throwable)
+            Log.ERROR -> logger.error(messageToLog, throwable)
         }
     }
 
@@ -259,7 +259,7 @@ constructor(
 
     override fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate) {
         val locationUpdateJson = locationUpdate.toJson(gson)
-        logger.debug { "sendEnhancedLocationMessage: publishing: $locationUpdateJson" }
+        logger.debug("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
         try {
             channels[trackableId]?.publish(EventNames.ENHANCED, locationUpdateJson)
         } catch (exception: AblyException) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -139,7 +139,7 @@ constructor(
     private val ably: AblyRealtime
     private val channels: MutableMap<String, Channel> = mutableMapOf()
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val logger = LoggerFactory.getLogger(this::class.simpleName)
+    private val logger = KotlinLogging.logger { }
 
     init {
         try {
@@ -244,7 +244,7 @@ constructor(
 
     override fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate) {
         val locationUpdateJson = locationUpdate.toJson(gson)
-        logger.debug("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
+        logger.debug { "sendEnhancedLocationMessage: publishing: $locationUpdateJson" }
         try {
             channels[trackableId]?.publish(EventNames.ENHANCED, locationUpdateJson)
         } catch (exception: AblyException) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -139,6 +139,7 @@ constructor(
     private val ably: AblyRealtime
     private val channels: MutableMap<String, Channel> = mutableMapOf()
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     init {
         try {
@@ -243,7 +244,7 @@ constructor(
 
     override fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate) {
         val locationUpdateJson = locationUpdate.toJson(gson)
-        Timber.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
+        logger.debug("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
         try {
             channels[trackableId]?.publish(EventNames.ENHANCED, locationUpdateJson)
         } catch (exception: AblyException) {

--- a/publishing-example-app/src/main/assets/logback.xml
+++ b/publishing-example-app/src/main/assets/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="logcat" class="ch.qos.logback.classic.android.LogcatAppender">
+    <tagEncoder>
+      <pattern>%logger{12}</pattern>
+    </tagEncoder>
+    <encoder>
+      <pattern>%msg</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="logcat" />
+  </root>
+</configuration>

--- a/publishing-example-app/src/main/assets/logback.xml
+++ b/publishing-example-app/src/main/assets/logback.xml
@@ -8,7 +8,10 @@
     </encoder>
   </appender>
 
+  <appender name="custom" class="com.ably.tracking.example.publisher.CustomLogsAppender" />
+
   <root level="DEBUG">
     <appender-ref ref="logcat" />
+    <appender-ref ref="custom" />
   </root>
 </configuration>

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt
@@ -1,0 +1,34 @@
+package com.ably.tracking.example.publisher
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.UnsynchronizedAppenderBase
+
+/**
+ * Example of a simple custom logs handler for the logback library.
+ * For more information see http://logback.qos.ch/manual/appenders.html
+ */
+class CustomLogsAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
+    override fun append(event: ILoggingEvent?) {
+        if (event == null) {
+            return
+        }
+        when (event.level.levelInt) {
+            Level.TRACE_INT -> {
+                // handle TRACE/VERBOSE logs
+            }
+            Level.DEBUG_INT -> {
+                // handle DEBUG logs
+            }
+            Level.INFO_INT -> {
+                // handle INFO logs
+            }
+            Level.WARN_INT -> {
+                // handle WARN logs
+            }
+            Level.ERROR_INT -> {
+                // handle ERROR logs
+            }
+        }
+    }
+}

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/CustomLogsAppender.kt
@@ -5,7 +5,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.UnsynchronizedAppenderBase
 
 /**
- * Example of a simple custom logs handler for the logback library.
+ * Example of a simple custom logs handler for the Logback library.
  * For more information see http://logback.qos.ch/manual/appenders.html
  */
 class CustomLogsAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
@@ -13,22 +13,8 @@ class CustomLogsAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
         if (event == null) {
             return
         }
-        when (event.level.levelInt) {
-            Level.TRACE_INT -> {
-                // handle TRACE/VERBOSE logs
-            }
-            Level.DEBUG_INT -> {
-                // handle DEBUG logs
-            }
-            Level.INFO_INT -> {
-                // handle INFO logs
-            }
-            Level.WARN_INT -> {
-                // handle WARN logs
-            }
-            Level.ERROR_INT -> {
-                // handle ERROR logs
-            }
-        }
+
+        // TODO log the message somewhere meaningful for your app
+        // e.g. FirebaseCrashlytics.getInstance().log("${event.level}: ${event.message}");
     }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import pub.devrel.easypermissions.AfterPermissionGranted
 import pub.devrel.easypermissions.EasyPermissions
-import timber.log.Timber
 
 private val REQUIRED_PERMISSIONS = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
 private const val REQUEST_LOCATION_PERMISSION = 1
@@ -30,7 +29,6 @@ class MainActivity : PublisherServiceActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Timber.d("Hello via Timber")
         setContentView(R.layout.activity_main)
         appPreferences = AppPreferences(this)
         updateLocationSourceMethodInfo()

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
@@ -8,7 +8,7 @@ import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.AmplifyConfiguration
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
 import com.google.gson.Gson
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
@@ -21,7 +21,7 @@ object S3Helper {
 
     private lateinit var gson: Gson
     private var isInitialized = false
-    private val logger = KotlinLogging.logger { }
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     fun init(context: Context) {
         if (isConfigFileProvided(context)) {
@@ -55,7 +55,7 @@ object S3Helper {
                     }
                     onListLoaded(filenamesWithSizes, filenames)
                 },
-                { error -> logger.error(error) { "Error when listing S3 files" } }
+                { error -> logger.error("Error when listing S3 files", error) }
             )
         } else {
             onUninitialized?.invoke()
@@ -83,7 +83,7 @@ object S3Helper {
                     val historyJson = result.file.readText()
                     onHistoryDataDownloaded(gson.fromJson(historyJson, LocationHistoryData::class.java))
                 },
-                { error -> logger.error(error) { "Error when downloading S3 file" } }
+                { error -> logger.error("Error when downloading S3 file", error) }
             )
         } else {
             onUninitialized?.invoke()
@@ -103,8 +103,8 @@ object S3Helper {
                 Amplify.Storage.uploadFile(
                     filename,
                     fileToUpload,
-                    { result -> logger.info { "Uploaded history data to S3: ${result.key}" } },
-                    { error -> logger.error(error) { "Error when uploading S3 file" } }
+                    { result -> logger.info("Uploaded history data to S3: ${result.key}") },
+                    { error -> logger.error("Error when uploading S3 file", error) }
                 )
             }
         } else {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
@@ -8,7 +8,7 @@ import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.AmplifyConfiguration
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
 import com.google.gson.Gson
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import java.io.File
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
@@ -21,7 +21,7 @@ object S3Helper {
 
     private lateinit var gson: Gson
     private var isInitialized = false
-    private val logger = LoggerFactory.getLogger(this::class.simpleName)
+    private val logger = KotlinLogging.logger { }
 
     fun init(context: Context) {
         if (isConfigFileProvided(context)) {
@@ -55,7 +55,7 @@ object S3Helper {
                     }
                     onListLoaded(filenamesWithSizes, filenames)
                 },
-                { error -> logger.error("Error when listing S3 files", error) }
+                { error -> logger.error(error) { "Error when listing S3 files" } }
             )
         } else {
             onUninitialized?.invoke()
@@ -83,7 +83,7 @@ object S3Helper {
                     val historyJson = result.file.readText()
                     onHistoryDataDownloaded(gson.fromJson(historyJson, LocationHistoryData::class.java))
                 },
-                { error -> logger.error("Error when downloading S3 file", error) }
+                { error -> logger.error(error) { "Error when downloading S3 file" } }
             )
         } else {
             onUninitialized?.invoke()
@@ -103,8 +103,8 @@ object S3Helper {
                 Amplify.Storage.uploadFile(
                     filename,
                     fileToUpload,
-                    { result -> logger.info("Uploaded history data to S3: ${result.key}") },
-                    { error -> logger.error("Error when uploading S3 file", error) }
+                    { result -> logger.info { "Uploaded history data to S3: ${result.key}" } },
+                    { error -> logger.error(error) { "Error when uploading S3 file" } }
                 )
             }
         } else {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/S3Helper.kt
@@ -8,7 +8,7 @@ import com.amplifyframework.core.Amplify
 import com.amplifyframework.core.AmplifyConfiguration
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
 import com.google.gson.Gson
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
@@ -21,6 +21,7 @@ object S3Helper {
 
     private lateinit var gson: Gson
     private var isInitialized = false
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     fun init(context: Context) {
         if (isConfigFileProvided(context)) {
@@ -54,7 +55,7 @@ object S3Helper {
                     }
                     onListLoaded(filenamesWithSizes, filenames)
                 },
-                { error -> Timber.e(error, "Error when listing S3 files") }
+                { error -> logger.error("Error when listing S3 files", error) }
             )
         } else {
             onUninitialized?.invoke()
@@ -82,7 +83,7 @@ object S3Helper {
                     val historyJson = result.file.readText()
                     onHistoryDataDownloaded(gson.fromJson(historyJson, LocationHistoryData::class.java))
                 },
-                { error -> Timber.e(error, "Error when downloading S3 file") }
+                { error -> logger.error("Error when downloading S3 file", error) }
             )
         } else {
             onUninitialized?.invoke()
@@ -102,8 +103,8 @@ object S3Helper {
                 Amplify.Storage.uploadFile(
                     filename,
                     fileToUpload,
-                    { result -> Timber.i("Uploaded history data to S3: ${result.key}") },
-                    { error -> Timber.e(error, "Error when uploading S3 file") }
+                    { result -> logger.info("Uploaded history data to S3: ${result.key}") },
+                    { error -> logger.error("Error when uploading S3 file", error) }
                 )
             }
         } else {

--- a/publishing-example-java-app/src/main/java/com/ably/tracking/example/javapublisher/MainActivity.java
+++ b/publishing-example-java-app/src/main/java/com/ably/tracking/example/javapublisher/MainActivity.java
@@ -3,14 +3,12 @@ package com.ably.tracking.example.javapublisher;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
-import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Timber.d("Hello via Timber");
         setContentView(R.layout.activity_main);
     }
 }

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -24,7 +24,6 @@ import com.ably.tracking.publisher.RoutingProfile;
 import com.ably.tracking.publisher.Trackable;
 import com.ably.tracking.publisher.java.PublisherFacade;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/Snippets.java
+++ b/publishing-example-java-app/src/test/java/com/ably/tracking/example/javapublisher/Snippets.java
@@ -1,5 +1,7 @@
 package com.ably.tracking.example.javapublisher;
 
+import androidx.annotation.NonNull;
+
 import com.ably.tracking.Accuracy;
 import com.ably.tracking.Resolution;
 import com.ably.tracking.publisher.DefaultProximity;
@@ -10,7 +12,6 @@ import com.ably.tracking.publisher.ResolutionPolicy;
 import com.ably.tracking.publisher.Trackable;
 import com.ably.tracking.publisher.TrackableResolutionRequest;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,16 +30,16 @@ public class Snippets {
     public void implementingResolutionPolicy() {
         // Implement the ResolutionPolicy interface.
         final ResolutionPolicy policy = new ResolutionPolicy() {
-            @NotNull
+            @NonNull
             @Override
-            public Resolution resolve(@NotNull Set<Resolution> resolutions) {
+            public Resolution resolve(@NonNull Set<Resolution> resolutions) {
                 // Return nonsense values, so we can validate them at the end of this test.
                 return new Resolution(Accuracy.MINIMUM, -666, -999);
             }
 
-            @NotNull
+            @NonNull
             @Override
-            public Resolution resolve(@NotNull TrackableResolutionRequest request) {
+            public Resolution resolve(@NonNull TrackableResolutionRequest request) {
                 // Return nonsense values, so we can validate them at the end of this test.
                 return new Resolution(Accuracy.MAXIMUM, -1666, -1999);
             }
@@ -118,7 +119,7 @@ public class Snippets {
         // Implement the ProximityHandler interface.
         final ResolutionPolicy.Methods.ProximityHandler handler = new ResolutionPolicy.Methods.ProximityHandler() {
             @Override
-            public void onProximityReached(@NotNull Proximity threshold) {
+            public void onProximityReached(@NonNull Proximity threshold) {
                 log.add("reached");
                 Assert.assertTrue(threshold instanceof DefaultProximity);
                 final DefaultProximity dp = (DefaultProximity) threshold;

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -27,7 +27,7 @@ import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 
 typealias LocationHistoryListener = (LocationHistoryData) -> Unit
 
@@ -106,6 +106,7 @@ internal class DefaultMapbox(
     private var mapboxNavigation: MapboxNavigation
     private var mapboxReplayer: MapboxReplayer? = null
     private var locationHistoryListener: (LocationHistoryListener)? = null
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     init {
         val mapboxBuilder = NavigationOptions.Builder(context)
@@ -189,7 +190,7 @@ internal class DefaultMapbox(
 
                     override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {
                         // We won't know the ETA for the active trackable and therefore we won't be able to check the temporal threshold.
-                        Timber.e(throwable, "Failed call to requestRoutes.")
+                        logger.error("Failed call to requestRoutes.", throwable)
                     }
                 }
             )

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -27,7 +27,7 @@ import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 
 typealias LocationHistoryListener = (LocationHistoryData) -> Unit
 
@@ -106,7 +106,7 @@ internal class DefaultMapbox(
     private var mapboxNavigation: MapboxNavigation
     private var mapboxReplayer: MapboxReplayer? = null
     private var locationHistoryListener: (LocationHistoryListener)? = null
-    private val logger = LoggerFactory.getLogger(this::class.simpleName)
+    private val logger = KotlinLogging.logger { }
 
     init {
         val mapboxBuilder = NavigationOptions.Builder(context)
@@ -190,7 +190,7 @@ internal class DefaultMapbox(
 
                     override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {
                         // We won't know the ETA for the active trackable and therefore we won't be able to check the temporal threshold.
-                        logger.error("Failed call to requestRoutes.", throwable)
+                        logger.error(throwable) { "Failed call to requestRoutes." }
                     }
                 }
             )

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -27,7 +27,7 @@ import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 
 typealias LocationHistoryListener = (LocationHistoryData) -> Unit
 
@@ -106,7 +106,7 @@ internal class DefaultMapbox(
     private var mapboxNavigation: MapboxNavigation
     private var mapboxReplayer: MapboxReplayer? = null
     private var locationHistoryListener: (LocationHistoryListener)? = null
-    private val logger = KotlinLogging.logger { }
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     init {
         val mapboxBuilder = NavigationOptions.Builder(context)
@@ -190,7 +190,7 @@ internal class DefaultMapbox(
 
                     override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {
                         // We won't know the ETA for the active trackable and therefore we won't be able to check the temporal threshold.
-                        logger.error(throwable) { "Failed call to requestRoutes." }
+                        logger.error("Failed call to requestRoutes.", throwable)
                     }
                 }
             )

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
@@ -14,11 +14,11 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 
 internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
     LocationEngine {
-    private val logger = KotlinLogging.logger { }
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
     private val gson = Gson()
     private var lastLocationResult: LocationEngineResult? = null
     private val registeredListeners = mutableListOf<LocationEngineCallback<LocationEngineResult>>()
@@ -29,13 +29,13 @@ internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulati
         val ably = AblyRealtime(ablyOptions)
         val simulationChannel = ably.channels.get(simulationTrackingId)
 
-        ably.connection.on { logger.debug { "Ably connection state change: $it" } }
-        simulationChannel.on { logger.debug { "Ably channel state change: $it" } }
+        ably.connection.on { logger.debug("Ably connection state change: $it") }
+        simulationChannel.on { logger.debug("Ably channel state change: $it") }
 
         simulationChannel.subscribe(EventNames.ENHANCED) { message ->
-            logger.debug { "Ably channel message: $message" }
+            logger.debug("Ably channel message: $message")
             message.getGeoJsonMessages(gson).forEach {
-                logger.debug { "Received enhanced location: ${it.synopsis()}" }
+                logger.debug("Received enhanced location: ${it.synopsis()}")
                 val loc = it.toLocation()
                 loc.elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
                 onLocationEngineResult(LocationEngineResult.create(loc))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
@@ -14,11 +14,11 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 
 internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
     LocationEngine {
-    private val logger = LoggerFactory.getLogger(this::class.simpleName)
+    private val logger = KotlinLogging.logger { }
     private val gson = Gson()
     private var lastLocationResult: LocationEngineResult? = null
     private val registeredListeners = mutableListOf<LocationEngineCallback<LocationEngineResult>>()
@@ -29,13 +29,13 @@ internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulati
         val ably = AblyRealtime(ablyOptions)
         val simulationChannel = ably.channels.get(simulationTrackingId)
 
-        ably.connection.on { logger.debug("Ably connection state change: $it") }
-        simulationChannel.on { logger.debug("Ably channel state change: $it") }
+        ably.connection.on { logger.debug { "Ably connection state change: $it" } }
+        simulationChannel.on { logger.debug { "Ably channel state change: $it" } }
 
         simulationChannel.subscribe(EventNames.ENHANCED) { message ->
-            logger.debug("Ably channel message: $message")
+            logger.debug { "Ably channel message: $message" }
             message.getGeoJsonMessages(gson).forEach {
-                logger.debug("Received enhanced location: ${it.synopsis()}")
+                logger.debug { "Received enhanced location: ${it.synopsis()}" }
                 val loc = it.toLocation()
                 loc.elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
                 onLocationEngineResult(LocationEngineResult.create(loc))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
@@ -14,10 +14,11 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 
 internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
     LocationEngine {
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
     private val gson = Gson()
     private var lastLocationResult: LocationEngineResult? = null
     private val registeredListeners = mutableListOf<LocationEngineCallback<LocationEngineResult>>()
@@ -28,13 +29,13 @@ internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulati
         val ably = AblyRealtime(ablyOptions)
         val simulationChannel = ably.channels.get(simulationTrackingId)
 
-        ably.connection.on { Timber.i("Ably connection state change: $it") }
-        simulationChannel.on { Timber.i("Ably channel state change: $it") }
+        ably.connection.on { logger.debug("Ably connection state change: $it") }
+        simulationChannel.on { logger.debug("Ably channel state change: $it") }
 
         simulationChannel.subscribe(EventNames.ENHANCED) { message ->
-            Timber.i("Ably channel message: $message")
+            logger.debug("Ably channel message: $message")
             message.getGeoJsonMessages(gson).forEach {
-                Timber.d("Received enhanced location: ${it.synopsis()}")
+                logger.debug("Received enhanced location: ${it.synopsis()}")
                 val loc = it.toLocation()
                 loc.elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
                 onLocationEngineResult(LocationEngineResult.create(loc))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
@@ -14,14 +14,14 @@ import com.ably.tracking.common.MILLISECONDS_PER_SECOND
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 
 open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngine {
     private val listeners: MutableMap<LocationEngineCallback<LocationEngineResult>, LocationListener> = mutableMapOf()
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     private val DEFAULT_PROVIDER = LocationManager.PASSIVE_PROVIDER
     private var currentProvider = DEFAULT_PROVIDER
-    private val logger = LoggerFactory.getLogger(this::class.simpleName)
+    private val logger = KotlinLogging.logger { }
 
     @SuppressLint("MissingPermission")
     override fun changeResolution(resolution: Resolution) {
@@ -57,7 +57,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         try {
             locationManager.getLastKnownLocation(provider)
         } catch (exception: IllegalArgumentException) {
-            logger.error("Could not get last location for $provider", exception)
+            logger.error(exception) { "Could not get last location for $provider" }
             null
         }
 
@@ -79,7 +79,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                     LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, listener, looper
                 )
             } catch (exception: IllegalArgumentException) {
-                logger.error("Could not request location updates", exception)
+                logger.error(exception) { "Could not request location updates" }
             }
         }
     }
@@ -96,7 +96,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                         LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, pendingIntent
                     )
                 } catch (exception: IllegalArgumentException) {
-                    logger.error("Could not request location updates", exception)
+                    logger.error(exception) { "Could not request location updates" }
                 }
             }
         }
@@ -161,15 +161,15 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         }
 
         override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {
-            logger.debug("onStatusChanged: $provider")
+            logger.debug { "onStatusChanged: $provider" }
         }
 
         override fun onProviderEnabled(provider: String) {
-            logger.debug("onProviderEnabled: $provider")
+            logger.debug { "onProviderEnabled: $provider" }
         }
 
         override fun onProviderDisabled(provider: String) {
-            logger.debug("onProviderDisabled: $provider")
+            logger.debug { "onProviderDisabled: $provider" }
         }
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
@@ -14,14 +14,14 @@ import com.ably.tracking.common.MILLISECONDS_PER_SECOND
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 
 open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngine {
     private val listeners: MutableMap<LocationEngineCallback<LocationEngineResult>, LocationListener> = mutableMapOf()
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     private val DEFAULT_PROVIDER = LocationManager.PASSIVE_PROVIDER
     private var currentProvider = DEFAULT_PROVIDER
-    private val logger = KotlinLogging.logger { }
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     @SuppressLint("MissingPermission")
     override fun changeResolution(resolution: Resolution) {
@@ -57,7 +57,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         try {
             locationManager.getLastKnownLocation(provider)
         } catch (exception: IllegalArgumentException) {
-            logger.error(exception) { "Could not get last location for $provider" }
+            logger.error("Could not get last location for $provider", exception)
             null
         }
 
@@ -79,7 +79,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                     LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, listener, looper
                 )
             } catch (exception: IllegalArgumentException) {
-                logger.error(exception) { "Could not request location updates" }
+                logger.error("Could not request location updates", exception)
             }
         }
     }
@@ -96,7 +96,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                         LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, pendingIntent
                     )
                 } catch (exception: IllegalArgumentException) {
-                    logger.error(exception) { "Could not request location updates" }
+                    logger.error("Could not request location updates", exception)
                 }
             }
         }
@@ -161,15 +161,15 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         }
 
         override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {
-            logger.debug { "onStatusChanged: $provider" }
+            logger.debug("onStatusChanged: $provider")
         }
 
         override fun onProviderEnabled(provider: String) {
-            logger.debug { "onProviderEnabled: $provider" }
+            logger.debug("onProviderEnabled: $provider")
         }
 
         override fun onProviderDisabled(provider: String) {
-            logger.debug { "onProviderDisabled: $provider" }
+            logger.debug("onProviderDisabled: $provider")
         }
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
@@ -14,13 +14,14 @@ import com.ably.tracking.common.MILLISECONDS_PER_SECOND
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 
 open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngine {
     private val listeners: MutableMap<LocationEngineCallback<LocationEngineResult>, LocationListener> = mutableMapOf()
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     private val DEFAULT_PROVIDER = LocationManager.PASSIVE_PROVIDER
     private var currentProvider = DEFAULT_PROVIDER
+    private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
     @SuppressLint("MissingPermission")
     override fun changeResolution(resolution: Resolution) {
@@ -56,7 +57,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         try {
             locationManager.getLastKnownLocation(provider)
         } catch (exception: IllegalArgumentException) {
-            Timber.e(exception)
+            logger.error("Could not get last location for $provider", exception)
             null
         }
 
@@ -78,7 +79,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                     LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, listener, looper
                 )
             } catch (exception: IllegalArgumentException) {
-                Timber.e(exception)
+                logger.error("Could not request location updates", exception)
             }
         }
     }
@@ -95,7 +96,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                         LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, pendingIntent
                     )
                 } catch (exception: IllegalArgumentException) {
-                    Timber.e(exception)
+                    logger.error("Could not request location updates", exception)
                 }
             }
         }
@@ -160,15 +161,15 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         }
 
         override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {
-            Timber.d("onStatusChanged: $provider")
+            logger.debug("onStatusChanged: $provider")
         }
 
         override fun onProviderEnabled(provider: String) {
-            Timber.d("onProviderEnabled: $provider")
+            logger.debug("onProviderEnabled: $provider")
         }
 
         override fun onProviderDisabled(provider: String) {
-            Timber.d("onProviderDisabled: $provider")
+            logger.debug("onProviderDisabled: $provider")
         }
     }
 

--- a/subscribing-example-app/src/main/assets/logback.xml
+++ b/subscribing-example-app/src/main/assets/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="logcat" class="ch.qos.logback.classic.android.LogcatAppender">
+    <tagEncoder>
+      <pattern>%logger{12}</pattern>
+    </tagEncoder>
+    <encoder>
+      <pattern>%msg</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="logcat" />
+  </root>
+</configuration>

--- a/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-example-java-app/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -8,7 +8,6 @@ import com.ably.tracking.connection.TokenRequest;
 import com.ably.tracking.subscriber.Subscriber;
 import com.ably.tracking.subscriber.java.SubscriberFacade;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -6,7 +6,6 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import timber.log.Timber
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -25,8 +24,6 @@ internal class DefaultSubscriber(
         get() = core.trackableStates
 
     init {
-        Timber.w("Started.")
-
         core = createCoreSubscriber(ably, resolution, trackableId)
     }
 


### PR DESCRIPTION
Replaced `Timber` logging library with `slf4j`. The SDKs use only the `slf4j-api` dependency (more precisely they use a Kotlin wrapper of that library) which allows them to use a logger, but the specific implementation must be provided by the SDKs users. If no implementation is provided then a built-in no-op logger is used.
Added a `LogHandler` for the `Ably` that forwards all the log messages to the `slf4j` logger.
Used `logback-android` which is an implementation of `slf4j` in the example apps. Set it so the logs go to the Logcat. Additionally created a sample custom logging handler for the publishing example app.