### PR TITLE
Fix crash when presence data is missing or in wrong format

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -268,12 +268,26 @@ constructor(
             try {
                 // Emit the current presence messages of the channel
                 channel.presence.get(true).let { messages ->
-                    messages.forEach {
+                    messages.forEach { presenceMessage ->
                         // Each message is launched in a fire-and-forget manner to not block this method on the listener() call
-                        scope.launch { listener(it.toTracking(gson)) }
+                        scope.launch {
+                            val parsedMessage = presenceMessage.toTracking(gson)
+                            if (parsedMessage != null) {
+                                listener(parsedMessage)
+                            } else {
+                                Timber.w("Presence message in wrong format: $presenceMessage")
+                            }
+                        }
                     }
                 }
-                channel.presence.subscribe { listener(it.toTracking(gson)) }
+                channel.presence.subscribe {
+                    val parsedMessage = it.toTracking(gson)
+                    if (parsedMessage != null) {
+                        listener(parsedMessage)
+                    } else {
+                        Timber.w("Presence message in wrong format: $it")
+                    }
+                }
             } catch (exception: AblyException) {
                 throw exception.errorInfo.toTrackingException()
             }

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -275,7 +275,7 @@ constructor(
                             if (parsedMessage != null) {
                                 listener(parsedMessage)
                             } else {
-                                Timber.w("Presence message in wrong format: $presenceMessage")
+                                Timber.w("Presence message in unexpected format: $presenceMessage")
                             }
                         }
                     }
@@ -285,7 +285,7 @@ constructor(
                     if (parsedMessage != null) {
                         listener(parsedMessage)
                     } else {
-                        Timber.w("Presence message in wrong format: $it")
+                        Timber.w("Presence message in unexpected format: $it")
                     }
                 }
             } catch (exception: AblyException) {

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -124,7 +124,6 @@ fun TokenRequest.toAuth(): Auth.TokenRequest =
  */
 fun io.ably.lib.types.PresenceMessage.toTracking(gson: Gson): PresenceMessage? =
     this.getPresenceData(gson)?.let { presenceData ->
-
         PresenceMessage(
             this.action.toTracking(),
             presenceData,

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -120,13 +120,17 @@ fun TokenRequest.toAuth(): Auth.TokenRequest =
 /**
  * Extension converting Ably Realtime presence message to the equivalent [PresenceMessage] API
  * presented to users of the Ably Asset Tracking SDKs.
+ * If presence data is missing or in wrong format it returns null.
  */
-fun io.ably.lib.types.PresenceMessage.toTracking(gson: Gson) =
-    PresenceMessage(
-        this.action.toTracking(),
-        this.getPresenceData(gson),
-        this.clientId
-    )
+fun io.ably.lib.types.PresenceMessage.toTracking(gson: Gson): PresenceMessage? =
+    this.getPresenceData(gson)?.let { presenceData ->
+
+        PresenceMessage(
+            this.action.toTracking(),
+            presenceData,
+            this.clientId
+        )
+    }
 
 fun io.ably.lib.types.PresenceMessage.Action.toTracking(): PresenceAction = when (this) {
     io.ably.lib.types.PresenceMessage.Action.present -> PresenceAction.PRESENT_OR_ENTER

--- a/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
@@ -8,11 +8,17 @@ import com.google.gson.Gson
 import io.ably.lib.types.Message
 import io.ably.lib.types.PresenceMessage
 
-fun PresenceMessage.getPresenceData(gson: Gson): PresenceData =
-    gson.fromJson(data as String, PresenceDataMessage::class.java).toTracking()
+/**
+ * Returns parsed data or null if data is missing or in wrong format.
+ */
+fun PresenceMessage.getPresenceData(gson: Gson): PresenceData? =
+    gson.fromJson(data as? String, PresenceDataMessage::class.java)?.toTracking()
 
-fun PresenceDataMessage.toTracking(): PresenceData =
-    PresenceData(type, resolution?.toTracking())
+/**
+ * Returns parsed data or null if data is in wrong format.
+ */
+fun PresenceDataMessage.toTracking(): PresenceData? =
+    type?.let { PresenceData(it, resolution?.toTracking()) }
 
 fun PresenceData.toMessage(): PresenceDataMessage =
     PresenceDataMessage(type, resolution?.toMessage())

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -26,7 +26,7 @@ enum class PresenceAction {
 data class PresenceData(val type: String, val resolution: Resolution? = null)
 
 @Shared
-data class PresenceDataMessage(val type: String, val resolution: ResolutionMessage? = null)
+data class PresenceDataMessage(val type: String?, val resolution: ResolutionMessage? = null)
 
 @Shared
 data class ResolutionMessage(

--- a/common/src/test/java/com/ably/tracking/common/PresenceDataTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/PresenceDataTests.kt
@@ -1,0 +1,53 @@
+package com.ably.tracking.common
+
+import com.google.gson.Gson
+import io.ably.lib.types.PresenceMessage
+import org.junit.Assert
+import org.junit.Test
+
+class PresenceDataTests {
+    private val gson = Gson()
+    private val clientId = "TEST"
+
+    @Test
+    fun `return null if presence data is null`() {
+        // given
+        val presenceData = null
+        val presenceMessage = PresenceMessage(PresenceMessage.Action.enter, clientId, presenceData)
+
+        // when
+        val parsedMessage = presenceMessage.toTracking(gson)
+
+        // then
+        Assert.assertNull(parsedMessage)
+    }
+
+    @Test
+    fun `return null if presence data is in wrong format`() {
+        // given
+        val presenceData = "{\"wrongField\": \"wrong_value\"}"
+        val presenceMessage = PresenceMessage(PresenceMessage.Action.enter, clientId, presenceData)
+
+        // when
+        val parsedMessage = presenceMessage.toTracking(gson)
+
+        // then
+        Assert.assertNull(parsedMessage)
+    }
+
+    @Test
+    fun `parse presence message if presence data is in correct format`() {
+        // given
+        val presenceData = gson.toJson(PresenceDataMessage("abc", null))
+        val presenceMessage = PresenceMessage(PresenceMessage.Action.enter, clientId, presenceData)
+
+        // when
+        val parsedMessage = presenceMessage.toTracking(gson)
+
+        // then
+        Assert.assertNotNull(parsedMessage)
+        Assert.assertNotNull(parsedMessage?.data)
+        Assert.assertEquals("abc", parsedMessage?.data?.type)
+        Assert.assertEquals(null, parsedMessage?.data?.resolution)
+    }
+}


### PR DESCRIPTION
Hotfix for crashes that occur when the `type` from `PresenceData` is null or the presence data is missing.
In both cases we will just log such presence message and ignore it so the Publisher and Subscriber SDKs won't receive it.