### PR TITLE
Use named parameters for hideKeyboard extension

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 
+private const val NO_FLAGS = 0
+
 fun Context.hideKeyboard(view: View) {
     (getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.hideSoftInputFromWindow(
         view.windowToken,
-        0
+        NO_FLAGS
     )
 }


### PR DESCRIPTION
To improve code readability I've extracted the magic number `0` to a `NO_FLAGS` constant. I've tried to use Kotlin's named parameters but it turns out that you can't use those if the function is a non-Kotlin one which is a bit disappointing.