### PR TITLE
Fix crash when clicking on an uninitialized S3 files list

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -28,6 +28,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun setupS3Preference() {
         (findPreference(getString(R.string.preferences_s3_file_key)) as ListPreference?)?.let { s3Preference ->
+            s3Preference.entries = emptyArray()
+            s3Preference.entryValues = emptyArray()
             S3Helper.fetchLocationHistoryFilenames(
                 onListLoaded = { filenamesWithSizes, filenames ->
                     s3Preference.entries = filenamesWithSizes.toTypedArray()


### PR DESCRIPTION
The publisher example app was crashing when clicking on an uninitialized S3 files list. To fix it I'm simply setting the list values to empty arrays.