### PR TITLE
Bring back section about secrets to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ This repository also contains example apps that showcase how the Ably Asset Trac
 
 To build these apps you will need to specify [credentials](#api-keys-and-access-tokens) in Gradle properties.
 
+There are, of course, [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to inject project properties into Gradle builds
+
+## API Keys and Access Tokens
+
+The following secrets need to be injected into Gradle by either storing them in `~/.gradle/gradle.properties`, or by using one of [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to do this:
+
+ - `ABLY_API_KEY`
+ - `MAPBOX_ACCESS_TOKEN`
+ - `GOOGLE_MAPS_API_KEY`
+
 ## Android Runtime Requirements
 
 ### Kotlin Users

--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ This repository also contains example apps that showcase how the Ably Asset Trac
 - the [Asset Publishing example app](publishing-example-app/)
 - the [Asset Subscribing example app](subscribing-example-app/)
 
-To build these apps you will need to specify [credentials](#api-keys-and-access-tokens) in Gradle properties.
-
-## API Keys and Access Tokens
+To build these apps from source you will need to specify credentials in Gradle properties.
 
 The following secrets need to be injected into Gradle by either storing them in `~/.gradle/gradle.properties`, or by using one of [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to do this:
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ This repository also contains example apps that showcase how the Ably Asset Trac
 
 To build these apps you will need to specify [credentials](#api-keys-and-access-tokens) in Gradle properties.
 
-There are, of course, [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to inject project properties into Gradle builds
-
 ## API Keys and Access Tokens
 
 The following secrets need to be injected into Gradle by either storing them in `~/.gradle/gradle.properties`, or by using one of [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to do this:


### PR DESCRIPTION
SDK users who visit it's Github page should see all information that is needed to get started in the README. This includes the instruction on how to configure required secrets.

This was moved to the CONTRIBUTING previously, but this should also be mentioned in the core README as it is needed by SDK users as well, not just contributors.