### PR TITLE
Rename workflow job names to match the file and workflow name

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  check:
+  assemble:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  build:
+  docs:
     runs-on: ubuntu-latest
     permissions:
       deployments: write

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  check:
+  emulate:
     runs-on: macos-latest
     strategy:
       matrix:


### PR DESCRIPTION
I've noticed that some of the workflows have wrong names (e.g. the `emulate` workflow's job was named `check`) so I've changed those names to match the workflow filenames.