### PR TITLE
Use ScrollView in publisher kotlin app to fix entering tracking ID

### DIFF
--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
+  <LinearLayout
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
   <TextView
     android:id="@+id/screenTitleTextView"
@@ -151,5 +155,6 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
+  </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -1,138 +1,148 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
-  <LinearLayout
-    android:orientation="vertical"
+
+  <ScrollView
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintBottom_toTopOf="@id/addTrackableButton"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="0dp">
 
-  <TextView
-    android:id="@+id/screenTitleTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/big_margin"
-    android:text="@string/add_trackable"
-    android:textColor="@color/black"
-    android:textSize="32sp"
-    android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingBottom="@dimen/medium_margin"
+      android:orientation="vertical">
 
-  <!-- Resolution -->
-  <TextView
-    android:id="@+id/resolutionSectionLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/big_margin"
-    android:text="@string/resolution_section_label"
-    android:textColor="@color/black"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/screenTitleTextView" />
+      <TextView
+        android:id="@+id/screenTitleTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/big_margin"
+        android:text="@string/add_trackable"
+        android:textColor="@color/black"
+        android:textSize="32sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-  <TextView
-    android:id="@+id/accuracyLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/medium_margin"
-    android:text="@string/accuracy_label"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/resolutionSectionLabelTextView" />
+      <!-- Resolution -->
+      <TextView
+        android:id="@+id/resolutionSectionLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/big_margin"
+        android:text="@string/resolution_section_label"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/screenTitleTextView" />
 
-  <androidx.appcompat.widget.AppCompatSpinner
-    android:id="@+id/accuracySpinner"
-    android:layout_width="match_parent"
-    android:layout_height="70dp"
-    android:layout_marginHorizontal="@dimen/medium_margin"
-    app:layout_constraintTop_toBottomOf="@id/accuracyLabelTextView" />
+      <TextView
+        android:id="@+id/accuracyLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/accuracy_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/resolutionSectionLabelTextView" />
 
-  <View
-    android:layout_width="0dp"
-    android:layout_height="1dp"
-    android:layout_marginBottom="6dp"
-    android:background="@color/dark_grey"
-    app:layout_constraintBottom_toBottomOf="@id/accuracySpinner"
-    app:layout_constraintEnd_toEndOf="@id/accuracySpinner"
-    app:layout_constraintStart_toStartOf="@id/accuracySpinner" />
+      <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/accuracySpinner"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_marginHorizontal="@dimen/medium_margin"
+        app:layout_constraintTop_toBottomOf="@id/accuracyLabelTextView" />
 
-  <TextView
-    android:id="@+id/desiredIntervalLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/medium_margin"
-    android:text="@string/desired_interval_label"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/accuracySpinner" />
+      <View
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginBottom="6dp"
+        android:background="@color/dark_grey"
+        app:layout_constraintBottom_toBottomOf="@id/accuracySpinner"
+        app:layout_constraintEnd_toEndOf="@id/accuracySpinner"
+        app:layout_constraintStart_toStartOf="@id/accuracySpinner" />
 
-  <androidx.appcompat.widget.AppCompatEditText
-    android:id="@+id/desiredIntervalEditText"
-    android:layout_width="match_parent"
-    android:layout_height="70dp"
-    android:layout_marginHorizontal="@dimen/medium_margin"
-    android:inputType="number"
-    app:layout_constraintTop_toBottomOf="@id/desiredIntervalLabelTextView"
-    tools:text="1000" />
+      <TextView
+        android:id="@+id/desiredIntervalLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/desired_interval_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/accuracySpinner" />
 
-  <TextView
-    android:id="@+id/minimumDisplacementLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/medium_margin"
-    android:text="@string/minimum_displacement_label"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/desiredIntervalEditText" />
+      <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/desiredIntervalEditText"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_marginHorizontal="@dimen/medium_margin"
+        android:inputType="number"
+        app:layout_constraintTop_toBottomOf="@id/desiredIntervalLabelTextView"
+        tools:text="1000" />
 
-  <androidx.appcompat.widget.AppCompatEditText
-    android:id="@+id/minimumDisplacementEditText"
-    android:layout_width="match_parent"
-    android:layout_height="70dp"
-    android:layout_marginHorizontal="@dimen/medium_margin"
-    android:inputType="numberDecimal"
-    app:layout_constraintTop_toBottomOf="@id/minimumDisplacementLabelTextView"
-    tools:text="1.0" />
+      <TextView
+        android:id="@+id/minimumDisplacementLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/minimum_displacement_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/desiredIntervalEditText" />
 
-  <!-- Trackable -->
-  <TextView
-    android:id="@+id/trackableSectionLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/medium_margin"
-    android:text="@string/trackable_section_label"
-    android:textColor="@color/black"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/minimumDisplacementEditText" />
+      <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/minimumDisplacementEditText"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_marginHorizontal="@dimen/medium_margin"
+        android:inputType="numberDecimal"
+        app:layout_constraintTop_toBottomOf="@id/minimumDisplacementLabelTextView"
+        tools:text="1.0" />
 
-  <TextView
-    android:id="@+id/trackableIdLabelTextView"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/medium_margin"
-    android:layout_marginTop="@dimen/medium_margin"
-    android:text="@string/tracking_id"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/trackableSectionLabelTextView" />
+      <!-- Trackable -->
+      <TextView
+        android:id="@+id/trackableSectionLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/trackable_section_label"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/minimumDisplacementEditText" />
 
-  <androidx.appcompat.widget.AppCompatEditText
-    android:id="@+id/trackableIdEditText"
-    android:layout_width="match_parent"
-    android:layout_height="70dp"
-    android:layout_marginHorizontal="@dimen/medium_margin"
-    android:imeOptions="actionDone"
-    android:inputType="text"
-    app:layout_constraintTop_toBottomOf="@id/trackableIdLabelTextView"
-    tools:text="Here goes test ID" />
+      <TextView
+        android:id="@+id/trackableIdLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/tracking_id"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/trackableSectionLabelTextView" />
+
+      <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/trackableIdEditText"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_marginHorizontal="@dimen/medium_margin"
+        android:imeOptions="actionDone"
+        android:inputType="text"
+        app:layout_constraintTop_toBottomOf="@id/trackableIdLabelTextView"
+        tools:text="Here goes test ID" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 
   <androidx.appcompat.widget.AppCompatButton
     android:id="@+id/addTrackableButton"
@@ -155,6 +165,5 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
-  </LinearLayout>
 
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
On small screens, the Publisher Example App written in Kotlin doesn't allow scrolling, and so entering tracking ID is impossible. The fix is to use scroll view

Left is the original, right has the scroll view.
![Frame 101](https://user-images.githubusercontent.com/24711048/119353175-79d63900-bc9a-11eb-964a-b3e667a3f8ee.png)

