### PR TITLE
Send failed location updates

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -66,14 +66,17 @@ interface Ably {
     /**
      * Sends an enhanced location update to the channel.
      * Should be called only when there's an existing channel for the [trackableId].
-     * If a channel for the [trackableId] doesn't exist then nothing happens.
+     * If a channel for the [trackableId] doesn't exist then it just calls [callback] with success.
      *
      * @param trackableId The ID of the trackable channel.
      * @param locationUpdate The location update that is sent to the channel.
-     *
-     * @throws ConnectionException if something goes wrong.
+     * @param callback The function that will be called when sending completes. If something goes wrong it will be called with [ConnectionException].
      */
-    fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate)
+    fun sendEnhancedLocation(
+        trackableId: String,
+        locationUpdate: EnhancedLocationUpdate,
+        callback: (Result<Unit>) -> Unit
+    )
 
     /**
      * Adds a listener for the enhanced location updates that are received from the channel.
@@ -284,13 +287,34 @@ constructor(
         }
     }
 
-    override fun sendEnhancedLocation(trackableId: String, locationUpdate: EnhancedLocationUpdate) {
-        val locationUpdateJson = locationUpdate.toJson(gson)
-        logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
-        try {
-            channels[trackableId]?.publish(EventNames.ENHANCED, locationUpdateJson)
-        } catch (exception: AblyException) {
-            throw exception.errorInfo.toTrackingException()
+    override fun sendEnhancedLocation(
+        trackableId: String,
+        locationUpdate: EnhancedLocationUpdate,
+        callback: (Result<Unit>) -> Unit
+    ) {
+        val trackableChannel = channels[trackableId]
+        if (trackableChannel != null) {
+            val locationUpdateJson = locationUpdate.toJson(gson)
+            logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
+            try {
+                trackableChannel.publish(
+                    EventNames.ENHANCED,
+                    locationUpdateJson,
+                    object : CompletionListener {
+                        override fun onSuccess() {
+                            callback(Result.success(Unit))
+                        }
+
+                        override fun onError(reason: ErrorInfo) {
+                            callback(Result.failure(reason.toTrackingException()))
+                        }
+                    }
+                )
+            } catch (exception: AblyException) {
+                callback(Result.failure(exception.errorInfo.toTrackingException()))
+            }
+        } else {
+            callback(Result.success(Unit))
         }
     }
 

--- a/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
@@ -6,6 +6,12 @@ open class LocationUpdate(val location: Location, val skippedLocations: List<Loc
             is LocationUpdate -> location == other.location && skippedLocations == other.skippedLocations
             else -> false
         }
+
+    override fun hashCode(): Int {
+        var result = location.hashCode()
+        result = 31 * result + skippedLocations.hashCode()
+        return result
+    }
 }
 
 class EnhancedLocationUpdate(
@@ -20,6 +26,13 @@ class EnhancedLocationUpdate(
             is EnhancedLocationUpdate -> intermediateLocations == other.intermediateLocations && type == other.type
             else -> false
         }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + intermediateLocations.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
 }
 
 enum class LocationUpdateType {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -384,6 +384,7 @@ constructor(
                         processNextWaitingEnhancedLocationUpdate(state, event.trackableId)
                     }
                     is SendEnhancedLocationFailureEvent -> {
+                        saveLocationForFurtherSending(state, event.trackableId, event.location)
                         logHandler?.w(
                             "Sending location update failed. Location saved for further sending",
                             event.exception

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -173,34 +173,7 @@ constructor(
                         }
                     }
                     is EnhancedLocationChangedEvent -> {
-                        for (trackable in state.trackables) {
-                            if (shouldSendLocation(
-                                    event.location,
-                                    state.lastSentEnhancedLocations[trackable.id],
-                                    state.resolutions[trackable.id]
-                                )
-                            ) {
-                                try {
-                                    val locationUpdate = EnhancedLocationUpdate(
-                                        event.location,
-                                        state.skippedEnhancedLocations[trackable.id] ?: emptyList(),
-                                        event.intermediateLocations,
-                                        event.type
-                                    )
-                                    ably.sendEnhancedLocation(trackable.id, locationUpdate)
-                                    state.lastSentEnhancedLocations[trackable.id] = locationUpdate.location
-                                    state.skippedEnhancedLocations[trackable.id]?.clear()
-                                    updateTrackableState(state, trackable.id)
-                                } catch (exception: ConnectionException) {
-                                    // TODO - what to do here if sending enhanced location fails?
-                                }
-                            } else {
-                                if (state.skippedEnhancedLocations[trackable.id] == null) {
-                                    state.skippedEnhancedLocations[trackable.id] = mutableListOf()
-                                }
-                                state.skippedEnhancedLocations[trackable.id]!!.add(event.location)
-                            }
-                        }
+                        state.trackables.forEach { processEnhancedLocationUpdate(event, state, it.id) }
                         scope.launch {
                             _locations.emit(
                                 EnhancedLocationUpdate(
@@ -352,7 +325,7 @@ constructor(
                             ?.let { enqueue(ChangeLocationEngineResolutionEvent()) }
                         state.requests.remove(event.trackable.id)
                         state.lastSentEnhancedLocations.remove(event.trackable.id)
-                        state.skippedEnhancedLocations.remove(event.trackable.id)
+                        state.skippedEnhancedLocations.clear(event.trackable.id)
                         // If this was the active Trackable then clear that state and remove destination.
                         if (state.active == event.trackable) {
                             removeCurrentDestination(state)
@@ -403,10 +376,100 @@ constructor(
                     is TripEndedEvent -> {
                         sendEndTripMetadata(event.trackable, state)
                     }
+                    is SendEnhancedLocationSuccessEvent -> {
+                        unmarkMessageAsPending(state, event.trackableId)
+                        state.lastSentEnhancedLocations[event.trackableId] = event.location
+                        state.skippedEnhancedLocations.clear(event.trackableId)
+                        updateTrackableState(state, event.trackableId)
+                        processNextWaitingEnhancedLocationUpdate(state, event.trackableId)
+                    }
+                    is SendEnhancedLocationFailureEvent -> {
+                        logHandler?.w(
+                            "Sending location update failed. Location saved for further sending",
+                            event.exception
+                        )
+                        processNextWaitingEnhancedLocationUpdate(state, event.trackableId)
+                    }
                 }
             }
         }
     }
+
+    private fun processEnhancedLocationUpdate(
+        event: EnhancedLocationChangedEvent,
+        state: State,
+        trackableId: String
+    ) {
+        when {
+            hasPendingMessage(state, trackableId) -> {
+                addEnhancedLocationUpdateToWaiting(event, state, trackableId)
+            }
+            shouldSendLocation(
+                event.location,
+                state.lastSentEnhancedLocations[trackableId],
+                state.resolutions[trackableId]
+            ) -> {
+                sendEnhancedLocationUpdate(event, state, trackableId)
+            }
+            else -> {
+                saveLocationForFurtherSending(state, trackableId, event.location)
+                processNextWaitingEnhancedLocationUpdate(state, trackableId)
+            }
+        }
+    }
+
+    private fun processNextWaitingEnhancedLocationUpdate(state: State, trackableId: String) {
+        state.waitingEnhancedLocationUpdates[trackableId]?.removeFirstOrNull()?.let {
+            processEnhancedLocationUpdate(it, state, trackableId)
+        }
+    }
+
+    private fun addEnhancedLocationUpdateToWaiting(
+        event: EnhancedLocationChangedEvent,
+        state: State,
+        trackableId: String
+    ) {
+        if (state.waitingEnhancedLocationUpdates[trackableId] == null) {
+            state.waitingEnhancedLocationUpdates[trackableId] = mutableListOf()
+        }
+        state.waitingEnhancedLocationUpdates[trackableId]!!.add(event)
+    }
+
+    private fun sendEnhancedLocationUpdate(
+        event: EnhancedLocationChangedEvent,
+        state: State,
+        trackableId: String
+    ) {
+        val locationUpdate = EnhancedLocationUpdate(
+            event.location,
+            state.skippedEnhancedLocations.toList(trackableId),
+            event.intermediateLocations,
+            event.type
+        )
+        markMessageAsPending(state, trackableId)
+        ably.sendEnhancedLocation(trackableId, locationUpdate) {
+            if (it.isSuccess) {
+                enqueue(SendEnhancedLocationSuccessEvent(locationUpdate.location, trackableId))
+            } else {
+                enqueue(SendEnhancedLocationFailureEvent(locationUpdate.location, trackableId, it.exceptionOrNull()))
+            }
+        }
+    }
+
+    private fun saveLocationForFurtherSending(state: State, trackableId: String, location: Location) {
+        state.skippedEnhancedLocations.add(trackableId, location)
+    }
+
+    private fun markMessageAsPending(state: State, trackableId: String) {
+        state.ongoingEnhancedLocationUpdates.add(trackableId)
+    }
+
+    private fun unmarkMessageAsPending(state: State, trackableId: String) {
+        state.ongoingEnhancedLocationUpdates.remove(trackableId)
+    }
+
+    private fun hasPendingMessage(state: State, trackableId: String): Boolean =
+        state.ongoingEnhancedLocationUpdates.contains(trackableId)
 
     private fun sendStartTripMetadata(trackable: Trackable, state: State) {
         val currentLocation = state.lastPublisherLocation
@@ -658,7 +721,7 @@ constructor(
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
         val lastSentEnhancedLocations: MutableMap<String, Location> = mutableMapOf()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
-        val skippedEnhancedLocations: MutableMap<String, MutableList<Location>> = mutableMapOf()
+        val skippedEnhancedLocations: SkippedLocations = SkippedLocations()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
         var estimatedArrivalTimeInMilliseconds: Long? = null
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
@@ -686,6 +749,11 @@ constructor(
             }
         val rawLocationChangedCommands: MutableList<(State) -> Unit> = mutableListOf()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
+        val ongoingEnhancedLocationUpdates: MutableSet<String> = mutableSetOf()
+            get() = if (isDisposed) throw PublisherStateDisposedException() else field
+        val waitingEnhancedLocationUpdates: MutableMap<String, MutableList<EnhancedLocationChangedEvent>> =
+            mutableMapOf()
+            get() = if (isDisposed) throw PublisherStateDisposedException() else field
 
         fun dispose() {
             trackables.clear()
@@ -694,7 +762,7 @@ constructor(
             lastChannelConnectionStateChanges.clear()
             resolutions.clear()
             lastSentEnhancedLocations.clear()
-            skippedEnhancedLocations.clear()
+            skippedEnhancedLocations.clearAll()
             estimatedArrivalTimeInMilliseconds = null
             active = null
             lastPublisherLocation = null
@@ -702,6 +770,8 @@ constructor(
             subscribers.clear()
             requests.clear()
             rawLocationChangedCommands.clear()
+            ongoingEnhancedLocationUpdates.clear()
+            waitingEnhancedLocationUpdates.clear()
             isDisposed = true
         }
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
@@ -1,23 +1,63 @@
 package com.ably.tracking.publisher
 
+/**
+ * Class responsible for managing state connected to location updates that are going to or are being published.
+ */
 internal class LocationsPublishingState {
+    /**
+     * The maximum number of retries after a location update is considered to be failed.
+     */
     private val MAX_RETRY_COUNT = 1
+
+    /**
+     * Stores information about trackables that have currently pending messages.
+     */
     private val pendingMessages: MutableSet<String> = mutableSetOf()
+
+    /**
+     * Stores location updates that are waiting to be processed, for each trackable independently.
+     */
     private val waitingLocationUpdates: MutableMap<String, MutableList<EnhancedLocationChangedEvent>> = mutableMapOf()
+
+    /**
+     * Stores the number of retries of the current location update, for each trackable independently.
+     */
     private val retryCounter: MutableMap<String, Int> = mutableMapOf()
 
+    /**
+     * Marks that the specified trackable has a pending message.
+     *
+     * @param trackableId The ID of the trackable.
+     */
     fun markMessageAsPending(trackableId: String) {
         pendingMessages.add(trackableId)
     }
 
+    /**
+     * Marks that the specified trackable does not have a pending message.
+     *
+     * @param trackableId The ID of the trackable.
+     */
     fun unmarkMessageAsPending(trackableId: String) {
         pendingMessages.remove(trackableId)
         resetRetryCount(trackableId)
     }
 
+    /**
+     * Checks if the specified trackable has a pending message.
+     *
+     * @param trackableId The ID of the trackable.
+     * @return true if trackable has pending message, false otherwise.
+     */
     fun hasPendingMessage(trackableId: String): Boolean =
         pendingMessages.contains(trackableId)
 
+    /**
+     * Adds the event to the waiting list for the specified trackable.
+     *
+     * @param trackableId The ID of the trackable.
+     * @param enhancedLocationChangedEvent The event that will be added to waiting list.
+     */
     fun addToWaiting(trackableId: String, enhancedLocationChangedEvent: EnhancedLocationChangedEvent) {
         if (waitingLocationUpdates[trackableId] == null) {
             waitingLocationUpdates[trackableId] = mutableListOf()
@@ -25,12 +65,29 @@ internal class LocationsPublishingState {
         waitingLocationUpdates[trackableId]!!.add(enhancedLocationChangedEvent)
     }
 
+    /**
+     * Returns the next event that's waiting to be processed.
+     *
+     * @param trackableId The ID of the trackable.
+     * @return The next waiting event or null if no events are waiting.
+     */
     fun getNextWaiting(trackableId: String): EnhancedLocationChangedEvent? =
         waitingLocationUpdates[trackableId]?.removeFirstOrNull()
 
+    /**
+     * Checks if sending of the current location update for the specified trackable should be retried.
+     *
+     * @param trackableId The ID of the trackable.
+     * @return true if should retry publishing, false otherwise.
+     */
     fun shouldRetryPublishing(trackableId: String): Boolean =
         getRetryCount(trackableId) < MAX_RETRY_COUNT
 
+    /**
+     * Increments the retry counter for the current location update for the specified trackable.
+     *
+     * @param trackableId The ID of the trackable.
+     */
     fun incrementRetryCount(trackableId: String) {
         retryCounter[trackableId] = getRetryCount(trackableId) + 1
     }
@@ -42,12 +99,20 @@ internal class LocationsPublishingState {
     private fun getRetryCount(trackableId: String): Int =
         retryCounter[trackableId] ?: 0
 
+    /**
+     * Clears the state for the specified trackable.
+     *
+     * @param trackableId The ID of the trackable.
+     */
     fun clear(trackableId: String) {
         pendingMessages.remove(trackableId)
         waitingLocationUpdates.remove(trackableId)
         retryCounter.remove(trackableId)
     }
 
+    /**
+     * Clears the state for all trackables.
+     */
     fun clearAll() {
         pendingMessages.clear()
         waitingLocationUpdates.clear()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
@@ -1,0 +1,37 @@
+package com.ably.tracking.publisher
+
+internal class LocationsPublishingState {
+    private val pendingMessages: MutableSet<String> = mutableSetOf()
+    private val waitingLocationUpdates: MutableMap<String, MutableList<EnhancedLocationChangedEvent>> = mutableMapOf()
+
+    fun markMessageAsPending(trackableId: String) {
+        pendingMessages.add(trackableId)
+    }
+
+    fun unmarkMessageAsPending(trackableId: String) {
+        pendingMessages.remove(trackableId)
+    }
+
+    fun hasPendingMessage(trackableId: String): Boolean =
+        pendingMessages.contains(trackableId)
+
+    fun addToWaiting(trackableId: String, enhancedLocationChangedEvent: EnhancedLocationChangedEvent) {
+        if (waitingLocationUpdates[trackableId] == null) {
+            waitingLocationUpdates[trackableId] = mutableListOf()
+        }
+        waitingLocationUpdates[trackableId]!!.add(enhancedLocationChangedEvent)
+    }
+
+    fun getNextWaiting(trackableId: String): EnhancedLocationChangedEvent? =
+        waitingLocationUpdates[trackableId]?.removeFirstOrNull()
+
+    fun clear(trackableId: String) {
+        pendingMessages.remove(trackableId)
+        waitingLocationUpdates.remove(trackableId)
+    }
+
+    fun clearAll() {
+        pendingMessages.clear()
+        waitingLocationUpdates.clear()
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
@@ -1,8 +1,10 @@
 package com.ably.tracking.publisher
 
 internal class LocationsPublishingState {
+    private val MAX_RETRY_COUNT = 1
     private val pendingMessages: MutableSet<String> = mutableSetOf()
     private val waitingLocationUpdates: MutableMap<String, MutableList<EnhancedLocationChangedEvent>> = mutableMapOf()
+    private val retryCounter: MutableMap<String, Int> = mutableMapOf()
 
     fun markMessageAsPending(trackableId: String) {
         pendingMessages.add(trackableId)
@@ -10,6 +12,7 @@ internal class LocationsPublishingState {
 
     fun unmarkMessageAsPending(trackableId: String) {
         pendingMessages.remove(trackableId)
+        resetRetryCount(trackableId)
     }
 
     fun hasPendingMessage(trackableId: String): Boolean =
@@ -25,13 +28,29 @@ internal class LocationsPublishingState {
     fun getNextWaiting(trackableId: String): EnhancedLocationChangedEvent? =
         waitingLocationUpdates[trackableId]?.removeFirstOrNull()
 
+    fun shouldRetryPublishing(trackableId: String): Boolean =
+        getRetryCount(trackableId) < MAX_RETRY_COUNT
+
+    fun incrementRetryCount(trackableId: String) {
+        retryCounter[trackableId] = getRetryCount(trackableId) + 1
+    }
+
+    private fun resetRetryCount(trackableId: String) {
+        retryCounter[trackableId] = 0
+    }
+
+    private fun getRetryCount(trackableId: String): Int =
+        retryCounter[trackableId] ?: 0
+
     fun clear(trackableId: String) {
         pendingMessages.remove(trackableId)
         waitingLocationUpdates.remove(trackableId)
+        retryCounter.remove(trackableId)
     }
 
     fun clearAll() {
         pendingMessages.clear()
         waitingLocationUpdates.clear()
+        retryCounter.clear()
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -1,5 +1,6 @@
 package com.ably.tracking.publisher
 
+import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.Location
 import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.TrackableState
@@ -74,7 +75,7 @@ internal data class SendEnhancedLocationSuccessEvent(
 ) : AdhocEvent()
 
 internal data class SendEnhancedLocationFailureEvent(
-    val location: Location,
+    val locationUpdate: EnhancedLocationUpdate,
     val trackableId: String,
     val exception: Throwable?,
 ) : AdhocEvent()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -68,6 +68,17 @@ internal data class EnhancedLocationChangedEvent(
     val type: LocationUpdateType
 ) : AdhocEvent()
 
+internal data class SendEnhancedLocationSuccessEvent(
+    val location: Location,
+    val trackableId: String,
+) : AdhocEvent()
+
+internal data class SendEnhancedLocationFailureEvent(
+    val location: Location,
+    val trackableId: String,
+    val exception: Throwable?,
+) : AdhocEvent()
+
 internal class RefreshResolutionPolicyEvent : AdhocEvent()
 
 internal data class SetDestinationSuccessEvent(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
@@ -1,11 +1,25 @@
 package com.ably.tracking.publisher
 
 import com.ably.tracking.Location
+import com.ably.tracking.LocationUpdate
 
+/**
+ * Class responsible for storing locations for multiple trackables that are then used as the [LocationUpdate.skippedLocations].
+ */
 internal class SkippedLocations {
+    /**
+     * The maximum size for each individual list of skipped locations.
+     */
     private val MAX_SKIPPED_LOCATIONS_SIZE = 60
     private val skippedLocations: MutableMap<String, MutableList<Location>> = mutableMapOf()
 
+    /**
+     * Adds a location to the list of skipped locations for the specified trackable.
+     * If by adding this location the list exceeds its size limit, then the oldest location from the list is removed.
+     *
+     * @param trackableId The ID of the trackable.
+     * @param location The location that will be added to the skipped locations list.
+     */
     fun add(trackableId: String, location: Location) {
         val locations = skippedLocations[trackableId] ?: mutableListOf()
         locations.add(location)
@@ -16,14 +30,29 @@ internal class SkippedLocations {
         skippedLocations[trackableId] = locations
     }
 
+    /**
+     * Returns the skipped locations list sorted by time for the specified trackable.
+     * If no locations are added for a trackable then it returns an empty list.
+     *
+     * @param trackableId The ID of the trackable.
+     * @return Skipped locations list sorted by time or empty list if no locations were added.
+     */
     fun toList(trackableId: String): List<Location> {
         return skippedLocations[trackableId] ?: emptyList()
     }
 
+    /**
+     * Clears the skipped locations list for the specified trackable ID.
+     *
+     * @param trackableId The ID of the trackable.
+     */
     fun clear(trackableId: String) {
         skippedLocations[trackableId]?.clear()
     }
 
+    /**
+     * Clears all skipped locations lists.
+     */
     fun clearAll() {
         skippedLocations.clear()
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
@@ -1,0 +1,30 @@
+package com.ably.tracking.publisher
+
+import com.ably.tracking.Location
+
+internal class SkippedLocations {
+    private val MAX_SKIPPED_LOCATIONS_SIZE = 60
+    private val skippedLocations: MutableMap<String, MutableList<Location>> = mutableMapOf()
+
+    fun add(trackableId: String, location: Location) {
+        val locations = skippedLocations[trackableId] ?: mutableListOf()
+        locations.add(location)
+        locations.sortBy { it.time }
+        if (locations.size > MAX_SKIPPED_LOCATIONS_SIZE) {
+            locations.removeFirst() // remove oldest location
+        }
+        skippedLocations[trackableId] = locations
+    }
+
+    fun toList(trackableId: String): List<Location> {
+        return skippedLocations[trackableId] ?: emptyList()
+    }
+
+    fun clear(trackableId: String) {
+        skippedLocations[trackableId]?.clear()
+    }
+
+    fun clearAll() {
+        skippedLocations.clear()
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -1,0 +1,145 @@
+package com.ably.tracking.publisher
+
+import android.annotation.SuppressLint
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Location
+import com.ably.tracking.LocationUpdateType
+import com.ably.tracking.Resolution
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.test.common.createLocation
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockSendEnhancedLocationFailure
+import com.ably.tracking.test.common.mockSendEnhancedLocationFailureThenSuccess
+import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class CorePublisherLocationUpdatesPublishingTest {
+    private val ably = mockk<Ably>(relaxed = true)
+    private val mapbox = mockk<Mapbox>(relaxed = true)
+    private val resolutionPolicy = mockk<ResolutionPolicy>(relaxed = true)
+    private val resolutionPolicyFactory = object : ResolutionPolicy.Factory {
+        override fun createResolutionPolicy(hooks: ResolutionPolicy.Hooks, methods: ResolutionPolicy.Methods) =
+            resolutionPolicy
+    }
+
+    @SuppressLint("MissingPermission")
+    private val corePublisher: CorePublisher =
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
+
+    @Test
+    fun `Should send a message only once if publishing it succeeds`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+        addTrackable(Trackable(trackableId))
+        ably.mockSendEnhancedLocationSuccess(trackableId)
+
+        // when
+        corePublisher.enqueue(createEnhancedLocationChangedEvent(createLocation()))
+
+        // then
+        runBlocking {
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            stopCorePublisher()
+        }
+        verify(exactly = 1) {
+            ably.sendEnhancedLocation(trackableId, any(), any())
+        }
+    }
+
+    @Test
+    fun `Should try to resend a message if it fails for the first time`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+        addTrackable(Trackable(trackableId))
+        ably.mockSendEnhancedLocationFailureThenSuccess(trackableId)
+
+        // when
+        corePublisher.enqueue(createEnhancedLocationChangedEvent(createLocation()))
+
+        // then
+        runBlocking {
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            stopCorePublisher()
+        }
+        verify(exactly = 2) {
+            ably.sendEnhancedLocation(trackableId, any(), any())
+        }
+    }
+
+    @Test
+    fun `Should not try to resend a message if it fails for the second time`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+        addTrackable(Trackable(trackableId))
+        ably.mockSendEnhancedLocationFailure(trackableId)
+
+        // when
+        corePublisher.enqueue(createEnhancedLocationChangedEvent(createLocation()))
+
+        // then
+        runBlocking {
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            stopCorePublisher()
+        }
+        verify(exactly = 2) {
+            ably.sendEnhancedLocation(trackableId, any(), any())
+        }
+    }
+
+    private fun createEnhancedLocationChangedEvent(location: Location) =
+        EnhancedLocationChangedEvent(location, emptyList(), LocationUpdateType.ACTUAL)
+
+    private fun mockAllTrackablesResolution(resolution: Resolution) {
+        every { resolutionPolicy.resolve(any<TrackableResolutionRequest>()) } returns resolution
+    }
+
+    private fun addTrackable(trackable: Trackable) {
+        ably.mockConnectSuccess(trackable.id)
+        runBlocking(Dispatchers.IO) {
+            addTrackableToCorePublisher(trackable)
+        }
+    }
+
+    private suspend fun addTrackableToCorePublisher(trackable: Trackable): StateFlow<TrackableState> {
+        return suspendCoroutine { continuation ->
+            corePublisher.request(
+                AddTrackableEvent(trackable) {
+                    try {
+                        continuation.resume(it.getOrThrow())
+                    } catch (exception: Exception) {
+                        continuation.resumeWithException(exception)
+                    }
+                }
+            )
+        }
+    }
+
+    private suspend fun stopCorePublisher() {
+        suspendCoroutine<Unit> { continuation ->
+            corePublisher.request(
+                StopEvent {
+                    try {
+                        continuation.resume(it.getOrThrow())
+                    } catch (exception: Exception) {
+                        continuation.resumeWithException(exception)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -9,6 +9,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.createLocation
 import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfConstants
@@ -17,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -120,6 +122,7 @@ class CorePublisherResolutionTest(
         addTrackable(Trackable(trackableId))
         var locationTimestamp = 1000L
         var location: Location? = null
+        ably.mockSendEnhancedLocationSuccess(trackableId)
 
         // when
         repeat(numberOfLocationUpdates) {
@@ -131,10 +134,11 @@ class CorePublisherResolutionTest(
 
         // then
         runBlocking {
+            delay(200) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
             stopCorePublisher()
         }
         verify(exactly = expectedNumberOfSentMessages) {
-            ably.sendEnhancedLocation(trackableId, any())
+            ably.sendEnhancedLocation(trackableId, any(), any())
         }
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -134,7 +134,7 @@ class CorePublisherResolutionTest(
 
         // then
         runBlocking {
-            delay(200) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
             stopCorePublisher()
         }
         verify(exactly = expectedNumberOfSentMessages) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/LocationsPublishingStateTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/LocationsPublishingStateTest.kt
@@ -1,0 +1,210 @@
+package com.ably.tracking.publisher
+
+import com.ably.tracking.LocationUpdateType
+import com.ably.tracking.test.common.createLocation
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class LocationsPublishingStateTest {
+    private val trackableId = "test-trackable-id"
+    private lateinit var locationsPublishingState: LocationsPublishingState
+
+    @Before
+    fun beforeEach() {
+        locationsPublishingState = LocationsPublishingState()
+    }
+
+    @Test
+    fun `Should return false if trackable has not marked any messages`() {
+        // given
+
+        // when
+        val hasPendingMessage = locationsPublishingState.hasPendingMessage(trackableId)
+
+        // then
+        Assert.assertFalse(hasPendingMessage)
+    }
+
+    @Test
+    fun `Should return true if trackable has marked a messages`() {
+        // given
+        locationsPublishingState.markMessageAsPending(trackableId)
+
+        // when
+        val hasPendingMessage = locationsPublishingState.hasPendingMessage(trackableId)
+
+        // then
+        Assert.assertTrue(hasPendingMessage)
+    }
+
+    @Test
+    fun `Should return false if trackable has marked and unmarked a messages`() {
+        // given
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.unmarkMessageAsPending(trackableId)
+
+        // when
+        val hasPendingMessage = locationsPublishingState.hasPendingMessage(trackableId)
+
+        // then
+        Assert.assertFalse(hasPendingMessage)
+    }
+
+    @Test
+    fun `Should return false if trackable has marked multiple times and unmarked a message only once`() {
+        // given
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.unmarkMessageAsPending(trackableId)
+
+        // when
+        val hasPendingMessage = locationsPublishingState.hasPendingMessage(trackableId)
+
+        // then
+        Assert.assertFalse(hasPendingMessage)
+    }
+
+    @Test
+    fun `Should return true if has not retried publishing a message yet`() {
+        // given
+
+        // when
+        val shouldRetryPublishing = locationsPublishingState.shouldRetryPublishing(trackableId)
+
+        // then
+        Assert.assertTrue(shouldRetryPublishing)
+    }
+
+    @Test
+    fun `Should return false if has retried publishing a message once`() {
+        // given
+        locationsPublishingState.incrementRetryCount(trackableId)
+
+        // when
+        val shouldRetryPublishing = locationsPublishingState.shouldRetryPublishing(trackableId)
+
+        // then
+        Assert.assertFalse(shouldRetryPublishing)
+    }
+
+    @Test
+    fun `Should return true if has retried publishing a message once and that message was then unmarked as pending`() {
+        // given
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.incrementRetryCount(trackableId)
+        locationsPublishingState.unmarkMessageAsPending(trackableId)
+
+        // when
+        val shouldRetryPublishing = locationsPublishingState.shouldRetryPublishing(trackableId)
+
+        // then
+        Assert.assertTrue(shouldRetryPublishing)
+    }
+
+    @Test
+    fun `Should return null if no events were added to the waiting list`() {
+        // given
+
+        // when
+        val nextWaitingEvent = locationsPublishingState.getNextWaiting(trackableId)
+
+        // then
+        Assert.assertNull(nextWaitingEvent)
+    }
+
+    @Test
+    fun `Should return events from the waiting list in the order they appeared in it (FIFO)`() {
+        // given
+        locationsPublishingState.addToWaiting(trackableId, createEvent(1))
+        locationsPublishingState.addToWaiting(trackableId, createEvent(2))
+        locationsPublishingState.addToWaiting(trackableId, createEvent(3))
+
+        // when
+        val firstNextWaitingEvent = locationsPublishingState.getNextWaiting(trackableId)
+        val secondNextWaitingEvent = locationsPublishingState.getNextWaiting(trackableId)
+        val thirdNextWaitingEvent = locationsPublishingState.getNextWaiting(trackableId)
+
+        // then
+        Assert.assertEquals(1, firstNextWaitingEvent!!.location.time)
+        Assert.assertEquals(2, secondNextWaitingEvent!!.location.time)
+        Assert.assertEquals(3, thirdNextWaitingEvent!!.location.time)
+    }
+
+    @Test
+    fun `Should return null if has no more waiting events`() {
+        // given
+        locationsPublishingState.addToWaiting(trackableId, createEvent(1))
+        locationsPublishingState.addToWaiting(trackableId, createEvent(2))
+
+        // when
+        locationsPublishingState.getNextWaiting(trackableId)
+        locationsPublishingState.getNextWaiting(trackableId)
+        val nextWaitingEvent = locationsPublishingState.getNextWaiting(trackableId)
+
+        // then
+        Assert.assertNull(nextWaitingEvent)
+    }
+
+    @Test
+    fun `Should clear the state for the specified trackable`() {
+        // given
+        locationsPublishingState.addToWaiting(trackableId, createEvent(1))
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.incrementRetryCount(trackableId)
+
+        // when
+        locationsPublishingState.clear(trackableId)
+
+        // then
+        Assert.assertNull(locationsPublishingState.getNextWaiting(trackableId))
+        Assert.assertFalse(locationsPublishingState.hasPendingMessage(trackableId))
+        Assert.assertTrue(locationsPublishingState.shouldRetryPublishing(trackableId))
+    }
+
+    @Test
+    fun `Should only clear the state for the specified trackable`() {
+        // given
+        val anotherTrackableId = "another-test-trackable-id"
+        locationsPublishingState.addToWaiting(trackableId, createEvent(1))
+        locationsPublishingState.addToWaiting(anotherTrackableId, createEvent(2))
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.markMessageAsPending(anotherTrackableId)
+        locationsPublishingState.incrementRetryCount(trackableId)
+        locationsPublishingState.incrementRetryCount(anotherTrackableId)
+
+        // when
+        locationsPublishingState.clear(trackableId)
+
+        // then
+        Assert.assertNotNull(locationsPublishingState.getNextWaiting(anotherTrackableId))
+        Assert.assertTrue(locationsPublishingState.hasPendingMessage(anotherTrackableId))
+        Assert.assertFalse(locationsPublishingState.shouldRetryPublishing(anotherTrackableId))
+    }
+
+    @Test
+    fun `Should clear the state for all trackables`() {
+        // given
+        val anotherTrackableId = "another-test-trackable-id"
+        locationsPublishingState.addToWaiting(trackableId, createEvent(1))
+        locationsPublishingState.addToWaiting(anotherTrackableId, createEvent(2))
+        locationsPublishingState.markMessageAsPending(trackableId)
+        locationsPublishingState.markMessageAsPending(anotherTrackableId)
+        locationsPublishingState.incrementRetryCount(trackableId)
+        locationsPublishingState.incrementRetryCount(anotherTrackableId)
+
+        // when
+        locationsPublishingState.clearAll()
+
+        // then
+        Assert.assertNull(locationsPublishingState.getNextWaiting(trackableId))
+        Assert.assertFalse(locationsPublishingState.hasPendingMessage(trackableId))
+        Assert.assertTrue(locationsPublishingState.shouldRetryPublishing(trackableId))
+        Assert.assertNull(locationsPublishingState.getNextWaiting(anotherTrackableId))
+        Assert.assertFalse(locationsPublishingState.hasPendingMessage(anotherTrackableId))
+        Assert.assertTrue(locationsPublishingState.shouldRetryPublishing(anotherTrackableId))
+    }
+
+    private fun createEvent(timestamp: Long) =
+        EnhancedLocationChangedEvent(createLocation(timestamp = timestamp), emptyList(), LocationUpdateType.ACTUAL)
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/SkippedLocationsTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/SkippedLocationsTest.kt
@@ -1,0 +1,134 @@
+package com.ably.tracking.publisher
+
+import com.ably.tracking.test.common.createLocation
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class SkippedLocationsTest {
+    private val trackableId = "test-trackable-id"
+    private lateinit var skippedLocations: SkippedLocations
+
+    @Before
+    fun beforeEach() {
+        skippedLocations = SkippedLocations()
+    }
+
+    @Test
+    fun `Should return empty list if no location was added`() {
+        // given
+
+        // when
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+
+        // then
+        Assert.assertTrue(skippedLocationsList.isEmpty())
+    }
+
+    @Test
+    fun `Should return locations sorted by time`() {
+        // given
+        val locations = listOf(
+            createLocation(timestamp = 4),
+            createLocation(timestamp = 1),
+            createLocation(timestamp = 3),
+            createLocation(timestamp = 2)
+        )
+
+        // when
+        locations.forEach {
+            skippedLocations.add(trackableId, it)
+        }
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+
+        // then
+        val skippedLocationsTimestamps = skippedLocationsList.map { it.time }
+        Assert.assertEquals(listOf<Long>(1, 2, 3, 4), skippedLocationsTimestamps)
+    }
+
+    @Test
+    fun `Should keep the list within the maximum size`() {
+        // given
+        val locations = (0..100).map { createLocation(timestamp = it.toLong()) }
+
+        // when
+        locations.forEach {
+            skippedLocations.add(trackableId, it)
+        }
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+
+        // then
+        Assert.assertEquals(60, skippedLocationsList.size)
+    }
+
+    @Test
+    fun `Should remove oldest locations when adding new ones if list limit is exceeded`() {
+        // given
+        val locations = (100 downTo 0).map { createLocation(timestamp = it.toLong()) }
+
+        // when
+        locations.forEach {
+            skippedLocations.add(trackableId, it)
+        }
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+
+        // then
+        val skippedLocationsTimestamps = skippedLocationsList.map { it.time }
+        Assert.assertEquals(41, skippedLocationsTimestamps.first())
+        Assert.assertEquals(100, skippedLocationsTimestamps.last())
+    }
+
+    @Test
+    fun `Should return an empty list if skipped locations were cleared for the trackable ID`() {
+        // given
+        val locations = (0..10).map { createLocation(timestamp = it.toLong()) }
+
+        // when
+        locations.forEach { skippedLocations.add(trackableId, it) }
+        skippedLocations.clear(trackableId)
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+
+        // then
+        Assert.assertTrue(skippedLocationsList.isEmpty())
+    }
+
+    @Test
+    fun `Should return empty lists if skipped locations were cleared for all trackables`() {
+        // given
+        val anotherTrackableId = "some-other-test-trackable-id"
+        val locations = (0..10).map { createLocation(timestamp = it.toLong()) }
+
+        // when
+        locations.forEach {
+            skippedLocations.add(trackableId, it)
+            skippedLocations.add(anotherTrackableId, it)
+        }
+        skippedLocations.clearAll()
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+        val anotherSkippedLocationsList = skippedLocations.toList(anotherTrackableId)
+
+        // then
+        Assert.assertTrue(skippedLocationsList.isEmpty())
+        Assert.assertTrue(anotherSkippedLocationsList.isEmpty())
+    }
+
+    @Test
+    fun `Should clear only skipped location for the specified trackable ID`() {
+        // given
+        val anotherTrackableId = "some-other-test-trackable-id"
+        val locations = (0..10).map { createLocation(timestamp = it.toLong()) }
+
+        // when
+        locations.forEach {
+            skippedLocations.add(trackableId, it)
+            skippedLocations.add(anotherTrackableId, it)
+        }
+        skippedLocations.clear(trackableId)
+        val skippedLocationsList = skippedLocations.toList(trackableId)
+        val anotherSkippedLocationsList = skippedLocations.toList(anotherTrackableId)
+
+        // then
+        Assert.assertTrue(skippedLocationsList.isEmpty())
+        Assert.assertTrue(anotherSkippedLocationsList.isNotEmpty())
+    }
+}

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -36,3 +36,27 @@ fun Ably.mockSendEnhancedLocationSuccess(trackableId: String) {
         callbackSlot.captured(Result.success(Unit))
     }
 }
+
+fun Ably.mockSendEnhancedLocationFailure(trackableId: String) {
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every {
+        sendEnhancedLocation(trackableId, any(), capture(callbackSlot))
+    } answers {
+        callbackSlot.captured(Result.failure(Exception("Test")))
+    }
+}
+
+fun Ably.mockSendEnhancedLocationFailureThenSuccess(trackableId: String) {
+    var hasFailed = false
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every {
+        sendEnhancedLocation(trackableId, any(), capture(callbackSlot))
+    } answers {
+        if (hasFailed) {
+            callbackSlot.captured(Result.success(Unit))
+        } else {
+            hasFailed = true
+            callbackSlot.captured(Result.failure(Exception("Test")))
+        }
+    }
+}

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -27,3 +27,12 @@ fun Ably.mockDisconnectSuccess(trackableId: String) {
         callbackSlot.captured(Result.success(Unit))
     }
 }
+
+fun Ably.mockSendEnhancedLocationSuccess(trackableId: String) {
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every {
+        sendEnhancedLocation(trackableId, any(), capture(callbackSlot))
+    } answers {
+        callbackSlot.captured(Result.success(Unit))
+    }
+}


### PR DESCRIPTION
When sending a location update fails then try to resend it. If it fails again then add the location to the `skippedLocations` list.

In order to implement that we've changed the `channel.publish()` method from a sync version to an async one. Thanks to that we now know when a location is send and if the sending procedure ends with success or failure. 
This has introduced some complexity to the way of handling state connected to published locations. After considering a few different approaches we've decided that we won't send any other messages for a given trackable if it already has a pending message that's being published. We're collecting all location updates that appear during publishing a message in the waiting list. After a pending message is published we're taking the next location update from that waiting list and process it.

This approach has one potential problem: when we're processing next location updates from the waiting list we're not sending them as separate events (as this introduces ordering issues) but rather we're iterating them until we find an location update that can be sent. If such thing is found then the queue is "unblocked" and starts processing other events. In worst case scenario the queue can be "blocked" for as long as it would take to process all the location updates in the waiting list. On the other hand to process them it only needs to compare a few things so this probably won't be a real problem I think :thinking:

When resending the message we're using the idempotent publishing feature of Ably to avoid sending duplicate location updates.