### PR TITLE
Added -no-snapshot-save to fix emulate workflow issue

### DIFF
--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [21, 24, 27, 29]
+        api-level: [ 21, 24, 27, 29 ]
         include:
           - api: 21
             excludeModules: true
@@ -25,8 +25,9 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          #Github's default -no-snapshot option causes check workflow failing likely it has to cold boot emulator
-          #It's either stuck or causes timeouts. Exact reason not known. #adding -no-snapshot-save will enable quick
+          #Github's default -no-snapshot option causes check workflow failing.It is likely because it has to cold boot
+          #emulator which might be taking long and causing a timeout issue or a freeze.
+          #Adding -no-snapshot-save will enable quick
           #boot. See https://developer.android.com/studio/run/emulator-commandline#common for more
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           # ${{ condition && 'ifTrue' || 'ifFalse' }} is a workaround for a ternary operator https://github.com/actions/runner/issues/409#issuecomment-752775072


### PR DESCRIPTION
This pull request aims to improve the emulate workflow with setting a 'quick boot' option.

It was first discovered in ably-java library and was causing this branch to fail checks
https://github.com/ably/ably-java/compare/705-push-listSubscriptions-ignore-params

I encountered the same issue on this library as well, but the issue is intermittent as it is time/timeout related 
See https://github.com/ably/ably-asset-tracking-android/runs/3906267210 for the report that caused issue in this repo.
