### PR TITLE
Beta release - 1.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change log
 
+## [1.0.0-beta.9](https://github.com/ably/ably-asset-tracking-android/tree/v1.0.0-beta.9)
+
+[Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.0.0-beta.8...v1.0.0-beta.9)
+
+**Implemented enhancements:**
+
+- Update ably-android library [\#404](https://github.com/ably/ably-asset-tracking-android/issues/404)
+- App Obfuscation causes invalid keys to be serialised into transmitted JSON [\#396](https://github.com/ably/ably-asset-tracking-android/issues/396)
+
+**Closed issues:**
+
+- Prepare Proguard configuration [\#50](https://github.com/ably/ably-asset-tracking-android/issues/50)
+
+**Merged pull requests:**
+
+- Update Ably SDK to 1.2.7 [\#405](https://github.com/ably/ably-asset-tracking-android/pull/405) ([KacperKluka](https://github.com/KacperKluka))
+- Add proguard configuration [\#399](https://github.com/ably/ably-asset-tracking-android/pull/399) ([KacperKluka](https://github.com/KacperKluka))
+- Explicitly specify DTO field names during serialization [\#398](https://github.com/ably/ably-asset-tracking-android/pull/398) ([KacperKluka](https://github.com/KacperKluka))
+
 ## [1.0.0-beta.8](https://github.com/ably/ably-asset-tracking-android/tree/v1.0.0-beta.8)
 
 [Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.0.0-beta.7...v1.0.0-beta.8)

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 
     // version MUST conform to the Semantic Versioning Specification (https://semver.org/) version 2.0.0
     // on incrementing this value, ensure to also increment versionCode in android defaultConfig (also in this file)
-    version = '1.0.0-beta.8'
+    version = '1.0.0-beta.9'
 
     repositories {
         google()
@@ -82,7 +82,7 @@ subprojects {
                 // projects in this repository. Therefore, this same version number is used for SDK and
                 // example app projects alike.
                 // - versionCode MUST be incremented by 1 for each release from the main branch
-                versionCode 10
+                versionCode 11
                 versionName version
 
                 testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
Addresses obfuscation-related issues reported by a customer who's currently evaluating Ably Asset Tracking.

Also updates the underlying `ably-android` implementation to [the version we released yesterday](https://github.com/ably/ably-java/releases/tag/v1.2.7).