### PR TITLE
Show loading when waiting for the trackable to be removed

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.example.publisher
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import com.ably.tracking.Location
@@ -72,14 +73,34 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
             .setTitle(R.string.stop_tracking_dialog_title)
             .setMessage(R.string.stop_tracking_dialog_message)
             .setPositiveButton(R.string.dialog_positive_button) { _, _ ->
+                showLoading()
                 scope.launch {
-                    val trackableToRemove = trackables?.find { trackable -> trackable.id == trackableId }
-                    trackableToRemove?.let { publisherService?.publisher?.remove(it) }
-                    finish()
+                    try {
+                        val trackableToRemove = trackables?.find { trackable -> trackable.id == trackableId }
+                        trackableToRemove?.let { publisherService?.publisher?.remove(it) }
+                        finish()
+                    } catch (exception: Exception) {
+                        hideLoading()
+                        showLongToast("Error when removing the trackable")
+                    }
                 }
             }
             .setNegativeButton(R.string.dialog_negative_button, null)
             .show()
+    }
+
+    private fun showLoading() {
+        stopTrackingProgressIndicator.visibility = View.VISIBLE
+        showMapButton.isEnabled = false
+        stopTrackingButton.isEnabled = false
+        stopTrackingButton.hideText()
+    }
+
+    private fun hideLoading() {
+        stopTrackingProgressIndicator.visibility = View.GONE
+        showMapButton.isEnabled = true
+        stopTrackingButton.isEnabled = true
+        stopTrackingButton.showText()
     }
 
     private fun updateLocationInfo(location: Location) {

--- a/publishing-example-app/src/main/res/layout/activity_trackable_details.xml
+++ b/publishing-example-app/src/main/res/layout/activity_trackable_details.xml
@@ -199,4 +199,17 @@
     android:textColor="@color/white"
     app:layout_constraintBottom_toBottomOf="parent" />
 
+  <ProgressBar
+    android:id="@+id/stopTrackingProgressIndicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:elevation="8dp"
+    android:indeterminateTint="@color/black"
+    android:visibility="gone"
+    app:layout_constraintBottom_toBottomOf="@id/stopTrackingButton"
+    app:layout_constraintEnd_toEndOf="@id/stopTrackingButton"
+    app:layout_constraintStart_toStartOf="@id/stopTrackingButton"
+    app:layout_constraintTop_toTopOf="@id/stopTrackingButton"
+    tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Show loading and block UI interactions when a user clicks on the "Stop Tracking" button and confirms the trackable removal.
![device-2021-10-20-161835](https://user-images.githubusercontent.com/62378170/138111194-62464b2c-649e-498b-908b-c7a952847d7e.png)
