### PR TITLE
Conform readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Please see `DefaultResolutionPolicy` [implementation](publishing-sdk/src/main/ja
 Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
 
 #### Useful links
+
 - [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
 - [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
 
@@ -199,7 +200,6 @@ We also provide support for applications written in Java, however the requiremen
     - [subscribing-sdk-java](subscribing-sdk-java/) for the [subscribing-sdk](subscribing-sdk/)
 - require Java 1.8 or later
 - require a minimum of Android API Level 24 at runtime
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,7 @@ try {
 
 Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
 
-### Useful Resources
-
+#### Useful links
 - [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
 - [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ val exampleConstraints = DefaultResolutionConstraints(
 ```
 
 These values are then used in the default `ResolutionPolicy`, created by the `DefaultResolutionPolicyFactory`. This default policy implementation uses a simple decision algorithm to determine the `Resolution` for a certain state, relative to proximity threshold, battery threshold and the presence of subscribers.
+
+### Providing a Custom Resolution Policy Implementation
+
+For the greatest flexibility it is possible to provide a custom implementation of the `ResolutionPolicy` interface. In this implementation the application developer can define which logic will be applied to their own parameters, including how resolution is to be determined based on the those parameters and requests from subscribers.
+
+Please see `DefaultResolutionPolicy` [implementation](publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultResolutionPolicyFactory.kt) for an example.
+
 ### Resources
 
 Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
@@ -193,12 +200,6 @@ We also provide support for applications written in Java, however the requiremen
 - require Java 1.8 or later
 - require a minimum of Android API Level 24 at runtime
 
-
-### Providing a Custom Resolution Policy Implementation
-
-For the greatest flexibility it is possible to provide a custom implementation of the `ResolutionPolicy` interface. In this implementation the application developer can define which logic will be applied to their own parameters, including how resolution is to be determined based on the those parameters and requests from subscribers.
-
-Please see `DefaultResolutionPolicy` [implementation](publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultResolutionPolicyFactory.kt) for an example.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ![.github/workflows/emulate.yml](https://github.com/ably/ably-asset-tracking-android/workflows/.github/workflows/emulate.yml/badge.svg)
 ![.github/workflows/assemble.yml](https://github.com/ably/ably-asset-tracking-android/workflows/.github/workflows/assemble.yml/badge.svg)
 
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
+
 ## Overview
 
 Ably Asset Tracking SDKs provide an easy way to track multiple assets with realtime location updates powered by [Ably](https://ably.com/) realtime network and Mapbox [Navigation SDK](https://docs.mapbox.com/android/navigation/overview/) with location enhancement.
@@ -25,14 +27,29 @@ In this repository there are two SDKs for Android devices:
 - the [Asset Publishing SDK](publishing-sdk/)
 - the [Asset Subscribing SDK](subscribing-sdk/)
 
-### Documentation
+## Example Apps
 
-Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
+This repository also contains example apps that showcase how the Ably Asset Tracking SDKs can be used:
 
-### Useful Resources
+- the [Asset Publishing example app](publishing-example-app/)
+- the [Asset Subscribing example app](subscribing-example-app/)
 
-- [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
-- [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
+To build these apps from source you will need to specify credentials in Gradle properties.
+
+The following secrets need to be injected into Gradle by either storing them in `~/.gradle/gradle.properties`, or by using one of [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to do this:
+
+ - `ABLY_API_KEY`: On your [Ably accounts page](https://ably.com/accounts/), select your application, and paste an API Key from the API Keys tab (with relevant capabilities for either subscriber/ publisher). This API key needs the following capabilities: `publish`, `subscribe`, `history` and `presence`.
+ - `MAPBOX_DOWNLOADS_TOKEN`: On the [Mapbox Access Tokens page](https://account.mapbox.com/access-tokens/), create a token with the `DOWNLOADS:READ` secret scope.
+ - `MAPBOX_ACCESS_TOKEN`: On the [Mapbox Access Tokens page](https://account.mapbox.com/access-tokens/), create a token with all public scopes or use the default public token automatically generated for you.
+ - `GOOGLE_MAPS_API_KEY`: Create an API key in Google Cloud, ensuring it has both `Geolocation` and `Maps SDK for Android` API.
+
+To do this, create a file in your home folder if it doesn't exist already, `~/.gradle/gradle.properties`, add the following code, and update the values:
+```bash
+ABLY_API_KEY=get_value_from_ably_dashboard
+MAPBOX_DOWNLOADS_TOKEN=create_token_with_downloads_read_secret_scope
+MAPBOX_ACCESS_TOKEN=create_token_with_all_public_scopes
+GOOGLE_MAPS_API_KEY=create_api_key_with_geolocation_maps_sdk
+```
 
 ## Usage
 
@@ -126,29 +143,14 @@ try {
 }
 ```
 
-## Example Apps
+### Documentation
 
-This repository also contains example apps that showcase how the Ably Asset Tracking SDKs can be used:
+Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
 
-- the [Asset Publishing example app](publishing-example-app/)
-- the [Asset Subscribing example app](subscribing-example-app/)
+### Useful Resources
 
-To build these apps from source you will need to specify credentials in Gradle properties.
-
-The following secrets need to be injected into Gradle by either storing them in `~/.gradle/gradle.properties`, or by using one of [many other ways](https://docs.gradle.org/current/userguide/build_environment.html) to do this:
-
- - `ABLY_API_KEY`: On your [Ably accounts page](https://ably.com/accounts/), select your application, and paste an API Key from the API Keys tab (with relevant capabilities for either subscriber/ publisher). This API key needs the following capabilities: `publish`, `subscribe`, `history` and `presence`.
- - `MAPBOX_DOWNLOADS_TOKEN`: On the [Mapbox Access Tokens page](https://account.mapbox.com/access-tokens/), create a token with the `DOWNLOADS:READ` secret scope.
- - `MAPBOX_ACCESS_TOKEN`: On the [Mapbox Access Tokens page](https://account.mapbox.com/access-tokens/), create a token with all public scopes or use the default public token automatically generated for you.
- - `GOOGLE_MAPS_API_KEY`: Create an API key in Google Cloud, ensuring it has both `Geolocation` and `Maps SDK for Android` API.
-
-To do this, create a file in your home folder if it doesn't exist already, `~/.gradle/gradle.properties`, add the following code, and update the values:
-```bash
-ABLY_API_KEY=get_value_from_ably_dashboard
-MAPBOX_DOWNLOADS_TOKEN=create_token_with_downloads_read_secret_scope
-MAPBOX_ACCESS_TOKEN=create_token_with_all_public_scopes
-GOOGLE_MAPS_API_KEY=create_api_key_with_geolocation_maps_sdk
-```
+- [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
+- [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
 
 ## Android Runtime Requirements
 

--- a/README.md
+++ b/README.md
@@ -143,29 +143,6 @@ try {
 }
 ```
 
-### Resources
-
-Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
-
-#### Useful links
-- [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
-- [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
-
-## Android Runtime Requirements
-
-### Kotlin Users
-
-These SDKs require a minimum of Android API Level 21 at runtime for applications written in Kotlin.
-
-### Java Users
-
-We also provide support for applications written in Java, however the requirements differ in that case:
-- must wrap using the appropriate Java facade for the SDK they are using:
-    - [publishing-sdk-java](publishing-sdk-java/) for the [publishing-sdk](publishing-sdk/)
-    - [subscribing-sdk-java](subscribing-sdk-java/) for the [subscribing-sdk](subscribing-sdk/)
-- require Java 1.8 or later
-- require a minimum of Android API Level 24 at runtime
-
 ## Resolution Policies
 
 In order to provide application developers with flexibility when it comes to choosing their own balance between higher frequency of updates and optimal battery usage, we provide several ways for them to define the logic used to determine the frequency of updates:
@@ -193,6 +170,29 @@ val exampleConstraints = DefaultResolutionConstraints(
 ```
 
 These values are then used in the default `ResolutionPolicy`, created by the `DefaultResolutionPolicyFactory`. This default policy implementation uses a simple decision algorithm to determine the `Resolution` for a certain state, relative to proximity threshold, battery threshold and the presence of subscribers.
+### Resources
+
+Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
+
+#### Useful links
+- [Introducing Ably Asset Tracking - public beta now available](https://ably.com/blog/ably-asset-tracking-beta)
+- [Accurate Delivery Tracking with Navigation SDK + Ably Realtime Network](https://www.mapbox.com/blog/accurate-delivery-tracking)
+
+## Android Runtime Requirements
+
+### Kotlin Users
+
+These SDKs require a minimum of Android API Level 21 at runtime for applications written in Kotlin.
+
+### Java Users
+
+We also provide support for applications written in Java, however the requirements differ in that case:
+- must wrap using the appropriate Java facade for the SDK they are using:
+    - [publishing-sdk-java](publishing-sdk-java/) for the [publishing-sdk](publishing-sdk/)
+    - [subscribing-sdk-java](subscribing-sdk-java/) for the [subscribing-sdk](subscribing-sdk/)
+- require Java 1.8 or later
+- require a minimum of Android API Level 24 at runtime
+
 
 ### Providing a Custom Resolution Policy Implementation
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ try {
 }
 ```
 
-### Documentation
+### Resources
 
 Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) documentation for a complete API reference and code examples.
 


### PR DESCRIPTION
This pull request aims to make Readme file conforming template described in this link
https://github.com/ably/ably-common/blob/main/templates/sdk-readme.md

Some notes 
* Documentation here has more sections here than in the standard template. I did not remove them as it made sense to have those additional sections (as there are subscribing / publishing SDKs)
* Sections are ordered with consideration of their semantics (For example I put resolution policy under "Usage" section as it was related)
* I renamed "Documentation" to "Resources" and changed "Useful resources" to "Useful links". I'm not sure if that's the correct approach but I thought it made sense