### PR TITLE
Report AAT version through Ably Agent Header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,10 +152,20 @@ subprojects {
                 buildType.buildConfigField 'String', 'MAPBOX_ACCESS_TOKEN', "\"${property('MAPBOX_ACCESS_TOKEN')}\""
             }
 
+            def applyVersionBuildConfigFields = { buildType ->
+                // Android library modules don't have access to both versionName and versionCode fields
+                // so we're adding them by ourselves.
+                // TODO drop buildType param by using closure delegate, which might be cleaner, or find alternative
+                // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/VariantDimension#buildConfigField(kotlin.String,%20kotlin.String,%20kotlin.String)
+                buildType.buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
+                buildType.buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
+            }
+
             // https://developer.android.com/studio/build/build-variants#build-types
             buildTypes {
                 debug {
                     applySecretBuildConfigFields delegate
+                    applyVersionBuildConfigFields delegate
                 }
 
                 release {
@@ -164,6 +174,9 @@ subprojects {
                     // variant/buildType.
                     if (evaluatedSubProjectIsAnApp) {
                         applySecretBuildConfigFields delegate
+                    }
+                    if (evaluatedSubProjectIsALibrary) {
+                        applyVersionBuildConfigFields delegate
                     }
 
                     minifyEnabled false

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -161,6 +161,7 @@ interface Ably {
 }
 
 private const val CHANNEL_NAME_PREFIX = "tracking:"
+private const val AGENT_HEADER_NAME = "ably-asset-tracking-android"
 
 class DefaultAbly
 /**
@@ -178,6 +179,7 @@ constructor(
     init {
         try {
             val clientOptions = connectionConfiguration.authentication.clientOptions.apply {
+                this.agents = mapOf(AGENT_HEADER_NAME to BuildConfig.VERSION_NAME)
                 this.idempotentRestPublishing = true
                 this.logLevel = Log.VERBOSE
                 this.logHandler = Log.LogHandler { severity, tag, msg, tr -> logMessage(severity, tag, msg, tr) }


### PR DESCRIPTION
Used the agent header from Ably SDK to report AAT version.

Had to manually add version fields to build config as they're not available in android library modules.