### PR TITLE
Pull request checks: run against HEAD, not merge commit

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,7 +8,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # Checkout HEAD, don't create merge commit. See https://github.com/ably/sdk-upload-action/issues/19
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # Checkout HEAD, don't create merge commit. See https://github.com/ably/sdk-upload-action/issues/19
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Checkout HEAD, don't create merge commit. See https://github.com/ably/sdk-upload-action/issues/19
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -11,7 +11,10 @@ jobs:
       matrix:
         api-level: [24, 27, 29]
     steps:
+      # Checkout HEAD, don't create merge commit. See https://github.com/ably/sdk-upload-action/issues/19
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2


### PR DESCRIPTION
I've started to get fed up with the "Conflict merging main into" Error instances we get for the docs workflow when running the SDK Upload Action step. It slows us down as it results in checks failing.

I'm going to prototype this particular fix to the problem in this repository for a few weeks, with the plan being to roll it out to workflows in other repositories soon after that as our new, conformed way of using the checkout action.

Full context: https://github.com/ably/sdk-upload-action/issues/19