### PR TITLE
Show error toast with a specific error message when publisher service is stopped

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -92,7 +92,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                         }
                     }
                 } else {
-                    onAddTrackableFailed()
+                    onAddTrackableFailed("Publisher service not started")
                 }
             } else {
                 showLongToast("Insert tracking ID")
@@ -109,8 +109,8 @@ class AddTrackableActivity : PublisherServiceActivity() {
         publisherService.startPublisher(createLocationSource(locationHistoryData))
     }
 
-    private fun onAddTrackableFailed() {
-        showLongToast("Error when adding the trackable")
+    private fun onAddTrackableFailed(message: String = "Error when adding the trackable") {
+        showLongToast(message)
         hideLoading()
     }
 


### PR DESCRIPTION
I have been testing how the app behaves if the location permission is revoked when the app is running. During those tests I've noticed that when we revoke the location permission, the publisher service gets killed and our app recreates. Because of that a user can end up on the "Add Trackable" screen without an active publisher service. To make the situation clear instead of showing a generic "Can't add trackable" error message I'm displaying a more meaningful one that explains that the service is not running.