### PR TITLE
Use channel modes to avoid unnecessary channel attachements

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -20,6 +20,7 @@ import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.AblyException
+import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Message
@@ -102,12 +103,16 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
      * @param useRewind If set to true then after connecting the channel will replay the last event that was sent in it.
+     * @param willPublish If set to true then the connection will allow sending data.
+     * @param willSubscribe If set to true then the connection will allow listening for data.
      * @param callback The function that will be called when connecting completes. If something goes wrong it will be called with [ConnectionException].
      */
     fun connect(
         trackableId: String,
         presenceData: PresenceData,
         useRewind: Boolean = false,
+        willPublish: Boolean = false,
+        willSubscribe: Boolean = false,
         callback: (Result<Unit>) -> Unit
     )
 
@@ -218,14 +223,26 @@ constructor(
         trackableId: String,
         presenceData: PresenceData,
         useRewind: Boolean,
+        willPublish: Boolean,
+        willSubscribe: Boolean,
         callback: (Result<Unit>) -> Unit
     ) {
         if (!channels.contains(trackableId)) {
             val channelName = "$CHANNEL_NAME_PREFIX$trackableId"
+            val channelOptions = ChannelOptions().apply {
+                val modesList = mutableListOf(ChannelMode.presence, ChannelMode.presence_subscribe)
+                if (willPublish) {
+                    modesList.add(ChannelMode.publish)
+                }
+                if (willSubscribe) {
+                    modesList.add(ChannelMode.subscribe)
+                }
+                modes = modesList.toTypedArray()
+            }
             val channel = if (useRewind)
-                ably.channels.get(channelName, ChannelOptions().apply { params = mapOf("rewind" to "1") })
+                ably.channels.get(channelName, channelOptions.apply { params = mapOf("rewind" to "1") })
             else
-                ably.channels.get(channelName)
+                ably.channels.get(channelName, channelOptions)
             channel.apply {
                 try {
                     presence.enter(

--- a/integration-testing-app/build.gradle
+++ b/integration-testing-app/build.gradle
@@ -23,4 +23,5 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "io.ably:ably-android:$ably_core_version"
     implementation 'io.jsonwebtoken:jjwt:0.7.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
 }

--- a/integration-testing-app/proguard-rules.pro
+++ b/integration-testing-app/proguard-rules.pro
@@ -14,3 +14,6 @@
 
 # This is needed for ObfuscationTest to receive messages from the Ably SDK
 -keep,allowobfuscation class io.ably.** { *; }
+
+# This is needed for ChannelModesTest to make HTTP request to Ably REST API
+-keep,allowobfuscation class okhttp3.** { *; }

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/ChannelModesTest.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/ChannelModesTest.kt
@@ -1,0 +1,101 @@
+package com.ably.tracking.tests
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.subscriber.Subscriber
+import com.ably.tracking.test.android.common.UnitExpectation
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class ChannelModesTest {
+    @Test
+    fun shouldCreateOnlyOnePublisherAndOneSubscriberConnection() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+
+        // when
+        testConnectionBetweenPublisherAndSubscriber(trackableId)
+        val metricsJson = getChannelMetricsJson(trackableId)
+
+        // then
+        Assert.assertEquals(1, metricsJson.get("publishers").asInt)
+        Assert.assertEquals(1, metricsJson.get("subscribers").asInt)
+    }
+
+    private fun getChannelMetricsJson(trackableId: String): JsonObject {
+        val httpClient = OkHttpClient()
+        val ablyKeyParts = ABLY_API_KEY.split(":")
+        val request = Request.Builder()
+            .url("https://rest.ably.io/channels/tracking:$trackableId")
+            .header("Authorization", Credentials.basic(ablyKeyParts.first(), ablyKeyParts.last()))
+            .build()
+        val response = httpClient.newCall(request).execute()
+        val responseBodyJson = Gson().fromJson(response.body!!.string(), JsonObject::class.java)
+        return responseBodyJson.getAsJsonObject("status")
+            .getAsJsonObject("occupancy")
+            .getAsJsonObject("metrics")
+    }
+
+    private fun testConnectionBetweenPublisherAndSubscriber(trackableId: String) {
+        // given
+        var hasNotReceivedLocationUpdate = true
+        val subscriberReceivedLocationUpdateExpectation = UnitExpectation("subscriber received a location update")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(Dispatchers.Default)
+
+        // when
+        // create subscriber and publisher
+        var subscriber: Subscriber
+        runBlocking {
+            subscriber = createAndStartSubscriber(trackableId)
+        }
+
+        val publisher = createAndStartPublisher(context)
+
+        // listen for location updates
+        subscriber.locations
+            .onEach {
+                // UnitExpectation throws an error if it's fulfilled more than once so we need to have this check
+                if (hasNotReceivedLocationUpdate) {
+                    hasNotReceivedLocationUpdate = false
+                    subscriberReceivedLocationUpdateExpectation.fulfill()
+                }
+            }
+            .launchIn(scope)
+
+        // start publishing location updates
+        runBlocking {
+            publisher.track(Trackable(trackableId))
+        }
+
+        // await for at least one received location update
+        subscriberReceivedLocationUpdateExpectation.await()
+
+        // cleanup
+        runBlocking {
+            coroutineScope {
+                launch { publisher.stop() }
+                launch { subscriber.stop() }
+            }
+        }
+
+        // then
+        subscriberReceivedLocationUpdateExpectation.assertFulfilled()
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -212,7 +212,7 @@ constructor(
                         event.handler(Result.success(Unit))
                     }
                     is AddTrackableEvent -> {
-                        ably.connect(event.trackable.id, state.presenceData) { result ->
+                        ably.connect(event.trackable.id, state.presenceData, willPublish = true) { result ->
                             try {
                                 result.getOrThrow()
                                 try {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -100,7 +100,7 @@ private class DefaultCoreSubscriber(
                 when (event) {
                     is StartEvent -> {
                         updateTrackableState(state)
-                        ably.connect(trackableId, state.presenceData, useRewind = true) {
+                        ably.connect(trackableId, state.presenceData, useRewind = true, willSubscribe = true) {
                             if (it.isSuccess) {
                                 subscribeForEnhancedEvents()
                                 try {

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -9,7 +9,7 @@ import io.mockk.slot
 fun Ably.mockConnectSuccess(trackableId: String) {
     val callbackSlot = slot<(Result<Unit>) -> Unit>()
     every {
-        connect(trackableId, any(), any(), capture(callbackSlot))
+        connect(trackableId, any(), any(), any(), any(), capture(callbackSlot))
     } answers {
         callbackSlot.captured(Result.success(Unit))
     }


### PR DESCRIPTION
I've created a test that queries the metadata of a channel to see how many attached publishers and subscribers there are. Then to fix the issue I've specified the modes of channels to avoid those unnecessary attachments.