### PR TITLE
Add hepler extension function for showing toasts

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
-import android.widget.Toast
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
@@ -86,7 +85,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                     addTrackable(trackableId)
                 }
             } else {
-                showToast("Insert tracking ID")
+                showLongToast("Insert tracking ID")
             }
         }
     }
@@ -140,7 +139,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                     )
                     finish()
                 } catch (exception: Exception) {
-                    showToast("Error when adding the trackable")
+                    showLongToast("Error when adding the trackable")
                     hideLoading()
                 }
             }
@@ -159,7 +158,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
             this,
             appPreferences.getS3File(),
             onHistoryDataDownloaded = { onHistoryDataDownloaded(it) },
-            onUninitialized = { showToast("S3 not initialized - cannot download history data") }
+            onUninitialized = { showLongToast("S3 not initialized - cannot download history data") }
         )
     }
 
@@ -173,10 +172,6 @@ class AddTrackableActivity : PublisherServiceActivity() {
         progressIndicator.visibility = View.GONE
         addTrackableButton.isEnabled = true
         trackableIdEditText.isEnabled = true
-    }
-
-    private fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
     private fun getTrackableId(): String = trackableIdEditText.text.toString().trim()

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -3,10 +3,19 @@ package com.ably.tracking.example.publisher
 import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
 
 fun Context.hideKeyboard(view: View) {
     (getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.hideSoftInputFromWindow(
         view.windowToken,
         0
     )
+}
+
+fun Context.showShortToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.showLongToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -4,10 +4,13 @@ import android.Manifest
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.activity_main.addTrackableFab
+import kotlinx.android.synthetic.main.activity_main.emptyStateContainer
+import kotlinx.android.synthetic.main.activity_main.locationSourceMethodTextView
+import kotlinx.android.synthetic.main.activity_main.settingsImageView
+import kotlinx.android.synthetic.main.activity_main.trackablesRecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -63,7 +66,7 @@ class MainActivity : PublisherServiceActivity() {
                             publisherService.publisher?.stop()
                             publisherService.publisher = null
                         } catch (e: Exception) {
-                            showToast("Stopping publisher error")
+                            showLongToast("Stopping publisher error")
                         }
                         stopPublisherService()
                     } else {
@@ -108,7 +111,7 @@ class MainActivity : PublisherServiceActivity() {
 
     @AfterPermissionGranted(REQUEST_LOCATION_PERMISSION)
     fun onLocationPermissionGranted() {
-        showToast("Permission granted")
+        showLongToast("Permission granted")
     }
 
     private fun showAddTrackableScreen() {
@@ -127,10 +130,6 @@ class MainActivity : PublisherServiceActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         // Forward results to EasyPermissions
         EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this)
-    }
-
-    private fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
     private fun showTrackablesList() {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -5,7 +5,6 @@ import android.app.Notification
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
-import android.widget.Toast
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import com.ably.tracking.Accuracy
@@ -132,11 +131,7 @@ class PublisherService : Service() {
             S3Helper.uploadHistoryData(
                 this,
                 historyData
-            ) { showToast("S3 not initialized - cannot upload history data") }
+            ) { showShortToast("S3 not initialized - cannot upload history data") }
         }
-    }
-
-    private fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 }


### PR DESCRIPTION
I've spotted that we had a lot of duplicated `showToast()` methods across the publisher example app so I've extracted the code to helper extension functions, making them available to everything that is or has a `Context` object.