### PR TITLE
Add simple log handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,6 @@ subprojects {
         dependencies {
             implementation 'androidx.appcompat:appcompat:1.2.0'
             implementation 'com.google.android.material:material:1.2.1'
-            implementation 'com.jakewharton.timber:timber:4.7.1'
 
             if (evaluatedSubProjectIsKotlin) {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -205,6 +204,7 @@ subprojects {
             if (evaluatedSubProjectIsAnApp) {
                 implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
                 implementation 'androidx.multidex:multidex:2.0.1'
+                implementation 'com.jakewharton.timber:timber:4.7.1'
             }
 
             testImplementation 'junit:junit:4.13.1'

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -3,7 +3,9 @@ package com.ably.tracking.common
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.common.logging.d
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 import com.google.gson.Gson
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.Channel
@@ -17,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import timber.log.Timber
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -133,7 +134,8 @@ class DefaultAbly
  * @throws ConnectionException if something goes wrong during Ably SDK initialization.
  */
 constructor(
-    connectionConfiguration: ConnectionConfiguration
+    connectionConfiguration: ConnectionConfiguration,
+    private val logHandler: LogHandler?,
 ) : Ably {
     private val gson = Gson()
     private val ably: AblyRealtime
@@ -243,7 +245,7 @@ constructor(
 
     override fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate) {
         val locationUpdateJson = locationUpdate.toJson(gson)
-        Timber.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
+        logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
         try {
             channels[trackableId]?.publish(EventNames.ENHANCED, locationUpdateJson)
         } catch (exception: AblyException) {

--- a/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
+++ b/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
@@ -1,0 +1,28 @@
+package com.ably.tracking.common.logging
+
+import com.ably.tracking.logging.LogHandler
+import com.ably.tracking.logging.LogLevel
+
+fun LogHandler.v(message: String, throwable: Throwable? = null) {
+    logMessage(LogLevel.VERBOSE, message, throwable)
+}
+
+fun LogHandler.i(message: String, throwable: Throwable? = null) {
+    logMessage(LogLevel.INFO, message, throwable)
+}
+
+fun LogHandler.d(message: String, throwable: Throwable? = null) {
+    logMessage(LogLevel.DEBUG, message, throwable)
+}
+
+fun LogHandler.w(message: String, throwable: Throwable? = null) {
+    logMessage(LogLevel.WARN, message, throwable)
+}
+
+fun LogHandler.e(message: String, throwable: Throwable? = null) {
+    logMessage(LogLevel.ERROR, message, throwable)
+}
+
+fun LogHandler.e(throwable: Throwable) {
+    logMessage(LogLevel.ERROR, "", throwable)
+}

--- a/core-sdk/src/main/java/com/ably/tracking/logging/LoggingConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/logging/LoggingConfigurationModels.kt
@@ -1,0 +1,9 @@
+package com.ably.tracking.logging
+
+interface LogHandler {
+    fun logMessage(level: LogLevel, message: String, throwable: Throwable? = null)
+}
+
+enum class LogLevel(val levelInt: Int) {
+    VERBOSE(1), INFO(2), DEBUG(3), WARN(4), ERROR(5)
+}

--- a/core-sdk/src/main/java/com/ably/tracking/logging/LoggingConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/logging/LoggingConfigurationModels.kt
@@ -1,9 +1,24 @@
 package com.ably.tracking.logging
 
+/**
+ * Simple interface that allows to handle logs sent from the SDK.
+ */
 interface LogHandler {
+    /**
+     * Gets called when a log message is sent from the SDK.
+     * This method is called synchronously and can be called from any thread.
+     * Don't run blocking code in this method as this can cause the SDK to malfunction.
+     *
+     * @param level The importance level of the message.
+     * @param message The message text.
+     * @param throwable Optional error object.
+     */
     fun logMessage(level: LogLevel, message: String, throwable: Throwable? = null)
 }
 
+/**
+ * Defines importance levels for log messages.
+ */
 enum class LogLevel(val levelInt: Int) {
     VERBOSE(1), INFO(2), DEBUG(3), WARN(4), ERROR(5)
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -11,6 +11,8 @@ import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
+import com.ably.tracking.logging.LogLevel
 import com.ably.tracking.publisher.DefaultResolutionPolicyFactory
 import com.ably.tracking.publisher.LocationHistoryData
 import com.ably.tracking.publisher.LocationSource
@@ -22,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 private const val MAPBOX_ACCESS_TOKEN = BuildConfig.MAPBOX_ACCESS_TOKEN
 private const val CLIENT_ID = "<INSERT_CLIENT_ID_HERE>"
@@ -71,6 +74,17 @@ class PublisherService : Service() {
             .resolutionPolicy(DefaultResolutionPolicyFactory(createDefaultResolution(), this))
             .androidContext(this)
             .profile(RoutingProfile.DRIVING)
+            .logHandler(object : LogHandler {
+                override fun logMessage(level: LogLevel, message: String, throwable: Throwable?) {
+                    when (level) {
+                        LogLevel.VERBOSE -> Timber.v(throwable, message)
+                        LogLevel.INFO -> Timber.i(throwable, message)
+                        LogLevel.DEBUG -> Timber.d(throwable, message)
+                        LogLevel.WARN -> Timber.w(throwable, message)
+                        LogLevel.ERROR -> Timber.e(throwable, message)
+                    }
+                }
+            })
             .start().apply {
                 locationHistory
                     .onEach { uploadLocationHistoryData(it) }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -9,6 +9,7 @@ import com.ably.tracking.common.MILLISECONDS_PER_SECOND
 import com.ably.tracking.common.ResultHandler
 import com.ably.tracking.common.clientOptions
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.debug.AblySimulationLocationEngine
 import com.ably.tracking.publisher.locationengine.FusedAndroidLocationEngine
 import com.ably.tracking.publisher.locationengine.GoogleLocationEngine
@@ -100,7 +101,8 @@ internal class DefaultMapbox(
     context: Context,
     private val mapConfiguration: MapConfiguration,
     connectionConfiguration: ConnectionConfiguration,
-    locationSource: LocationSource? = null
+    locationSource: LocationSource? = null,
+    logHandler: LogHandler?,
 ) : Mapbox {
     private val mainDispatcher = Dispatchers.Main.immediate
     private var mapboxNavigation: MapboxNavigation
@@ -110,11 +112,11 @@ internal class DefaultMapbox(
     init {
         val mapboxBuilder = NavigationOptions.Builder(context)
             .accessToken(mapConfiguration.apiKey)
-            .locationEngine(getBestLocationEngine(context))
+            .locationEngine(getBestLocationEngine(context, logHandler))
         locationSource?.let {
             when (it) {
                 is LocationSourceAbly -> {
-                    useAblySimulationLocationEngine(mapboxBuilder, it, connectionConfiguration)
+                    useAblySimulationLocationEngine(mapboxBuilder, it, connectionConfiguration, logHandler)
                 }
                 is LocationSourceRaw -> {
                     useHistoryDataReplayerLocationEngine(mapboxBuilder, it)
@@ -212,22 +214,24 @@ internal class DefaultMapbox(
         }
     }
 
-    private fun getBestLocationEngine(context: Context): ResolutionLocationEngine =
+    private fun getBestLocationEngine(context: Context, logHandler: LogHandler?): ResolutionLocationEngine =
         if (LocationEngineUtils.hasGoogleLocationServices(context)) {
             GoogleLocationEngine(context)
         } else {
-            FusedAndroidLocationEngine(context)
+            FusedAndroidLocationEngine(context, logHandler)
         }
 
     private fun useAblySimulationLocationEngine(
         mapboxBuilder: NavigationOptions.Builder,
         locationSource: LocationSourceAbly,
-        connectionConfiguration: ConnectionConfiguration
+        connectionConfiguration: ConnectionConfiguration,
+        logHandler: LogHandler?
     ) {
         mapboxBuilder.locationEngine(
             AblySimulationLocationEngine(
                 connectionConfiguration.authentication.clientOptions,
-                locationSource.simulationChannelName
+                locationSource.simulationChannelName,
+                logHandler
             )
         )
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
 import kotlinx.coroutines.flow.SharedFlow
@@ -180,6 +181,15 @@ interface Publisher {
          * @return A new instance of the builder with this property changed.
          */
         fun locationSource(locationSource: LocationSource?): Builder
+
+        /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Sets the log handler.
+         *
+         * @param logHandler The class that will handle log messages.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun logHandler(logHandler: LogHandler): Builder
 
         /**
          * Creates a [Publisher] and starts publishing.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -48,7 +48,7 @@ internal data class PublisherBuilder(
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultPublisher(
             DefaultAbly(connectionConfiguration!!, logHandler),
-            DefaultMapbox(androidContext!!, mapConfiguration!!, connectionConfiguration, locationSource),
+            DefaultMapbox(androidContext!!, mapConfiguration!!, connectionConfiguration, locationSource, logHandler),
             resolutionPolicyFactory!!,
             routingProfile,
             DefaultBatteryDataProvider(androidContext)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -47,7 +47,7 @@ internal data class PublisherBuilder(
         }
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultPublisher(
-            DefaultAbly(connectionConfiguration!!),
+            DefaultAbly(connectionConfiguration!!, logHandler),
             DefaultMapbox(androidContext!!, mapConfiguration!!, connectionConfiguration, locationSource),
             resolutionPolicyFactory!!,
             routingProfile,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 
 internal data class PublisherBuilder(
     val connectionConfiguration: ConnectionConfiguration? = null,
@@ -14,6 +15,7 @@ internal data class PublisherBuilder(
     val androidContext: Context? = null,
     val routingProfile: RoutingProfile = RoutingProfile.DRIVING,
     val resolutionPolicyFactory: ResolutionPolicy.Factory? = null,
+    val logHandler: LogHandler? = null,
     val locationSource: LocationSource? = null
 ) : Publisher.Builder {
 
@@ -34,6 +36,9 @@ internal data class PublisherBuilder(
 
     override fun locationSource(locationSource: LocationSource?): Publisher.Builder =
         this.copy(locationSource = locationSource)
+
+    override fun logHandler(logHandler: LogHandler): Publisher.Builder =
+        this.copy(logHandler = logHandler)
 
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/debug/AblySimulationLocationEngine.kt
@@ -5,8 +5,11 @@ import android.os.Looper
 import android.os.SystemClock
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.getGeoJsonMessages
+import com.ably.tracking.common.logging.d
+import com.ably.tracking.common.logging.i
 import com.ably.tracking.common.synopsis
 import com.ably.tracking.common.toLocation
+import com.ably.tracking.logging.LogHandler
 import com.google.gson.Gson
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
@@ -14,9 +17,12 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
-import timber.log.Timber
 
-internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulationTrackingId: String) :
+internal class AblySimulationLocationEngine(
+    ablyOptions: ClientOptions,
+    simulationTrackingId: String,
+    logHandler: LogHandler?
+) :
     LocationEngine {
     private val gson = Gson()
     private var lastLocationResult: LocationEngineResult? = null
@@ -28,13 +34,13 @@ internal class AblySimulationLocationEngine(ablyOptions: ClientOptions, simulati
         val ably = AblyRealtime(ablyOptions)
         val simulationChannel = ably.channels.get(simulationTrackingId)
 
-        ably.connection.on { Timber.i("Ably connection state change: $it") }
-        simulationChannel.on { Timber.i("Ably channel state change: $it") }
+        ably.connection.on { logHandler?.i("Ably connection state change: $it") }
+        simulationChannel.on { logHandler?.i("Ably channel state change: $it") }
 
         simulationChannel.subscribe(EventNames.ENHANCED) { message ->
-            Timber.i("Ably channel message: $message")
+            logHandler?.i("Ably channel message: $message")
             message.getGeoJsonMessages(gson).forEach {
-                Timber.d("Received enhanced location: ${it.synopsis()}")
+                logHandler?.d("Received enhanced location: ${it.synopsis()}")
                 val loc = it.toLocation()
                 loc.elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
                 onLocationEngineResult(LocationEngineResult.create(loc))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/locationengine/FusedAndroidLocationEngine.kt
@@ -11,12 +11,17 @@ import android.os.Bundle
 import android.os.Looper
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.MILLISECONDS_PER_SECOND
+import com.ably.tracking.common.logging.d
+import com.ably.tracking.common.logging.e
+import com.ably.tracking.logging.LogHandler
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
-import timber.log.Timber
 
-open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngine {
+open class FusedAndroidLocationEngine(
+    context: Context,
+    private val logHandler: LogHandler?
+) : ResolutionLocationEngine {
     private val listeners: MutableMap<LocationEngineCallback<LocationEngineResult>, LocationListener> = mutableMapOf()
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     private val DEFAULT_PROVIDER = LocationManager.PASSIVE_PROVIDER
@@ -56,7 +61,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         try {
             locationManager.getLastKnownLocation(provider)
         } catch (exception: IllegalArgumentException) {
-            Timber.e(exception)
+            logHandler?.e(exception)
             null
         }
 
@@ -78,7 +83,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                     LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, listener, looper
                 )
             } catch (exception: IllegalArgumentException) {
-                Timber.e(exception)
+                logHandler?.e(exception)
             }
         }
     }
@@ -95,7 +100,7 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
                         LocationManager.NETWORK_PROVIDER, request.interval, request.displacement, pendingIntent
                     )
                 } catch (exception: IllegalArgumentException) {
-                    Timber.e(exception)
+                    logHandler?.e(exception)
                 }
             }
         }
@@ -160,15 +165,15 @@ open class FusedAndroidLocationEngine(context: Context) : ResolutionLocationEngi
         }
 
         override fun onStatusChanged(provider: String, status: Int, extras: Bundle) {
-            Timber.d("onStatusChanged: $provider")
+            logHandler?.d("onStatusChanged: $provider")
         }
 
         override fun onProviderEnabled(provider: String) {
-            Timber.d("onProviderEnabled: $provider")
+            logHandler?.d("onProviderEnabled: $provider")
         }
 
         override fun onProviderDisabled(provider: String) {
-            Timber.d("onProviderDisabled: $provider")
+            logHandler?.d("onProviderDisabled: $provider")
         }
     }
 

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -16,6 +16,8 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
+import com.ably.tracking.logging.LogLevel
 import com.ably.tracking.subscriber.Subscriber
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -33,6 +35,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 private const val CLIENT_ID = "<INSERT_CLIENT_ID_HERE>"
 private const val ABLY_API_KEY = BuildConfig.ABLY_API_KEY
@@ -117,6 +120,17 @@ class MainActivity : AppCompatActivity() {
                 .connection(ConnectionConfiguration(Authentication.basic(CLIENT_ID, ABLY_API_KEY)))
                 .trackingId(trackableId)
                 .resolution(resolution)
+                .logHandler(object : LogHandler {
+                    override fun logMessage(level: LogLevel, message: String, throwable: Throwable?) {
+                        when (level) {
+                            LogLevel.VERBOSE -> Timber.v(throwable, message)
+                            LogLevel.INFO -> Timber.i(throwable, message)
+                            LogLevel.DEBUG -> Timber.d(throwable, message)
+                            LogLevel.WARN -> Timber.w(throwable, message)
+                            LogLevel.ERROR -> Timber.e(throwable, message)
+                        }
+                    }
+                })
                 .start()
                 .apply {
                     locations

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -6,7 +6,6 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import timber.log.Timber
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -25,8 +24,6 @@ internal class DefaultSubscriber(
         get() = core.trackableStates
 
     init {
-        Timber.w("Started.")
-
         core = createCoreSubscriber(ably, resolution, trackableId)
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -96,6 +97,15 @@ interface Subscriber {
          * @return A new instance of the builder with this property changed.
          */
         fun trackingId(trackingId: String): Builder
+
+        /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Sets the log handler.
+         *
+         * @param logHandler The class that will handle log messages.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun logHandler(logHandler: LogHandler): Builder
 
         /**
          * Creates a [Subscriber] and starts listening for location updates.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -31,7 +31,7 @@ internal data class SubscriberBuilder(
         }
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultSubscriber(
-            DefaultAbly(connectionConfiguration!!),
+            DefaultAbly(connectionConfiguration!!, logHandler),
             resolution,
             trackingId!!
         ).apply {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.subscriber
 
 import com.ably.tracking.BuilderConfigurationIncompleteException
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -8,6 +9,7 @@ import com.ably.tracking.connection.ConnectionConfiguration
 internal data class SubscriberBuilder(
     val connectionConfiguration: ConnectionConfiguration? = null,
     val resolution: Resolution? = null,
+    val logHandler: LogHandler? = null,
     val trackingId: String? = null
 ) : Subscriber.Builder {
 
@@ -19,6 +21,9 @@ internal data class SubscriberBuilder(
 
     override fun trackingId(trackingId: String): Subscriber.Builder =
         this.copy(trackingId = trackingId)
+
+    override fun logHandler(logHandler: LogHandler): Subscriber.Builder =
+        this.copy(logHandler = logHandler)
 
     override suspend fun start(): Subscriber {
         if (isMissingRequiredFields()) {


### PR DESCRIPTION
I've added a very simple `LogHandler` interface that can be used to receive log messages from Asset Tracking SDKs. It is optional to provide an implementation of this interface. If no implementation is provided then no log messages are emitted.