### PR TITLE
Update ktlint and bring back NewApi rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jlleitschuh.gradle.ktlint' version '10.0.0'
+    id 'org.jlleitschuh.gradle.ktlint' version '10.1.0'
     id 'org.jetbrains.dokka' version '1.4.32'
 }
 
@@ -127,7 +127,6 @@ subprojects {
                               'IconLocation',
                               'StopShip',
                               'DefaultLocale',
-                              'NewApi',
                               'ObsoleteSdkInt'
 
                 // Lint rules which are disabled by default (see: lint --show), but which we would


### PR DESCRIPTION
The `NewApi` rule was added to the ignored ones because it was wrongly reporting errors about `forEach` function in Kotlin. I have thought that it was a bug in the `ktlint` but it turns out that might not be true. After a recent upgrade of gradle in our project and without changing the version of `ktlint` the rule started to work once again. So perhaps it was some mismatch between `ktlint` and the previous gradle version :man_shrugging:
I've also updated the `ktilnt` as there's a new minor version :wink: