### PR TITLE
Update Mapbox to beta.12

### DIFF
--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation 'com.mapbox.navigation:core:2.0.0-beta.4'
+    implementation 'com.mapbox.navigation:core:2.0.0-beta.12'
 
     // Only the Core SDK portion of the MapBox Maps SDK for Android.
     // https://docs.mapbox.com/android/maps/overview/

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -17,7 +17,7 @@ import com.ably.tracking.publisher.locationengine.LocationEngineUtils
 import com.ably.tracking.publisher.locationengine.ResolutionLocationEngine
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
@@ -173,7 +173,7 @@ internal class DefaultMapbox(
         runBlocking(mainDispatcher) {
             mapboxNavigation.requestRoutes(
                 RouteOptions.builder()
-                    .applyDefaultParams()
+                    .applyDefaultNavigationOptions()
                     .accessToken(mapConfiguration.apiKey)
                     .coordinates(getRouteCoordinates(currentLocation, destination))
                     .profile(routingProfile.toMapboxProfileName())


### PR DESCRIPTION
Updated Mapbox to version `beta.12` as the newest one `beta.13` has known issues with location history data which we use for trip history files.