### PR TITLE
Manually start and stop the publisher service

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -71,14 +71,6 @@ class AddTrackableActivity : PublisherServiceActivity() {
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
-    override fun onPublisherServiceConnected(publisherService: PublisherService) {
-        // If the publisher is not started it means that we've just created the service and we should add a trackable
-        if (!publisherService.isPublisherStarted) {
-            startPublisherAndAddTrackable(getTrackableId())
-        }
-    }
-
-    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     private fun addTrackableClicked() {
         getTrackableId().let { trackableId ->
             if (trackableId.isNotEmpty()) {
@@ -86,7 +78,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                 if (isPublisherServiceStarted()) {
                     startPublisherAndAddTrackable(trackableId)
                 } else {
-                    startAndBindPublisherService()
+                    onAddTrackableFailed()
                 }
             } else {
                 showLongToast("Insert tracking ID")

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -70,7 +70,6 @@ class MainActivity : PublisherServiceActivity() {
                         } catch (e: Exception) {
                             showLongToast("Stopping publisher error")
                         }
-                        stopPublisherService()
                     } else {
                         showTrackablesList()
                     }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -4,11 +4,13 @@ import android.Manifest
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.activity_main.addTrackableFab
 import kotlinx.android.synthetic.main.activity_main.emptyStateContainer
 import kotlinx.android.synthetic.main.activity_main.locationSourceMethodTextView
+import kotlinx.android.synthetic.main.activity_main.publisherServiceSwitch
 import kotlinx.android.synthetic.main.activity_main.settingsImageView
 import kotlinx.android.synthetic.main.activity_main.trackablesRecyclerView
 import kotlinx.coroutines.CoroutineScope
@@ -45,9 +47,8 @@ class MainActivity : PublisherServiceActivity() {
             startActivity(Intent(this, SettingsActivity::class.java))
         }
 
-        addTrackableFab.setOnClickListener {
-            showAddTrackableScreen()
-        }
+        addTrackableFab.setOnClickListener { onAddTrackableClick() }
+        publisherServiceSwitch.setOnClickListener { onServiceSwitchClick(publisherServiceSwitch.isChecked) }
 
         trackablesRecyclerView.adapter = trackablesAdapter
         trackablesRecyclerView.layoutManager = LinearLayoutManager(this)
@@ -56,6 +57,7 @@ class MainActivity : PublisherServiceActivity() {
     }
 
     override fun onPublisherServiceConnected(publisherService: PublisherService) {
+        indicatePublisherServiceIsOn()
         publisherService.publisher?.let { publisher ->
             trackablesUpdateJob = publisher.trackables
                 .onEach {
@@ -78,6 +80,7 @@ class MainActivity : PublisherServiceActivity() {
     }
 
     override fun onPublisherServiceDisconnected() {
+        indicatePublisherServiceIsOff()
         trackablesUpdateJob?.cancel()
     }
 
@@ -92,6 +95,27 @@ class MainActivity : PublisherServiceActivity() {
                 putExtra(TRACKABLE_ID_EXTRA, trackableId)
             }
         )
+    }
+
+    private fun onServiceSwitchClick(isSwitchingOn: Boolean) {
+        if (isSwitchingOn) {
+            startAndBindPublisherService()
+        } else {
+            if (trackablesAdapter.trackables.isEmpty()) {
+                stopPublisherService()
+            } else {
+                showCannotStopServiceDialog()
+                indicatePublisherServiceIsOn()
+            }
+        }
+    }
+
+    private fun onAddTrackableClick() {
+        if (isPublisherServiceStarted()) {
+            showAddTrackableScreen()
+        } else {
+            showServiceNotStartedDialog()
+        }
     }
 
     private fun updateLocationSourceMethodInfo() {
@@ -140,5 +164,29 @@ class MainActivity : PublisherServiceActivity() {
     private fun hideTrackablesList() {
         trackablesRecyclerView.visibility = View.GONE
         emptyStateContainer.visibility = View.VISIBLE
+    }
+
+    private fun indicatePublisherServiceIsOn() {
+        publisherServiceSwitch.isChecked = true
+    }
+
+    private fun indicatePublisherServiceIsOff() {
+        publisherServiceSwitch.isChecked = false
+    }
+
+    private fun showServiceNotStartedDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.service_not_started_dialog_title)
+            .setMessage(R.string.service_not_started_dialog_message)
+            .setPositiveButton(R.string.dialog_positive_button, null)
+            .show()
+    }
+
+    private fun showCannotStopServiceDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.cannot_stop_service_dialog_title)
+            .setMessage(R.string.cannot_stop_service_dialog_message)
+            .setPositiveButton(R.string.dialog_positive_button, null)
+            .show()
     }
 }

--- a/publishing-example-app/src/main/res/layout/activity_main.xml
+++ b/publishing-example-app/src/main/res/layout/activity_main.xml
@@ -111,8 +111,36 @@
     android:layout_height="0dp"
     android:layout_marginTop="16dp"
     android:visibility="gone"
-    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintBottom_toTopOf="@id/publisherServiceBackground"
     app:layout_constraintTop_toBottomOf="@id/trackableListLabelTextView" />
+
+  <View
+    android:id="@+id/publisherServiceBackground"
+    android:layout_width="match_parent"
+    android:layout_height="90dp"
+    android:background="@color/location_source_background"
+    app:layout_constraintBottom_toBottomOf="parent" />
+
+  <TextView
+    android:id="@+id/publisherServiceSwitchLabelTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/medium_margin"
+    android:text="@string/publisher_service_label"
+    android:textColor="@color/black"
+    android:textSize="16sp"
+    app:layout_constraintBottom_toBottomOf="@id/publisherServiceBackground"
+    app:layout_constraintStart_toStartOf="@id/publisherServiceBackground"
+    app:layout_constraintTop_toTopOf="@id/publisherServiceBackground" />
+
+  <androidx.appcompat.widget.SwitchCompat
+    android:id="@+id/publisherServiceSwitch"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/medium_margin"
+    app:layout_constraintBottom_toBottomOf="@id/publisherServiceSwitchLabelTextView"
+    app:layout_constraintStart_toEndOf="@id/publisherServiceSwitchLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherServiceSwitchLabelTextView" />
 
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/addTrackableFab"

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
   <string name="trackable_details">Trackable details</string>
   <string name="add_trackable">Add trackable</string>
   <string name="location_source_label">Location Source:</string>
+  <string name="publisher_service_label">Publisher Service:</string>
   <string name="current_location_and_bearing">Current location and bearing</string>
   <string name="latitude_label">Lat:</string>
   <string name="longitude_label">Long:</string>
@@ -51,4 +52,8 @@
   <string name="preferences_update_resolution_minimum_displacement_title">Set Minimum Displacement</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>
+  <string name="service_not_started_dialog_title">Publisher service not started</string>
+  <string name="service_not_started_dialog_message">The publisher service has to be started to start adding trackables. Please use the switch at the bottom of the screen to turn it on.</string>
+  <string name="cannot_stop_service_dialog_title">Publisher still has added trackables</string>
+  <string name="cannot_stop_service_dialog_message">The publisher has added trackables. Remove them before stopping the publisher service.</string>
 </resources>


### PR DESCRIPTION
Before, we were starting the publisher service automatically when adding the first trackable. Then it was stopped when we removed the last trackable. This was a convenient solution but was not giving us a lot of flexibility.
Now, the service has to be manually started and stopped. The app will not allow to add a trackable if the service is not started and will not allow to stop the service if it has any trackables added.
![device-2021-10-20-094901](https://user-images.githubusercontent.com/62378170/138050853-4f3021e6-f0d9-4fd2-ac87-a1cf1f82bfd5.png)
