### PR TITLE
Start replaying recorded trip when the trip is started

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -179,11 +179,13 @@ internal class DefaultMapbox(
                 toggleHistory(true)
                 startTripSession()
             }
+            mapboxReplayer?.play()
         }
     }
 
     override fun stopAndClose() {
         runBlocking(mainDispatcher) {
+            mapboxReplayer?.stop()
             mapboxNavigation.apply {
                 stopTripSession()
                 mapboxReplayer?.finish()
@@ -319,7 +321,6 @@ internal class DefaultMapbox(
             val historyEvents = locationSource.historyData.events.toReplayEvents()
             val lastHistoryEvent = historyEvents.last()
             this.pushEvents(historyEvents)
-            this.play()
             this.registerObserver(object : ReplayEventsObserver {
                 override fun replayEvents(events: List<ReplayEventBase>) {
                     if (events.last() == lastHistoryEvent) {


### PR DESCRIPTION
Often the integration tests fail on a condition that "subscriber hasn't received any location update". This may happen due to a bad network connection. But another cause could be the fact that in the Publisher we were immediately starting the location playback when the Publisher was created. Now the locations playback will start when the first trackable is added which should result in more location updates to send and hopefully some of them will reach the subscriber.