### PR TITLE
Run the check workflow on the newest Java versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,14 +7,17 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Java 11 is the minimum for Gradle 7, Java 16 is the newest STS, Java 17 is the newest LTS
+        java-version: [ 11, 16, 17 ]
     steps:
       - uses: actions/checkout@v2
 
-      # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
 
       - run: ./gradlew check testDebugUnitTestCoverage testReleaseUnitTestCoverage --profile
         env:


### PR DESCRIPTION
After call with @ikbalkaya we've discovered that our project doesn't build on JDK 16 (probably because of `kapt`). I've modified the `check` workflow to run both on Java 11, 16 and 17 to check if it will work.