### PR TITLE
Extract hardcoded strings from example apps to string resources

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import androidx.annotation.RequiresPermission
+import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import com.ably.tracking.Accuracy
@@ -74,7 +75,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
     private fun addTrackableClicked() {
         getTrackableId().let { trackableId ->
             if (!hasFineOrCoarseLocationPermissionGranted(this)) {
-                showLongToast("Grant the location permission to use the publisher")
+                showLongToast(R.string.error_location_permission_required)
                 finish()
                 return
             }
@@ -92,10 +93,10 @@ class AddTrackableActivity : PublisherServiceActivity() {
                         }
                     }
                 } else {
-                    onAddTrackableFailed("Publisher service not started")
+                    onAddTrackableFailed(R.string.error_publisher_service_not_started)
                 }
             } else {
-                showLongToast("Insert tracking ID")
+                showLongToast(R.string.error_no_trackable_id)
             }
         }
     }
@@ -109,8 +110,8 @@ class AddTrackableActivity : PublisherServiceActivity() {
         publisherService.startPublisher(createLocationSource(locationHistoryData))
     }
 
-    private fun onAddTrackableFailed(message: String = "Error when adding the trackable") {
-        showLongToast(message)
+    private fun onAddTrackableFailed(@StringRes messageResourceId: Int = R.string.error_trackable_adding_failed) {
+        showLongToast(messageResourceId)
         hideLoading()
     }
 
@@ -161,7 +162,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                 onHistoryDataDownloaded = { continuation.resume(it) },
                 onError = { continuation.resumeWithException(it) },
                 onUninitialized = {
-                    showLongToast("S3 not initialized - cannot download history data")
+                    showLongToast(R.string.error_s3_not_initialized_history_data_download)
                     continuation.resumeWithException(Exception("S3 not initialized"))
                 }
             )

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AddTrackableActivity.kt
@@ -162,7 +162,7 @@ class AddTrackableActivity : PublisherServiceActivity() {
                 onHistoryDataDownloaded = { continuation.resume(it) },
                 onError = { continuation.resumeWithException(it) },
                 onUninitialized = {
-                    showLongToast(R.string.error_s3_not_initialized_history_data_download)
+                    showLongToast(R.string.error_s3_not_initialized_history_data_download_failed)
                     continuation.resumeWithException(Exception("S3 not initialized"))
                 }
             )

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -16,6 +16,14 @@ fun Context.hideKeyboard(view: View) {
     )
 }
 
+fun Context.showShortToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.showLongToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+}
+
 fun Context.showShortToast(@StringRes stringResourceId: Int) {
     Toast.makeText(this, stringResourceId, Toast.LENGTH_SHORT).show()
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.Toast
+import androidx.annotation.StringRes
 
 private const val NO_FLAGS = 0
 
@@ -15,12 +16,12 @@ fun Context.hideKeyboard(view: View) {
     )
 }
 
-fun Context.showShortToast(message: String) {
-    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+fun Context.showShortToast(@StringRes stringResourceId: Int) {
+    Toast.makeText(this, stringResourceId, Toast.LENGTH_SHORT).show()
 }
 
-fun Context.showLongToast(message: String) {
-    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+fun Context.showLongToast(@StringRes stringResourceId: Int) {
+    Toast.makeText(this, stringResourceId, Toast.LENGTH_LONG).show()
 }
 
 fun Button.hideText() {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/LocationSourceType.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/LocationSourceType.kt
@@ -1,5 +1,9 @@
 package com.ably.tracking.example.publisher
 
-enum class LocationSourceType(val displayName: String) {
-    PHONE("Phone"), ABLY_CHANNEL("Ably Channel"), S3_FILE("S3 File")
+import androidx.annotation.StringRes
+
+enum class LocationSourceType(@StringRes val displayNameResourceId: Int) {
+    PHONE(R.string.location_source_phone),
+    ABLY_CHANNEL(R.string.location_source_ably_channel),
+    S3_FILE(R.string.location_source_s3_file)
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -62,7 +62,7 @@ class MainActivity : PublisherServiceActivity() {
                             publisherService.publisher?.stop()
                             publisherService.publisher = null
                         } catch (e: Exception) {
-                            showLongToast(R.string.error_stop_publisher)
+                            showLongToast(R.string.error_stopping_publisher_failed)
                         }
                     } else {
                         showTrackablesList()

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -118,7 +118,7 @@ class MainActivity : PublisherServiceActivity() {
     }
 
     private fun updateLocationSourceMethodInfo() {
-        locationSourceMethodTextView.text = appPreferences.getLocationSource().displayName
+        locationSourceMethodTextView.text = getString(appPreferences.getLocationSource().displayNameResourceId)
     }
 
     private fun requestLocationPermission() {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : PublisherServiceActivity() {
                             publisherService.publisher?.stop()
                             publisherService.publisher = null
                         } catch (e: Exception) {
-                            showLongToast("Stopping publisher error")
+                            showLongToast(R.string.error_stop_publisher)
                         }
                     } else {
                         showTrackablesList()
@@ -134,7 +134,7 @@ class MainActivity : PublisherServiceActivity() {
 
     @AfterPermissionGranted(REQUEST_LOCATION_PERMISSION)
     fun onLocationPermissionGranted() {
-        showLongToast("Permission granted")
+        showLongToast(R.string.info_permission_granted)
     }
 
     private fun showAddTrackableScreen() {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -132,7 +132,7 @@ class PublisherService : Service() {
             S3Helper.uploadHistoryData(
                 this,
                 historyData
-            ) { showShortToast("S3 not initialized - cannot upload history data") }
+            ) { showShortToast(R.string.error_s3_not_initialized_history_data_upload) }
         }
     }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -132,7 +132,7 @@ class PublisherService : Service() {
             S3Helper.uploadHistoryData(
                 this,
                 historyData
-            ) { showShortToast(R.string.error_s3_not_initialized_history_data_upload) }
+            ) { showShortToast(R.string.error_s3_not_initialized_history_data_upload_failed) }
         }
     }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -52,7 +52,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 setupS3Preference(filenamesWithSizes, filenames)
             },
             onUninitialized = {
-                requireContext().showShortToast(R.string.error_s3_not_initialized_history_data_fetch)
+                requireContext().showShortToast(R.string.error_s3_not_initialized_history_data_fetch_failed)
             }
         )
     }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -1,7 +1,6 @@
 package com.ably.tracking.example.publisher
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
@@ -53,11 +52,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 setupS3Preference(filenamesWithSizes, filenames)
             },
             onUninitialized = {
-                Toast.makeText(
-                    requireContext(),
-                    "S3 not initialized - cannot fetch files",
-                    Toast.LENGTH_SHORT
-                ).show()
+                requireContext().showShortToast(R.string.error_s3_not_initialized_history_data_fetch)
             }
         )
     }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -61,7 +61,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val appPreferences = AppPreferences.getInstance(requireContext())
         (findPreference(getString(R.string.preferences_location_source_key)) as ListPreference?)?.apply {
             entries = LocationSourceType.values()
-                .map { it.displayName }
+                .map { getString(it.displayNameResourceId) }
                 .toTypedArray()
             entryValues = LocationSourceType.values().map { it.name }.toTypedArray()
             value = appPreferences.getLocationSource().name

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -81,7 +81,7 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
                         finish()
                     } catch (exception: Exception) {
                         hideLoading()
-                        showLongToast("Error when removing the trackable")
+                        showLongToast(R.string.error_trackable_removal_failed)
                     }
                 }
             }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -65,7 +65,7 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
     }
 
     private fun updateLocationSourceMethodInfo() {
-        locationSourceMethodTextView.text = appPreferences.getLocationSource().displayName
+        locationSourceMethodTextView.text = getString(appPreferences.getLocationSource().displayNameResourceId)
     }
 
     private fun stopTracking() {

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -67,4 +67,8 @@
   <string name="error_trackable_removal_failed">Error when removing the trackable</string>
   <string name="error_stop_publisher">Stopping publisher error</string>
   <string name="info_permission_granted">Permission granted</string>
+
+  <string name="location_source_phone">Phone</string>
+  <string name="location_source_ably_channel">Ably Channel</string>
+  <string name="location_source_s3_file">S3 File</string>
 </resources>

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -56,4 +56,15 @@
   <string name="service_not_started_dialog_message">The publisher service has to be started to start adding trackables. Please use the switch at the bottom of the screen to turn it on.</string>
   <string name="cannot_stop_service_dialog_title">Publisher still has added trackables</string>
   <string name="cannot_stop_service_dialog_message">The publisher has added trackables. Remove them before stopping the publisher service.</string>
+
+  <string name="error_s3_not_initialized_history_data_upload">S3 not initialized - cannot upload history data</string>
+  <string name="error_s3_not_initialized_history_data_download">S3 not initialized - cannot download history data</string>
+  <string name="error_s3_not_initialized_history_data_fetch">S3 not initialized - cannot fetch files</string>
+  <string name="error_location_permission_required">Grant the location permission to use the publisher</string>
+  <string name="error_no_trackable_id">Insert tracking ID</string>
+  <string name="error_publisher_service_not_started">Publisher service not started</string>
+  <string name="error_trackable_adding_failed">Error when adding the trackable</string>
+  <string name="error_trackable_removal_failed">Error when removing the trackable</string>
+  <string name="error_stop_publisher">Stopping publisher error</string>
+  <string name="info_permission_granted">Permission granted</string>
 </resources>

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -57,14 +57,14 @@
   <string name="cannot_stop_service_dialog_title">Publisher still has added trackables</string>
   <string name="cannot_stop_service_dialog_message">The publisher has added trackables. Remove them before stopping the publisher service.</string>
 
-  <string name="error_s3_not_initialized_history_data_upload">S3 not initialized - cannot upload history data</string>
-  <string name="error_s3_not_initialized_history_data_download">S3 not initialized - cannot download history data</string>
-  <string name="error_s3_not_initialized_history_data_fetch">S3 not initialized - cannot fetch files</string>
+  <string name="error_s3_not_initialized_history_data_upload_failed">S3 not initialized - cannot upload history data</string>
+  <string name="error_s3_not_initialized_history_data_download_failed">S3 not initialized - cannot download history data</string>
+  <string name="error_s3_not_initialized_history_data_fetch_failed">S3 not initialized - cannot fetch files</string>
   <string name="error_no_trackable_id">Insert tracking ID</string>
   <string name="error_publisher_service_not_started">Publisher service not started</string>
   <string name="error_trackable_adding_failed">Error when adding the trackable</string>
   <string name="error_trackable_removal_failed">Error when removing the trackable</string>
-  <string name="error_stop_publisher">Stopping publisher error</string>
+  <string name="error_stopping_publisher_failed">Stopping publisher error</string>
   <string name="info_permission_granted">Permission granted</string>
 
   <string name="location_source_phone">Phone</string>

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
@@ -121,12 +122,12 @@ class MainActivity : AppCompatActivity() {
                         showStartedSubscriberLayout()
                         hideLoading()
                     } catch (exception: Exception) {
-                        showToast("Starting subscriber error")
+                        showToast(R.string.error_start_subscriber)
                         hideLoading()
                     }
                 }
             } else {
-                showToast("Insert trackable ID")
+                showToast(R.string.error_no_trackable_id)
             }
         }
     }
@@ -174,7 +175,7 @@ class MainActivity : AppCompatActivity() {
                 resolution = newResolution
                 updateResolutionInfo(newResolution)
             } catch (exception: Exception) {
-                showToast("Changing resolution error")
+                showToast(R.string.error_change_resolution)
             }
         }
     }
@@ -244,7 +245,7 @@ class MainActivity : AppCompatActivity() {
                 hideLoading()
             } catch (exception: Exception) {
                 hideLoading()
-                showToast("Stopping subscriber error")
+                showToast(R.string.error_stop_subscriber)
             }
         }
     }
@@ -299,8 +300,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    private fun showToast(@StringRes stringResourceId: Int) {
+        Toast.makeText(this, stringResourceId, Toast.LENGTH_SHORT).show()
     }
 
     private fun showAssetInformation() {

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -122,7 +122,7 @@ class MainActivity : AppCompatActivity() {
                         showStartedSubscriberLayout()
                         hideLoading()
                     } catch (exception: Exception) {
-                        showToast(R.string.error_start_subscriber)
+                        showToast(R.string.error_starting_subscriber_failed)
                         hideLoading()
                     }
                 }
@@ -175,7 +175,7 @@ class MainActivity : AppCompatActivity() {
                 resolution = newResolution
                 updateResolutionInfo(newResolution)
             } catch (exception: Exception) {
-                showToast(R.string.error_change_resolution)
+                showToast(R.string.error_changing_resolution_failed)
             }
         }
     }
@@ -245,7 +245,7 @@ class MainActivity : AppCompatActivity() {
                 hideLoading()
             } catch (exception: Exception) {
                 hideLoading()
-                showToast(R.string.error_stop_subscriber)
+                showToast(R.string.error_stopping_subscriber_failed)
             }
         }
     }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -300,6 +300,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
     private fun showToast(@StringRes stringResourceId: Int) {
         Toast.makeText(this, stringResourceId, Toast.LENGTH_SHORT).show()
     }

--- a/subscribing-example-app/src/main/res/values/strings.xml
+++ b/subscribing-example-app/src/main/res/values/strings.xml
@@ -14,4 +14,8 @@
   <string name="resolution_minimum_displacement_value">%.1fm</string>
   <string name="resolution_desired_interval">Desired interval</string>
   <string name="resolution_desired_interval_value">%dms</string>
+  <string name="error_start_subscriber">Starting subscriber error</string>
+  <string name="error_stop_subscriber">Stopping subscriber error</string>
+  <string name="error_no_trackable_id">Insert trackable ID</string>
+  <string name="error_change_resolution">Changing resolution error</string>
 </resources>

--- a/subscribing-example-app/src/main/res/values/strings.xml
+++ b/subscribing-example-app/src/main/res/values/strings.xml
@@ -14,8 +14,8 @@
   <string name="resolution_minimum_displacement_value">%.1fm</string>
   <string name="resolution_desired_interval">Desired interval</string>
   <string name="resolution_desired_interval_value">%dms</string>
-  <string name="error_start_subscriber">Starting subscriber error</string>
-  <string name="error_stop_subscriber">Stopping subscriber error</string>
+  <string name="error_starting_subscriber_failed">Starting subscriber error</string>
+  <string name="error_stopping_subscriber_failed">Stopping subscriber error</string>
   <string name="error_no_trackable_id">Insert trackable ID</string>
-  <string name="error_change_resolution">Changing resolution error</string>
+  <string name="error_changing_resolution_failed">Changing resolution error</string>
 </resources>


### PR DESCRIPTION
We should keep all potentially translatable strings in the `strings.xml` resources file to make it easier to localize the app. I've changed the toast helper methods to accept string resource ID to prevent using hardcoded strings in the future.