### PR TITLE
Update Kotlin to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jlleitschuh.gradle.ktlint' version '9.4.1'
+    id 'org.jlleitschuh.gradle.ktlint' version '10.0.0'
     id 'org.jetbrains.dokka' version '1.4.32'
 }
 
@@ -127,6 +127,7 @@ subprojects {
                               'IconLocation',
                               'StopShip',
                               'DefaultLocale',
+                              'NewApi',
                               'ObsoleteSdkInt'
 
                 // Lint rules which are disabled by default (see: lint --show), but which we would
@@ -172,7 +173,7 @@ subprojects {
 
         // https://github.com/jlleitschuh/ktlint-gradle#configuration
         ktlint {
-            version = '0.39.0' // override because v.9.4.1 of org.jlleitschuh.gradle.ktlint plugin is at 0.38.1 which has issues
+            version = '0.41.0' // override because v.9.4.1 of org.jlleitschuh.gradle.ktlint plugin is at 0.38.1 which has issues
             verbose = true // shows rule name that failed
             android = true
             outputColorName = 'RED' // easier to spot failures in console output

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.10'
 
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -2,7 +2,7 @@ apply plugin: 'jacoco'
 
 jacoco {
     // Gradle 6.7.1 ships with JaCoCo 0.8.5 (October 2019) but we would like to use the more recent version.
-    toolVersion = '0.8.6' // September 2020
+    toolVersion = '0.8.7' // May 2021
 }
 
 tasks.withType(Test) {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -7,7 +7,6 @@ import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import com.ably.tracking.Accuracy
-import java.util.Locale
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +59,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val appPreferences = AppPreferences(requireContext())
         (findPreference(getString(R.string.preferences_resolution_accuracy_key)) as ListPreference?)?.apply {
             entries = Accuracy.values()
-                .map { it.name.toLowerCase(Locale.getDefault()).capitalize(Locale.getDefault()) }
+                .map { accuracy -> accuracy.name.lowercase().replaceFirstChar { it.uppercase() } }
                 .toTypedArray()
             entryValues = Accuracy.values().map { it.name }.toTypedArray()
             value = appPreferences.getResolutionAccuracy().name

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -185,7 +185,7 @@ class MainActivity : AppCompatActivity() {
         }
 
     private fun updateResolutionInfo(resolution: Resolution) {
-        resolutionAccuracyTextView.text = resolution.accuracy.name.toLowerCase().capitalize()
+        resolutionAccuracyTextView.text = resolution.accuracy.name.lowercase().replaceFirstChar { it.uppercase() }
         resolutionDisplacementTextView.text =
             getString(R.string.resolution_minimum_displacement_value, resolution.minimumDisplacement)
         resolutionIntervalTextView.text =


### PR DESCRIPTION
I've updated Kotlin to 1.5.0. This needed some small code changes. After updating I've encountered a weird issue with ktlint and because of that I've added `NewApi`rule to the "information" group to make lint work. I've also created an issue that aims to bring that rule back to the "errors" group https://github.com/ably/ably-asset-tracking-android/issues/371.