### PR TITLE
Handle revoked location permissions on the add screen when trying to add a trackable

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.example.publisher
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
@@ -73,9 +74,8 @@ class AddTrackableActivity : PublisherServiceActivity() {
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     private fun addTrackableClicked() {
         getTrackableId().let { trackableId ->
-            if (!hasFineOrCoarseLocationPermissionGranted(this)) {
-                showLongToast("Grant the location permission to use the publisher")
-                finish()
+            if (!PermissionsHelper.hasFineOrCoarseLocationPermissionGranted(this)) {
+                PermissionsHelper.requestLocationPermission(this)
                 return
             }
             if (trackableId.isNotEmpty()) {
@@ -206,5 +206,18 @@ class AddTrackableActivity : PublisherServiceActivity() {
                 ColorStateList.valueOf(ContextCompat.getColor(this, R.color.button_inactive))
             addTrackableButton.setTextColor(ContextCompat.getColor(this, R.color.mid_grey))
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        PermissionsHelper.onRequestPermissionsResult(
+            requestCode,
+            permissions,
+            grantResults,
+            onLocationPermissionGranted = {
+                addTrackableClicked()
+            }
+        )
     }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -73,6 +73,11 @@ class AddTrackableActivity : PublisherServiceActivity() {
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     private fun addTrackableClicked() {
         getTrackableId().let { trackableId ->
+            if (!hasFineOrCoarseLocationPermissionGranted(this)) {
+                showLongToast("Grant the location permission to use the publisher")
+                finish()
+                return
+            }
             if (trackableId.isNotEmpty()) {
                 showLoading()
                 if (isPublisherServiceStarted()) {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.example.publisher
 
-import android.Manifest
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -19,12 +18,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import pub.devrel.easypermissions.AfterPermissionGranted
-import pub.devrel.easypermissions.EasyPermissions
 import timber.log.Timber
-
-private val REQUIRED_PERMISSIONS = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
-private const val REQUEST_LOCATION_PERMISSION = 1
 
 class MainActivity : PublisherServiceActivity() {
     private lateinit var appPreferences: AppPreferences
@@ -41,7 +35,7 @@ class MainActivity : PublisherServiceActivity() {
         appPreferences = AppPreferences.getInstance(this)
         updateLocationSourceMethodInfo()
 
-        requestLocationPermission()
+        PermissionsHelper.requestLocationPermission(this)
 
         settingsImageView.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
@@ -121,27 +115,11 @@ class MainActivity : PublisherServiceActivity() {
         locationSourceMethodTextView.text = appPreferences.getLocationSource().displayName
     }
 
-    private fun requestLocationPermission() {
-        if (!EasyPermissions.hasPermissions(this, *REQUIRED_PERMISSIONS)) {
-            EasyPermissions.requestPermissions(
-                this,
-                "Please grant the location permission",
-                REQUEST_LOCATION_PERMISSION,
-                *REQUIRED_PERMISSIONS
-            )
-        }
-    }
-
-    @AfterPermissionGranted(REQUEST_LOCATION_PERMISSION)
-    fun onLocationPermissionGranted() {
-        showLongToast("Permission granted")
-    }
-
     private fun showAddTrackableScreen() {
-        if (hasFineOrCoarseLocationPermissionGranted(this)) {
+        if (PermissionsHelper.hasFineOrCoarseLocationPermissionGranted(this)) {
             startActivity(Intent(this, AddTrackableActivity::class.java))
         } else {
-            requestLocationPermission()
+            PermissionsHelper.requestLocationPermission(this)
         }
     }
 
@@ -151,8 +129,12 @@ class MainActivity : PublisherServiceActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        // Forward results to EasyPermissions
-        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this)
+        PermissionsHelper.onRequestPermissionsResult(
+            requestCode,
+            permissions,
+            grantResults,
+            onLocationPermissionGranted = { showLongToast("Permission granted") }
+        )
     }
 
     private fun showTrackablesList() {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PermissionsHelper.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PermissionsHelper.kt
@@ -2,13 +2,51 @@ package com.ably.tracking.example.publisher
 
 import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
+import pub.devrel.easypermissions.AfterPermissionGranted
+import pub.devrel.easypermissions.EasyPermissions
 
-fun hasFineOrCoarseLocationPermissionGranted(context: Context): Boolean =
-    hasPermissionGranted(context, ACCESS_FINE_LOCATION) ||
-        hasPermissionGranted(context, ACCESS_COARSE_LOCATION)
+object PermissionsHelper {
+    private val REQUIRED_PERMISSIONS = arrayOf(ACCESS_FINE_LOCATION)
+    private const val REQUEST_LOCATION_PERMISSION = 1
 
-fun hasPermissionGranted(context: Context, permission: String): Boolean =
-    ActivityCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    fun requestLocationPermission(activity: Activity) {
+        if (!EasyPermissions.hasPermissions(activity, *REQUIRED_PERMISSIONS)) {
+            EasyPermissions.requestPermissions(
+                activity,
+                "Please grant the location permission",
+                REQUEST_LOCATION_PERMISSION,
+                *REQUIRED_PERMISSIONS
+            )
+        }
+    }
+
+    fun hasFineOrCoarseLocationPermissionGranted(context: Context): Boolean =
+        hasPermissionGranted(context, ACCESS_FINE_LOCATION) ||
+            hasPermissionGranted(context, ACCESS_COARSE_LOCATION)
+
+    private fun hasPermissionGranted(context: Context, permission: String): Boolean =
+        ActivityCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+        onLocationPermissionGranted: () -> Unit
+    ) {
+        EasyPermissions.onRequestPermissionsResult(
+            requestCode,
+            permissions,
+            grantResults,
+            object {
+                @AfterPermissionGranted(REQUEST_LOCATION_PERMISSION)
+                fun onPermissionGranted() {
+                    onLocationPermissionGranted()
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
We should protect the app from a scenario in which someone revokes the location permissions after they have been granted. In this PR I'm securing the "Add Trackable" screen. If a user tries to add a trackable but the permissions aren't granted we ~close the screen and display an error message~ request those missing permissions.