### PR TITLE
Remove battery level from LocationUpdate

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
@@ -43,7 +43,6 @@ fun EnhancedLocationUpdate.toJson(gson: Gson): String =
     gson.toJson(
         EnhancedLocationUpdateMessage(
             location.toGeoJson(),
-            batteryLevel,
             skippedLocations.map { it.toGeoJson() },
             intermediateLocations.map { it.toGeoJson() },
             type.toMessage()
@@ -55,7 +54,6 @@ fun Message.getEnhancedLocationUpdate(gson: Gson): EnhancedLocationUpdate =
         .let { message ->
             EnhancedLocationUpdate(
                 message.location.toLocation(),
-                message.batteryLevel,
                 message.skippedLocations.map { it.toLocation() },
                 message.intermediateLocations.map { it.toLocation() },
                 message.type.toTracking()

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -56,7 +56,6 @@ enum class AccuracyMessage {
 @Shared
 data class EnhancedLocationUpdateMessage(
     val location: GeoJsonMessage,
-    val batteryLevel: Float?,
     val skippedLocations: List<GeoJsonMessage>,
     val intermediateLocations: List<GeoJsonMessage>,
     val type: LocationUpdateTypeMessage

--- a/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
@@ -1,20 +1,19 @@
 package com.ably.tracking
 
-open class LocationUpdate(val location: Location, val batteryLevel: Float?, val skippedLocations: List<Location>) {
+open class LocationUpdate(val location: Location, val skippedLocations: List<Location>) {
     override fun equals(other: Any?): Boolean =
         when (other) {
-            is LocationUpdate -> location == other.location && batteryLevel == other.batteryLevel && skippedLocations == other.skippedLocations
+            is LocationUpdate -> location == other.location && skippedLocations == other.skippedLocations
             else -> false
         }
 }
 
 class EnhancedLocationUpdate(
     location: Location,
-    batteryLevel: Float?,
     skippedLocations: List<Location>,
     val intermediateLocations: List<Location>,
     val type: LocationUpdateType
-) : LocationUpdate(location, batteryLevel, skippedLocations) {
+) : LocationUpdate(location, skippedLocations) {
     override fun equals(other: Any?): Boolean =
         when (other) {
             !super.equals(other) -> false

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -21,7 +21,6 @@ constructor(
     mapbox: Mapbox,
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
-    batteryDataProvider: BatteryDataProvider
 ) :
     Publisher {
     private val core: CorePublisher
@@ -39,7 +38,7 @@ constructor(
         get() = core.locationHistory
 
     init {
-        core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, batteryDataProvider)
+        core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile)
     }
 
     override suspend fun track(trackable: Trackable): StateFlow<TrackableState> {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -46,7 +46,6 @@ internal data class PublisherBuilder(
             DefaultMapbox(androidContext!!, mapConfiguration!!, connectionConfiguration, locationSource),
             resolutionPolicyFactory!!,
             routingProfile,
-            DefaultBatteryDataProvider(androidContext)
         )
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -60,12 +60,10 @@ internal class ConnectionForTrackableCreatedEvent(
 
 internal data class RawLocationChangedEvent(
     val location: Location,
-    val batteryLevel: Float?
 ) : AdhocEvent()
 
 internal data class EnhancedLocationChangedEvent(
     val location: Location,
-    val batteryLevel: Float?,
     val intermediateLocations: List<Location>,
     val type: LocationUpdateType
 ) : AdhocEvent()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -107,11 +107,10 @@ class CorePublisherResolutionTest(
         override fun createResolutionPolicy(hooks: ResolutionPolicy.Hooks, methods: ResolutionPolicy.Methods) =
             resolutionPolicy
     }
-    private val batteryDataProvider = mockk<BatteryDataProvider>(relaxed = true)
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, batteryDataProvider)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING)
 
     @Test
     fun `Should send limited location updates`() {
@@ -140,7 +139,7 @@ class CorePublisherResolutionTest(
     }
 
     private fun createEnhancedLocationChangedEvent(location: Location) =
-        EnhancedLocationChangedEvent(location, null, emptyList(), LocationUpdateType.ACTUAL)
+        EnhancedLocationChangedEvent(location, emptyList(), LocationUpdateType.ACTUAL)
 
     private fun mockAllTrackablesResolution(resolution: Resolution) {
         every { resolutionPolicy.resolve(any<TrackableResolutionRequest>()) } returns resolution

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -20,11 +20,10 @@ class DefaultPublisherTest {
         override fun createResolutionPolicy(hooks: ResolutionPolicy.Hooks, methods: ResolutionPolicy.Methods) =
             resolutionPolicy
     }
-    private val batteryDataProvider = mockk<BatteryDataProvider>(relaxed = true)
 
     @SuppressLint("MissingPermission")
     private val publisher: Publisher =
-        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, batteryDataProvider)
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when adding a trackable with subscribing to presence error`() {


### PR DESCRIPTION
Removed `batteryLevel` from both API's `LocationUpdate` types and JSON messages types.
**WARNING** Merging this PR before making changes in the cocoa SDKs will make the cocoa Subscriber SDK stop working with Android Publisher SDK.