### PR TITLE
Downgrade Mapbox to 1.6.1

### DIFF
--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation 'com.mapbox.navigation:core:2.0.0-beta.12'
+    implementation 'com.mapbox.navigation:core:1.6.1'
 
     // Only the Core SDK portion of the MapBox Maps SDK for Android.
     // https://docs.mapbox.com/android/maps/overview/

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -17,7 +17,7 @@ import com.ably.tracking.publisher.locationengine.LocationEngineUtils
 import com.ably.tracking.publisher.locationengine.ResolutionLocationEngine
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
@@ -110,8 +110,7 @@ internal class DefaultMapbox(
     private var locationHistoryListener: (LocationHistoryListener)? = null
 
     init {
-        val mapboxBuilder = NavigationOptions.Builder(context)
-            .accessToken(mapConfiguration.apiKey)
+        val mapboxBuilder = MapboxNavigation.defaultNavigationOptionsBuilder(context, mapConfiguration.apiKey)
             .locationEngine(getBestLocationEngine(context, logHandler))
         locationSource?.let {
             when (it) {
@@ -173,7 +172,7 @@ internal class DefaultMapbox(
         runBlocking(mainDispatcher) {
             mapboxNavigation.requestRoutes(
                 RouteOptions.builder()
-                    .applyDefaultNavigationOptions()
+                    .applyDefaultParams()
                     .accessToken(mapConfiguration.apiKey)
                     .coordinates(getRouteCoordinates(currentLocation, destination))
                     .profile(routingProfile.toMapboxProfileName())


### PR DESCRIPTION
I've downgraded the Mapbox dependency to `1.6.1` which is the newest version that's still using `Mapbox Core Common` in version `v9.2.0`