### PR TITLE
Run integration testing workflow on multiple API levels

### DIFF
--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   check:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [24, 27, 29]
     steps:
       - uses: actions/checkout@v2
 
@@ -18,7 +21,7 @@ jobs:
 
       - uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 24
+          api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck
         env:
           ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/NotificationHelpers.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/NotificationHelpers.kt
@@ -8,6 +8,9 @@ import android.os.Build
 const val NOTIFICATION_CHANNEL_ID = "test-notification-channel"
 
 fun createNotificationChannel(context: Context) {
+    // This guard is required by the official Android documentation as the notification
+    // channels API is not available in the support library.
+    // https://developer.android.com/training/notify-user/channels#CreateChannel
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         context.getSystemService(NotificationManager::class.java).apply {
             createNotificationChannel(

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/NotificationHelpers.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/NotificationHelpers.kt
@@ -1,0 +1,22 @@
+package com.ably.tracking.test.android.common
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+
+const val NOTIFICATION_CHANNEL_ID = "test-notification-channel"
+
+fun createNotificationChannel(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        context.getSystemService(NotificationManager::class.java).apply {
+            createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Publisher Service Channel",
+                    NotificationManager.IMPORTANCE_LOW
+                )
+            )
+        }
+    }
+}

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
@@ -16,6 +16,8 @@ import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.PublisherNotificationProvider
 import com.ably.tracking.publisher.RoutingProfile
 import com.ably.tracking.subscriber.Subscriber
+import com.ably.tracking.test.android.common.NOTIFICATION_CHANNEL_ID
+import com.ably.tracking.test.android.common.createNotificationChannel
 import com.google.gson.Gson
 
 private const val MAPBOX_ACCESS_TOKEN = BuildConfig.MAPBOX_ACCESS_TOKEN
@@ -31,8 +33,9 @@ fun createAndStartPublisher(
     authentication: Authentication = defaultConnectionConfiguration,
     locationData: LocationHistoryData = getLocationData(context),
     onLocationDataEnded: () -> Unit = {}
-) =
-    Publisher.publishers()
+): Publisher {
+    createNotificationChannel(context)
+    return Publisher.publishers()
         .androidContext(context)
         .connection(ConnectionConfiguration(authentication))
         .map(MapConfiguration(MAPBOX_ACCESS_TOKEN))
@@ -42,7 +45,7 @@ fun createAndStartPublisher(
         .backgroundTrackingNotificationProvider(
             object : PublisherNotificationProvider {
                 override fun getNotification(): Notification =
-                    NotificationCompat.Builder(context, "test-channel")
+                    NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                         .setContentTitle("Title")
                         .setContentText("Text")
                         .setSmallIcon(R.drawable.aat_logo)
@@ -51,6 +54,7 @@ fun createAndStartPublisher(
             1234
         )
         .start()
+}
 
 suspend fun createAndStartSubscriber(
     trackingId: String,

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
@@ -11,7 +11,9 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.test.android.common.BooleanExpectation
+import com.ably.tracking.test.android.common.NOTIFICATION_CHANNEL_ID
 import com.ably.tracking.test.android.common.UnitExpectation
+import com.ably.tracking.test.android.common.createNotificationChannel
 import com.ably.tracking.test.android.common.testLogD
 import com.google.gson.Gson
 import kotlinx.coroutines.runBlocking
@@ -36,6 +38,7 @@ class PublisherIntegrationTests {
         val trackExpectation = BooleanExpectation("track response")
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val locationData = getLocationData(context)
+        createNotificationChannel(context)
 
         // when
         testLogD("WHEN")
@@ -102,7 +105,7 @@ class PublisherIntegrationTests {
             .backgroundTrackingNotificationProvider(
                 object : PublisherNotificationProvider {
                     override fun getNotification(): Notification =
-                        NotificationCompat.Builder(context, "test-channel")
+                        NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                             .setContentTitle("TEST")
                             .setContentText("Test")
                             .setSmallIcon(R.drawable.aat_logo)


### PR DESCRIPTION
Used the Github Actions matrix strategy to run the `emulate` workflow on multiple API levels.