### PR TITLE
Detach a channel when disconnecting from it in the Ably wrapper

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -260,8 +260,16 @@ constructor(
                         override fun onSuccess() {
                             channelToRemove.unsubscribe()
                             channelToRemove.presence.unsubscribe()
-                            channels.remove(trackableId)
-                            callback(Result.success(Unit))
+                            channelToRemove.detach(object : CompletionListener {
+                                override fun onSuccess() {
+                                    channels.remove(trackableId)
+                                    callback(Result.success(Unit))
+                                }
+
+                                override fun onError(reason: ErrorInfo) {
+                                    callback(Result.failure(reason.toTrackingException()))
+                                }
+                            })
                         }
 
                         override fun onError(reason: ErrorInfo) {


### PR DESCRIPTION
Calling `detach()` on a channel and waiting for it to succeed during the `disconnect()` method of the `Ably` wrapper class.