### PR TITLE
Add test checking the order of set route callbacks

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -1,15 +1,23 @@
 package com.ably.tracking.publisher
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.ably.tracking.Location
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.test.android.common.NOTIFICATION_CHANNEL_ID
+import com.ably.tracking.test.android.common.UnitExpectation
 import com.ably.tracking.test.android.common.createNotificationChannel
+import com.ably.tracking.test.android.common.testLogD
 import com.google.gson.Gson
+import com.mapbox.module.Mapbox_TripNotificationModuleConfiguration
+import com.mapbox.navigation.base.trip.notification.TripNotification
+import com.mapbox.navigation.core.MapboxNavigation
+import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -34,6 +42,75 @@ class MapboxTests {
         // then
     }
 
+    /**
+     * This test aims to check if the [Mapbox.setRoute] callbacks are called in the order in which they are invoked.
+     *
+     * This is important because we want to always use the destination from the most recent active trackable.
+     * I've also tried to check if [Mapbox.clearRoute] cancels the ongoing [Mapbox.setRoute] callbacks but it doesn't.
+     *
+     * While working on this test I've discovered an issue connected probably to creating multiple Mapbox instances.
+     * When I was running this test in isolation everything worked fine. However, when I ran the whole test class
+     * then this test was randomly failing with a SIGSEGV fatal signal. This probably means some troubles in native C++ code.
+     * To show this issue I'm deliberately creating a [MapboxNavigation] instance (normally it's hidden behind the [Mapbox] wrapper)
+     * and then stopping it with [MapboxNavigation.onDestroy]. The issue happens randomly which makes it harder to debug.
+     * If we introduce a delay between stopping the first instance and starting the second one then the test succeeds.
+     */
+    @SuppressLint("MissingPermission")
+    @Test
+    fun routeCallbacksShouldBeCalledInTheSameOrderInWhichTheyWereStarted() {
+        // given
+        val numberOfRoutes = 3
+        val orderedRouteNumbers = (1..numberOfRoutes).toList()
+        val startLocation = Location(1.0, 2.0, 3.0, 0f, 0f, 0f, 1000L)
+        val callbacksOrder = mutableListOf<Int>()
+        val callbackExpectations = orderedRouteNumbers.map { UnitExpectation("$it destination callback called") }
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        createNotificationChannel(context)
+
+        // create and stop a MapboxNavigation instance to make the test break (it happens randomly)
+        setupMapboxNavigationTripNotification(context)
+        val mapboxNavigation =
+            MapboxNavigation(MapboxNavigation.defaultNavigationOptionsBuilder(context, MAPBOX_ACCESS_TOKEN).build())
+        mapboxNavigation.onDestroy()
+
+        // If we would uncomment this sleep and wait for a 1 second here the test will succeed
+        // Thread.sleep(1000)
+
+        // create the Mapbox wrapper class that we want to test
+        val mapbox: Mapbox = createMapbox(context)
+
+        // when
+        mapbox.startTrip()
+        orderedRouteNumbers.forEach { routeNumber ->
+            testLogD("Setting route number $routeNumber")
+            mapbox.setRoute(
+                startLocation,
+                Destination(routeNumber.toDouble(), routeNumber.toDouble()),
+                RoutingProfile.DRIVING
+            ) {
+                testLogD("Route $routeNumber set")
+                callbacksOrder.add(routeNumber)
+                callbackExpectations[routeNumber - 1].fulfill()
+            }
+        }
+
+        // await asynchronous events
+        testLogD("Waiting for setRoute callbacks")
+        callbackExpectations.forEach { it.await() }
+
+        // cleanup
+        testLogD("Stopping mapbox wrapper")
+        mapbox.stopAndClose()
+
+        // then
+        Assert.assertEquals("All route callback should be called", numberOfRoutes, callbacksOrder.size)
+        Assert.assertEquals(
+            "Callbacks should be called in the order of invocation",
+            orderedRouteNumbers,
+            callbacksOrder
+        )
+    }
+
     private fun createMapbox(context: Context) =
         DefaultMapbox(
             context,
@@ -55,5 +132,24 @@ class MapboxTests {
     private fun getLocationData(context: Context): LocationHistoryData {
         val historyString = context.assets.open("location_history_small.txt").use { String(it.readBytes()) }
         return gson.fromJson(historyString, LocationHistoryData::class.java)
+    }
+
+    // Utility function required to create MapboxNavigation in this test file. Normally this is done in the Mapbox wrapper class.
+    private fun setupMapboxNavigationTripNotification(context: Context) {
+        Mapbox_TripNotificationModuleConfiguration.moduleProvider =
+            object : Mapbox_TripNotificationModuleConfiguration.ModuleProvider {
+                override fun createTripNotification(): TripNotification =
+                    MapboxTripNotification(
+                        object : PublisherNotificationProvider {
+                            override fun getNotification(): Notification =
+                                NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+                                    .setContentTitle("TEST")
+                                    .setContentText("Test")
+                                    .setSmallIcon(R.drawable.aat_logo)
+                                    .build()
+                        },
+                        12345
+                    )
+            }
     }
 }


### PR DESCRIPTION
When I was working on adding the test that checks the order of `mapbox.setRoute()` callbacks I've encountered an unexpected problem. The test was working when I ran it in isolation, however, when it was run as a part of the whole test class suite then it was randomly failing. This is an example of the error it was throwing
```
A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x30 in tid 24409 (Thread-3), pid 24330 (.publisher.test)
```
This leads me to believe that there is some issue with the native C/C++ code as the `SIGSEGV` error means that the process tries to access a memory location that doesn't belong to it. With this in mind, I've tried to reproduce the error when running the test in isolation. I've managed to do that by creating another instance of the Mapbox wrapper and stopping it right before creating the instance that was being tested. Then I changed the first instance to the `MapboxNavigation` to be sure that it isn't caused by some operations we do in the wrapper class. It was failing randomly but always with the same error. Then I've introduced a 1-second delay between the stopping of the first instance and the creation of the second one and it seemed to fix the issue.

I'm out of ideas on how to fix it and I'm wondering why is that happening? I thought that the `MapboxNavigation.onDestroy()` method will synchronously stop the Mapbox and free any resources it uses, but maybe that's not the case? :thinking: 

---

**Update**
I've finally been able to get more logs from this crash:
```
    --------- beginning of crash
2021-09-23 16:45:35.788 950-976/com.ably.tracking.publisher.test A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x30 in tid 976 (Thread-3)
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: Build fingerprint: 'google/sdk_google_phone_x86/generic_x86:7.0/NYC/4409132:user/release-keys'
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: Revision: '0'
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: ABI: 'x86'
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: pid: 950, tid: 976, name: Thread-3  >>> com.ably.tracking.publisher.test <<<
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x30
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG:     eax 00000030  ebx a7bc77b0  ecx 00000030  edx 00000016
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG:     esi 00000000  edi 00000030
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG:     xcs 00000073  xds 0000007b  xes 0000007b  xfs 0000003b  xss 0000007b
2021-09-23 16:45:35.844 1037-1037/? A/DEBUG:     eip a7b649e3  ebp 8d202588  esp 8d202570  flags 00010206
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG: backtrace:
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #00 pc 000759e3  /system/lib/libc.so (pthread_mutex_lock+35)
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #01 pc 00133640  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libmapbox-common.so (_ZNSt6__ndk15mutex4lockEv+32)
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #02 pc 0028e317  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #03 pc 0028e026  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #04 pc 002b5d01  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #05 pc 002b6319  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #06 pc 00284eac  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #07 pc 002b66d3  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #08 pc 002ec417  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #09 pc 002ecf9d  /data/app/com.ably.tracking.publisher.test-1/lib/x86/libnavigator-android.so
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #10 pc 00074fb2  /system/lib/libc.so (_ZL15__pthread_startPv+210)
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #11 pc 0002026e  /system/lib/libc.so (__start_thread+30)
2021-09-23 16:45:35.846 1037-1037/? A/DEBUG:     #12 pc 0001e046  /system/lib/libc.so (__bionic_clone+70)
```