### PR TITLE
Refactor AddTrackableActivity non-atomic method

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -76,11 +76,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
             if (trackableId.isNotEmpty()) {
                 showLoading()
                 if (isPublisherServiceStarted()) {
-                    publisherService.let { publisherService ->
-                        if (publisherService == null) {
-                            onAddTrackableFailed()
-                            return
-                        }
+                    publisherService?.let { publisherService ->
                         scope.launch(CoroutineExceptionHandler { _, _ -> onAddTrackableFailed() }) {
                             if (!publisherService.isPublisherStarted) {
                                 startPublisher(publisherService)

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -76,7 +76,20 @@ class AddTrackableActivity : PublisherServiceActivity() {
             if (trackableId.isNotEmpty()) {
                 showLoading()
                 if (isPublisherServiceStarted()) {
-                    startPublisherAndAddTrackable(trackableId)
+                    publisherService.let { publisherService ->
+                        if (publisherService == null) {
+                            onAddTrackableFailed()
+                            return
+                        }
+                        scope.launch(CoroutineExceptionHandler { _, _ -> onAddTrackableFailed() }) {
+                            if (!publisherService.isPublisherStarted) {
+                                startPublisher(publisherService)
+                            }
+                            publisherService.publisher!!.track(createTrackable(trackableId))
+                            showTrackableDetailsScreen(trackableId)
+                            finish()
+                        }
+                    }
                 } else {
                     onAddTrackableFailed()
                 }
@@ -87,27 +100,12 @@ class AddTrackableActivity : PublisherServiceActivity() {
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
-    private fun startPublisherAndAddTrackable(trackableId: String) {
-        publisherService.let { publisherService ->
-            if (publisherService == null) {
-                onAddTrackableFailed()
-                return
-            }
-            scope.launch(
-                CoroutineExceptionHandler { _, _ -> onAddTrackableFailed() }
-            ) {
-                if (!publisherService.isPublisherStarted) {
-                    val locationHistoryData = when (appPreferences.getLocationSource()) {
-                        LocationSourceType.S3_FILE -> downloadLocationHistoryData()
-                        else -> null
-                    }
-                    publisherService.startPublisher(createLocationSource(locationHistoryData))
-                }
-                publisherService.publisher!!.track(createTrackable(trackableId))
-                showTrackableDetailsScreen(trackableId)
-                finish()
-            }
+    private suspend fun startPublisher(publisherService: PublisherService) {
+        val locationHistoryData = when (appPreferences.getLocationSource()) {
+            LocationSourceType.S3_FILE -> downloadLocationHistoryData()
+            else -> null
         }
+        publisherService.startPublisher(createLocationSource(locationHistoryData))
     }
 
     private fun onAddTrackableFailed() {


### PR DESCRIPTION
As promised [here](https://github.com/ably/ably-asset-tracking-android/pull/449#discussion_r719315233), after the publisher start/stop was removed from the add screen, I am now able to refactor this non-atomic method which had only existed to avoid code repetition.