### PR TITLE
Send trip start and trip end events on a meta channel from Publisher SDK

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -132,6 +132,24 @@ interface Ably {
      * @throws ConnectionException if something goes wrong.
      */
     suspend fun close(presenceData: PresenceData)
+
+    /**
+     * Sends trip metadata when the trip starts.
+     *
+     * @param metadata The metadata of a tracked trackable.
+     *
+     * @throws ConnectionException if something goes wrong.
+     */
+    fun sendTripStartMetadata(metadata: TripMetadata)
+
+    /**
+     * Sends trip metadata when the trip ends.
+     *
+     * @param metadata The metadata of a tracked trackable.
+     *
+     * @throws ConnectionException if something goes wrong.
+     */
+    fun sendTripEndMetadata(metadata: TripMetadata)
 }
 
 private const val CHANNEL_NAME_PREFIX = "tracking:"
@@ -362,6 +380,24 @@ constructor(
                 }
             }
             ably.close()
+        }
+    }
+
+    private fun getTripMetadataChannel(): Channel = ably.channels.get(ChannelNames.METADATA_TRIP)
+
+    override fun sendTripStartMetadata(metadata: TripMetadata) {
+        try {
+            getTripMetadataChannel().publish(EventNames.TRIP_START, metadata.toMessageJson(gson))
+        } catch (exception: AblyException) {
+            throw exception.errorInfo.toTrackingException()
+        }
+    }
+
+    override fun sendTripEndMetadata(metadata: TripMetadata) {
+        try {
+            getTripMetadataChannel().publish(EventNames.TRIP_END, metadata.toMessageJson(gson))
+        } catch (exception: AblyException) {
+            throw exception.errorInfo.toTrackingException()
         }
     }
 }

--- a/common/src/main/java/com/ably/tracking/common/Constants.kt
+++ b/common/src/main/java/com/ably/tracking/common/Constants.kt
@@ -6,8 +6,14 @@ const val MILLISECONDS_PER_MINUTE = MILLISECONDS_PER_SECOND * 60
 
 const val METERS_PER_KILOMETER = 1000
 
+object ChannelNames {
+    const val METADATA_TRIP = "[meta]asset-tracking:trip-lifecycle"
+}
+
 object EventNames {
     const val ENHANCED = "enhanced"
+    const val TRIP_START = "trip.start"
+    const val TRIP_END = "trip.end"
 }
 
 object ClientTypes {

--- a/common/src/main/java/com/ably/tracking/common/Constants.kt
+++ b/common/src/main/java/com/ably/tracking/common/Constants.kt
@@ -17,6 +17,13 @@ object ChannelNames {
     const val METADATA_TRIP = "[meta]asset-tracking:trip-lifecycle"
 }
 
+/**
+ * The trip event naming approach (e.g. `trip.start`) is similar to what we use in
+ * lifecycle events on Ably metachannels (see
+ * [Lifecycle Events](https://ably.com/documentation/realtime/metachannels#lifecycle-events)).
+ *
+ * This way we align the metachannel message format.
+ */
 object EventNames {
     const val ENHANCED = "enhanced"
     const val TRIP_START = "trip.start"

--- a/common/src/main/java/com/ably/tracking/common/Constants.kt
+++ b/common/src/main/java/com/ably/tracking/common/Constants.kt
@@ -7,6 +7,13 @@ const val MILLISECONDS_PER_MINUTE = MILLISECONDS_PER_SECOND * 60
 const val METERS_PER_KILOMETER = 1000
 
 object ChannelNames {
+    /**
+     * This is a metachannel, which will be defined across the Ably infrastructure.
+     *
+     * **Note**: Simply using `tracking` as the namespace prefix wouldn't be enough as,
+     * in the wider Ably context, `tracking` can mean many things. Whereas,
+     * `asset-tracking` specifies a product.
+     */
     const val METADATA_TRIP = "[meta]asset-tracking:trip-lifecycle"
 }
 

--- a/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageMappers.kt
@@ -77,3 +77,14 @@ fun LocationUpdateType.toMessage(): LocationUpdateTypeMessage =
         LocationUpdateType.PREDICTED -> LocationUpdateTypeMessage.PREDICTED
         LocationUpdateType.ACTUAL -> LocationUpdateTypeMessage.ACTUAL
     }
+
+fun TripMetadata.toMessageJson(gson: Gson): String = gson.toJson(
+    TripMetadataMessage(
+        trackingId,
+        timestamp,
+        TripDataMessage(
+            originLocation.toGeoJson(),
+            destinationLocation?.toGeoJson()
+        )
+    )
+)

--- a/common/src/main/java/com/ably/tracking/common/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/MessageModels.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.common
 
-import com.ably.tracking.annotations.Shared
 import com.ably.tracking.GeoJsonMessage
 import com.ably.tracking.Resolution
+import com.ably.tracking.annotations.Shared
 import com.google.gson.annotations.SerializedName
 
 object GeoJsonTypes {
@@ -69,3 +69,16 @@ enum class LocationUpdateTypeMessage {
     @SerializedName("ACTUAL")
     ACTUAL,
 }
+
+@Shared
+data class TripMetadataMessage(
+    val trackingId: String,
+    val timestamp: Long,
+    val tripData: TripDataMessage
+)
+
+@Shared
+data class TripDataMessage(
+    val originLocation: GeoJsonMessage,
+    val destinationLocation: GeoJsonMessage?
+)

--- a/common/src/main/java/com/ably/tracking/common/TripMetadata.kt
+++ b/common/src/main/java/com/ably/tracking/common/TripMetadata.kt
@@ -1,0 +1,10 @@
+package com.ably.tracking.common
+
+import com.ably.tracking.Location
+
+data class TripMetadata(
+    val trackingId: String,
+    val timestamp: Long,
+    val originLocation: Location,
+    val destinationLocation: Location?
+)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -377,6 +377,7 @@ constructor(
                         if (state.isTracking) {
                             stopLocationUpdates(state)
                         }
+                        state.trackables.forEach { sendEndTripMetadata(it, state) }
                         try {
                             ably.close(state.presenceData)
                             state.dispose()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -16,6 +16,7 @@ import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceAction
 import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.toAssetTracking
+import com.ably.tracking.logging.LogHandler
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,8 +50,9 @@ internal fun createCorePublisher(
     mapbox: Mapbox,
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
+    logHandler: LogHandler?,
 ): CorePublisher {
-    return DefaultCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile)
+    return DefaultCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, logHandler)
 }
 
 private class DefaultCorePublisher
@@ -60,6 +62,7 @@ constructor(
     private val mapbox: Mapbox,
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
+    private val logHandler: LogHandler?,
 ) : CorePublisher {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val sendEventChannel: SendChannel<Event>

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
+import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.coroutines.resume
@@ -21,6 +22,7 @@ constructor(
     mapbox: Mapbox,
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
+    logHandler: LogHandler?,
 ) :
     Publisher {
     private val core: CorePublisher
@@ -38,7 +40,7 @@ constructor(
         get() = core.locationHistory
 
     init {
-        core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile)
+        core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, logHandler)
     }
 
     override suspend fun track(trackable: Trackable): StateFlow<TrackableState> {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationHelpers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationHelpers.kt
@@ -16,3 +16,6 @@ internal fun Location.distanceInMetersFrom(lat: Double, lng: Double): Double =
     TurfMeasurement.distance(Point.fromLngLat(longitude, latitude), Point.fromLngLat(lng, lat)) * METERS_PER_KILOMETER
 
 internal fun Location.timeFrom(location: Location): Long = abs(time - location.time)
+
+internal fun Destination.toLocation(): Location =
+    Location(latitude, longitude, 0.0, 0f, 0f, 0f, 0)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -51,6 +51,7 @@ internal data class PublisherBuilder(
             DefaultMapbox(androidContext!!, mapConfiguration!!, connectionConfiguration, locationSource, logHandler),
             resolutionPolicyFactory!!,
             routingProfile,
+            logHandler,
         )
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -91,3 +91,11 @@ internal data class ChannelConnectionStateChangeEvent(
     val connectionStateChange: ConnectionStateChange,
     val trackableId: String
 ) : AdhocEvent()
+
+internal data class TripStartedEvent(
+    val trackable: Trackable,
+) : AdhocEvent()
+
+internal data class TripEndedEvent(
+    val trackable: Trackable,
+) : AdhocEvent()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -110,7 +110,7 @@ class CorePublisherResolutionTest(
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
 
     @Test
     fun `Should send limited location updates`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -23,7 +23,7 @@ class DefaultPublisherTest {
 
     @SuppressLint("MissingPermission")
     private val publisher: Publisher =
-        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING)
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when adding a trackable with subscribing to presence error`() {


### PR DESCRIPTION
When a trackable is added we're sending trip start event. When a trackable is removed we're sending trip end event. When the publisher is stopped we're sending end trip events for all trackables in the publisher.

I've changed the approach of postponing operations until a raw location is present. Before we had a static field with a `Destination` that was used to postpone setting the destination until any raw location is received. Now we have a list of commands that are run when a raw location is received. This way it's much more flexible and allows to queue multiple operations that depend on raw location.