### PR TITLE
Change the way of setting build config fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,30 +142,34 @@ subprojects {
                       'UnusedIds'
             }
 
-            def applySecretBuildConfigFields = { buildType ->
-                // Configuration that must not be applied to SDK project main source set builds for the release variant/buildType.
-                // This configuration is, however, required for Android's connectedCheck task (which uses the androidTest source set
-                // with the debug variant/buildType).
-                // TODO drop buildType param by using closure delegate, which might be cleaner, or find alternative
-                // https://github.com/ably/ably-asset-tracking-android/issues/411
-                buildType.buildConfigField 'String', 'ABLY_API_KEY', "\"${property('ABLY_API_KEY')}\""
-                buildType.buildConfigField 'String', 'MAPBOX_ACCESS_TOKEN', "\"${property('MAPBOX_ACCESS_TOKEN')}\""
-            }
-
-            def applyVersionBuildConfigFields = { buildType ->
-                // Android library modules don't have access to both versionName and versionCode fields
-                // so we're adding them by ourselves.
-                // TODO drop buildType param by using closure delegate, which might be cleaner, or find alternative
-                // https://github.com/ably/ably-asset-tracking-android/issues/411
-                buildType.buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
-                buildType.buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
-            }
-
             // https://developer.android.com/studio/build/build-variants#build-types
             buildTypes {
+                // Helper function allowing to create our custom DSL and hide setting the delegate
+                def apply = { action ->
+                    [on: { delegateObject ->
+                        action.delegate = delegateObject
+                        action()
+                    }]
+                }
+
+                def secretConfigFields = {
+                    // Configuration that must not be applied to SDK project main source set builds for the release variant/buildType.
+                    // This configuration is, however, required for Android's connectedCheck task (which uses the androidTest source set
+                    // with the debug variant/buildType).
+                    buildConfigField 'String', 'ABLY_API_KEY', "\"${property('ABLY_API_KEY')}\""
+                    buildConfigField 'String', 'MAPBOX_ACCESS_TOKEN', "\"${property('MAPBOX_ACCESS_TOKEN')}\""
+                }
+
+                def versionConfigFields = {
+                    // Android library modules don't have access to both versionName and versionCode fields
+                    // so we're adding them by ourselves.
+                    buildConfigField "String", "VERSION_NAME", "\"${defaultConfig.versionName}\""
+                    buildConfigField "long", "VERSION_CODE", "${defaultConfig.versionCode}"
+                }
+
                 debug {
-                    applySecretBuildConfigFields delegate
-                    applyVersionBuildConfigFields delegate
+                    apply secretConfigFields on it
+                    apply versionConfigFields on it
                 }
 
                 release {
@@ -173,10 +177,10 @@ subprojects {
                     // integration tests (via Android's `connectedCheck` task), which are testing using the debug
                     // variant/buildType.
                     if (evaluatedSubProjectIsAnApp) {
-                        applySecretBuildConfigFields delegate
+                        apply secretConfigFields on it
                     }
                     if (evaluatedSubProjectIsALibrary) {
-                        applyVersionBuildConfigFields delegate
+                        apply versionConfigFields on it
                     }
 
                     minifyEnabled false


### PR DESCRIPTION
As suggested I've tried to get rid of the 'buildType` param from the closures responsible for setting additional build config fields. In order to use the delegates mechanism we need to explicitly set the delegate object. This forces us to write additional code in each place where we want to use those closures. For example instead of
```groovy
applyVersionConfigFields delegate
```

we would have to write
```groovy
applyVersionConfigFields.delegate = delegate
applyVersionConfigFields()
```

and if we would have forgotten to set the delegate then the method would crash.

To somehow use the delegates mechanism and still keep things simple to use I've added a special helper method `apply` which wraps that delegate assignment and allows us to write the configuration more like a spoken language: `apply versionConfigFields on it` (where `it` is the build type).

WDYT? Does it look better now? It's more complicated than it was before and I'm wondering if we should change it.