### PR TITLE
Increase the distance value compensation added to mocked locations in tests

### DIFF
--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -208,7 +208,7 @@ class CorePublisherResolutionTest(
         // calculating a point that is distant from the old location by the specified distance
         val newLocationPoint = TurfMeasurement.along(
             movementLine,
-            distanceInMeters + 0.0001, // we're adding a small distance value to compensate the inaccuracy of this method
+            distanceInMeters + 0.01, // we're adding a small distance value to compensate the inaccuracy of this method
             TurfConstants.UNIT_METRES
         )
         return createLocation(newLocationPoint.latitude(), newLocationPoint.longitude(), timestamp)


### PR DESCRIPTION
The tests that create new locations and mock their position were failing from time to time so the distance compensation value has been increased in order to fix it.