### PR TITLE
Fix overlapping text in subscriber example app

### DIFF
--- a/subscribing-example-app/src/main/res/layout/asset_information_view.xml
+++ b/subscribing-example-app/src/main/res/layout/asset_information_view.xml
@@ -123,7 +123,7 @@
     android:layout_height="wrap_content"
     app:layout_constraintEnd_toEndOf="@id/resolutionAccuracyLabelTextView"
     app:layout_constraintStart_toStartOf="@id/resolutionAccuracyLabelTextView"
-    app:layout_constraintTop_toBottomOf="@id/resolutionAccuracyLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/resolutionDisplacementTextView"
     tools:text="Balanced" />
 
   <TextView
@@ -132,7 +132,7 @@
     android:layout_height="wrap_content"
     app:layout_constraintEnd_toEndOf="@id/resolutionDisplacementLabelTextView"
     app:layout_constraintStart_toStartOf="@id/resolutionDisplacementLabelTextView"
-    app:layout_constraintTop_toTopOf="@id/resolutionAccuracyTextView"
+    app:layout_constraintTop_toBottomOf="@id/resolutionDisplacementLabelTextView"
     tools:text="10.0m" />
 
   <TextView
@@ -141,7 +141,7 @@
     android:layout_height="wrap_content"
     app:layout_constraintEnd_toEndOf="@id/resolutionIntervalLabelTextView"
     app:layout_constraintStart_toStartOf="@id/resolutionIntervalLabelTextView"
-    app:layout_constraintTop_toTopOf="@id/resolutionAccuracyTextView"
+    app:layout_constraintTop_toTopOf="@id/resolutionDisplacementTextView"
     tools:text="100ms" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The resolution values were overlapping their labels. In order to fix it We've aligned those value texts to the one with the longest label ("Min displacement").
![device-2021-06-22-094017](https://user-images.githubusercontent.com/62378170/122884583-98356000-d33e-11eb-899b-c51d408c4302.png)
