### PR TITLE
Run tests with minification and check if it doesn't affect DTO messages format

### DIFF
--- a/integration-testing-app/build.gradle
+++ b/integration-testing-app/build.gradle
@@ -8,6 +8,13 @@ android {
     defaultConfig {
         applicationId "com.ably.tracking.tests"
     }
+
+    buildTypes {
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {

--- a/integration-testing-app/proguard-rules.pro
+++ b/integration-testing-app/proguard-rules.pro
@@ -1,0 +1,13 @@
+# Integration tests specfic rule
+
+# Because this module only has android test classes the proguard doesn't see any code and when
+# shrinking it removes all possible code. In order to make tests work we're explicitly specifying
+# to keep all classes from AAT and Kotlin standard libs. Even though we're keeping the classes
+# we're still obfuscating them with 'allowobfuscation'.
+-keep,allowobfuscation class com.ably.tracking.** { *; }
+-keep,allowobfuscation class kotlin.** { *; }
+-keep,allowobfuscation class kotlinx.** { *; }
+
+# This is needed for AuthenticationTests.jwtAuthenticationShouldCreateWorkingConnectionBetweenPublisherAndSubscriber()
+# test which needs to create a JWT authentication config.
+-keep,allowobfuscation class io.jsonwebtoken.** { *; }

--- a/integration-testing-app/proguard-rules.pro
+++ b/integration-testing-app/proguard-rules.pro
@@ -11,3 +11,6 @@
 # This is needed for AuthenticationTests.jwtAuthenticationShouldCreateWorkingConnectionBetweenPublisherAndSubscriber()
 # test which needs to create a JWT authentication config.
 -keep,allowobfuscation class io.jsonwebtoken.** { *; }
+
+# This is needed for ObfuscationTest to receive messages from the Ably SDK
+-keep,allowobfuscation class io.ably.** { *; }

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/ObfuscationTest.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/ObfuscationTest.kt
@@ -1,0 +1,94 @@
+package com.ably.tracking.tests
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ably.tracking.publisher.BuildConfig
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.test.android.common.UnitExpectation
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import io.ably.lib.realtime.AblyRealtime
+import io.ably.lib.realtime.ChannelState
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class ObfuscationTest {
+    private val gson = Gson()
+
+    @Test
+    fun messagesFormatShouldNotBeAffectedByObfuscation() {
+        // given
+        var hasNotReceivedLocationUpdate = true
+        val receivedLocationUpdateExpectation = UnitExpectation("received a location update")
+        val ablyConnectionReadyExpectation = UnitExpectation("ably connected")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val trackableId = UUID.randomUUID().toString()
+        var receivedEnhancedMessageJson: JsonObject? = null
+
+        // create Ably connection
+        val ably = AblyRealtime(BuildConfig.ABLY_API_KEY)
+        val channel = ably.channels.get("tracking:$trackableId")
+
+        // listen for location updates
+        channel.subscribe("enhanced") {
+            // UnitExpectation throws an error if it's fulfilled more than once so we need to have this check
+            if (hasNotReceivedLocationUpdate) {
+                hasNotReceivedLocationUpdate = false
+                val dataString = it.data as String
+                receivedEnhancedMessageJson = gson.fromJson(dataString, JsonObject::class.java)
+                receivedLocationUpdateExpectation.fulfill()
+            }
+        }
+
+        // await for Ably connection to be ready to receive location updates
+        channel.on(ChannelState.attached) {
+            ablyConnectionReadyExpectation.fulfill()
+        }
+        ablyConnectionReadyExpectation.await()
+
+        // create publisher
+        val publisher = createAndStartPublisher(context)
+
+        // start publishing location updates
+        runBlocking {
+            publisher.track(Trackable(trackableId))
+        }
+
+        // await for at least one received location update
+        receivedLocationUpdateExpectation.await()
+
+        // cleanup
+        runBlocking {
+            publisher.stop()
+        }
+        ably.close()
+
+        // then
+        receivedLocationUpdateExpectation.assertFulfilled()
+        ablyConnectionReadyExpectation.assertFulfilled()
+        assertNotNull(receivedEnhancedMessageJson)
+        receivedEnhancedMessageJson?.let { messageJson ->
+            assertTrue(messageJson.has("location"))
+            assertTrue(messageJson.has("skippedLocations"))
+            assertTrue(messageJson.has("intermediateLocations"))
+            assertTrue(messageJson.has("type"))
+            val locationJson = messageJson.get("location").asJsonObject
+            assertTrue(locationJson.has("type"))
+            assertTrue(locationJson.has("geometry"))
+            assertTrue(locationJson.has("properties"))
+            val geometryJson = locationJson.get("geometry").asJsonObject
+            assertTrue(geometryJson.has("type"))
+            assertTrue(geometryJson.has("coordinates"))
+            val propertiesJson = locationJson.get("properties").asJsonObject
+            assertTrue(propertiesJson.has("accuracyHorizontal"))
+            assertTrue(propertiesJson.has("bearing"))
+            assertTrue(propertiesJson.has("speed"))
+            assertTrue(propertiesJson.has("time"))
+        }
+    }
+}


### PR DESCRIPTION
Enabled minification for integration tests module. Added test that checks if obfuscation affects DTO messages format (i.e. the EnhancedLocationMessage).

I've tried to minify integration tests in `publishing-sdk` but for some reason it doesn't work. I guess that's because this module is an Android library and not an Android app.