### PR TITLE
Add loading to the subscriber example app and handle error paths

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/Extensions.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/Extensions.kt
@@ -1,0 +1,23 @@
+package com.ably.tracking.example.subscriber
+
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.Button
+
+private const val NO_FLAGS = 0
+
+fun Context.hideKeyboard(view: View) {
+    (getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.hideSoftInputFromWindow(
+        view.windowToken,
+        NO_FLAGS
+    )
+}
+
+fun Button.hideText() {
+    textScaleX = 0f
+}
+
+fun Button.showText() {
+    textScaleX = 1f
+}

--- a/subscribing-example-app/src/main/res/layout/trackable_input_controls_view.xml
+++ b/subscribing-example-app/src/main/res/layout/trackable_input_controls_view.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -36,5 +37,18 @@
     android:text="@string/start_button_ready"
     android:textColor="@color/mid_grey"
     app:layout_constraintBottom_toBottomOf="parent" />
+
+  <ProgressBar
+    android:id="@+id/progressIndicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:elevation="8dp"
+    android:indeterminateTint="@color/black"
+    android:visibility="gone"
+    app:layout_constraintBottom_toBottomOf="@id/startButton"
+    app:layout_constraintEnd_toEndOf="@id/startButton"
+    app:layout_constraintStart_toStartOf="@id/startButton"
+    app:layout_constraintTop_toTopOf="@id/startButton"
+    tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The subscriber start and stop methods take some time to complete so we should show some loading information when they are ongoing. I've added the loading progress indicator and improved a bit the flow of changing between layout states. Now, error paths are handled better.