### PR TITLE
Use real world timestamps for enhanced location updates

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/LocationMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/LocationMappers.kt
@@ -2,5 +2,5 @@ package com.ably.tracking.common
 
 import com.ably.tracking.Location
 
-fun android.location.Location.toAssetTracking(): Location =
-    Location(latitude, longitude, altitude, accuracy, bearing, speed, time)
+fun android.location.Location.toAssetTracking(timestamp: Long = time): Location =
+    Location(latitude, longitude, altitude, accuracy, bearing, speed, timestamp)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -198,9 +198,15 @@ internal class DefaultMapbox(
                 val intermediateLocations =
                     if (keyPoints.size > 1) keyPoints.subList(0, keyPoints.size - 1)
                     else emptyList()
+                val currentTimeInMilliseconds = System.currentTimeMillis()
                 locationUpdatesObserver.onEnhancedLocationChanged(
-                    enhancedLocation.toAssetTracking(),
-                    intermediateLocations.map { it.toAssetTracking() }
+                    // Enhanced locations don't have real world timestamps so we use the current device time
+                    enhancedLocation.toAssetTracking(currentTimeInMilliseconds),
+                    // Intermediate locations should have timestamps in relation to the enhanced location time
+                    intermediateLocations.map { location ->
+                        val timeDifference = enhancedLocation.time - location.time
+                        location.toAssetTracking(currentTimeInMilliseconds - timeDifference)
+                    }
                 )
             }
         }


### PR DESCRIPTION
We have to manually set the timestamps of the enhanced location updates since the ones that come from Mapbox are not real world timestamps.
I also noticed that our Mapbox wrapper exposes a Mapbox-specific interface to our `CorePublisher` so I've refactored the code to remove that coupling https://github.com/ably/ably-asset-tracking-android/commit/3538885af02c36e73383090943c4c7ed86f77a9b
After that was done I added code that sets the timestamps of enhanced location updates to the current device time. The `intermediateLocations` timestamps are calculated in relation to the `enhancedLocation` https://github.com/ably/ably-asset-tracking-android/commit/75132c6007a31cd9d0e20d96d176a6bc54ae1d6a