### PR TITLE
Send raw locations from the Publisher

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -9,7 +9,7 @@ import com.ably.tracking.common.logging.i
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.common.logging.w
 import com.ably.tracking.common.message.getEnhancedLocationUpdate
-import com.ably.tracking.common.message.toJson
+import com.ably.tracking.common.message.toMessageJson
 import com.ably.tracking.common.message.toMessage
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
@@ -326,7 +326,7 @@ constructor(
     ) {
         val trackableChannel = channels[trackableId]
         if (trackableChannel != null) {
-            val locationUpdateJson = locationUpdate.toJson(gson)
+            val locationUpdateJson = locationUpdate.toMessageJson(gson)
             logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
             try {
                 trackableChannel.publish(
@@ -358,7 +358,7 @@ constructor(
     ) {
         val trackableChannel = channels[trackableId]
         if (trackableChannel != null) {
-            val locationUpdateJson = locationUpdate.toJson(gson)
+            val locationUpdateJson = locationUpdate.toMessageJson(gson)
             logHandler?.d("sendRawLocationMessage: publishing: $locationUpdateJson")
             try {
                 trackableChannel.publish(

--- a/common/src/main/java/com/ably/tracking/common/AblyModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyModels.kt
@@ -8,4 +8,4 @@ enum class PresenceAction {
     PRESENT_OR_ENTER, LEAVE_OR_ABSENT, UPDATE;
 }
 
-data class PresenceData(val type: String, val resolution: Resolution? = null)
+data class PresenceData(val type: String, val resolution: Resolution? = null, val rawLocations: Boolean? = null)

--- a/common/src/main/java/com/ably/tracking/common/Constants.kt
+++ b/common/src/main/java/com/ably/tracking/common/Constants.kt
@@ -15,6 +15,7 @@ const val METERS_PER_KILOMETER = 1000
  */
 object EventNames {
     const val ENHANCED = "enhanced"
+    const val RAW = "raw"
 }
 
 object ClientTypes {

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -18,7 +18,7 @@ fun PresenceDataMessage.toTracking(): PresenceData? =
     type?.let { PresenceData(it, resolution?.toTracking()) }
 
 fun PresenceData.toMessage(): PresenceDataMessage =
-    PresenceDataMessage(type, resolution?.toMessage())
+    PresenceDataMessage(type, resolution?.toMessage(), rawLocations)
 
 fun ResolutionMessage.toTracking(): Resolution =
     Resolution(accuracy.toTracking(), desiredInterval, minimumDisplacement)

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -42,7 +42,7 @@ fun Accuracy.toMessage(): AccuracyMessage = when (this) {
     Accuracy.MAXIMUM -> AccuracyMessage.MAXIMUM
 }
 
-fun LocationUpdate.toJson(gson: Gson): String =
+fun LocationUpdate.toMessageJson(gson: Gson): String =
     gson.toJson(
         LocationUpdateMessage(
             location.toMessage(),
@@ -50,7 +50,7 @@ fun LocationUpdate.toJson(gson: Gson): String =
         )
     )
 
-fun EnhancedLocationUpdate.toJson(gson: Gson): String =
+fun EnhancedLocationUpdate.toMessageJson(gson: Gson): String =
     gson.toJson(
         EnhancedLocationUpdateMessage(
             location.toMessage(),

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.common.message
 import com.ably.tracking.Accuracy
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.Location
+import com.ably.tracking.LocationUpdate
 import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.MILLISECONDS_PER_SECOND
@@ -40,6 +41,14 @@ fun Accuracy.toMessage(): AccuracyMessage = when (this) {
     Accuracy.HIGH -> AccuracyMessage.HIGH
     Accuracy.MAXIMUM -> AccuracyMessage.MAXIMUM
 }
+
+fun LocationUpdate.toJson(gson: Gson): String =
+    gson.toJson(
+        LocationUpdateMessage(
+            location.toMessage(),
+            skippedLocations.map { it.toMessage() },
+        )
+    )
 
 fun EnhancedLocationUpdate.toJson(gson: Gson): String =
     gson.toJson(

--- a/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
@@ -18,7 +18,8 @@ fun LocationMessage.synopsis(): String =
 @Shared
 data class PresenceDataMessage(
     @SerializedName("type") val type: String?,
-    @SerializedName("resolution") val resolution: ResolutionMessage? = null
+    @SerializedName("resolution") val resolution: ResolutionMessage? = null,
+    @SerializedName("rawLocations") val rawLocations: Boolean? = null,
 )
 
 @Shared

--- a/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
@@ -64,6 +64,12 @@ enum class LocationUpdateTypeMessage {
 }
 
 @Shared
+data class LocationUpdateMessage(
+    @SerializedName("location") val location: LocationMessage,
+    @SerializedName("skippedLocations") val skippedLocations: List<LocationMessage>,
+)
+
+@Shared
 data class LocationMessage(
     @SerializedName("type") val type: String,
     @SerializedName("geometry") val geometry: LocationGeometry,

--- a/common/src/test/java/com/ably/tracking/common/PresenceDataTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/PresenceDataTests.kt
@@ -39,7 +39,7 @@ class PresenceDataTests {
     @Test
     fun `parse presence message if presence data is in correct format`() {
         // given
-        val presenceData = gson.toJson(PresenceDataMessage("abc", null))
+        val presenceData = gson.toJson(PresenceDataMessage("abc", null, null))
         val presenceMessage = PresenceMessage(PresenceMessage.Action.enter, clientId, presenceData)
 
         // when
@@ -50,5 +50,6 @@ class PresenceDataTests {
         Assert.assertNotNull(parsedMessage?.data)
         Assert.assertEquals("abc", parsedMessage?.data?.type)
         Assert.assertEquals(null, parsedMessage?.data?.resolution)
+        Assert.assertEquals(null, parsedMessage?.data?.rawLocations)
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -139,7 +139,7 @@ constructor(
     ) {
         launch {
             // state
-            val state = State(routingProfile, policy.resolve(emptySet()))
+            val state = State(routingProfile, policy.resolve(emptySet()), areRawLocationsEnabled)
 
             // processing
             for (event in receiveEventChannel) {
@@ -755,7 +755,8 @@ constructor(
 
     private inner class State(
         routingProfile: RoutingProfile,
-        locationEngineResolution: Resolution
+        locationEngineResolution: Resolution,
+        areRawLocationsEnabled: Boolean?,
     ) {
         private var isDisposed: Boolean = false
         var isStopped: Boolean = false
@@ -795,7 +796,7 @@ constructor(
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
         val requests: MutableMap<String, MutableMap<Subscriber, Resolution>> = mutableMapOf()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
-        var presenceData: PresenceData = PresenceData(ClientTypes.PUBLISHER)
+        var presenceData: PresenceData = PresenceData(ClientTypes.PUBLISHER, rawLocations = areRawLocationsEnabled)
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
         var active: Trackable? = null
             get() = if (isDisposed) throw PublisherStateDisposedException() else field

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -50,8 +50,16 @@ internal fun createCorePublisher(
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
     logHandler: LogHandler?,
+    areRawLocationsEnabled: Boolean?,
 ): CorePublisher {
-    return DefaultCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, logHandler)
+    return DefaultCorePublisher(
+        ably,
+        mapbox,
+        resolutionPolicyFactory,
+        routingProfile,
+        logHandler,
+        areRawLocationsEnabled
+    )
 }
 
 /**
@@ -67,6 +75,7 @@ constructor(
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
     private val logHandler: LogHandler?,
+    private val areRawLocationsEnabled: Boolean?,
 ) : CorePublisher {
     private val scope = CoroutineScope(singleThreadDispatcher + SupervisorJob())
     private val sendEventChannel: SendChannel<Event>
@@ -155,7 +164,9 @@ constructor(
                     }
                     is RawLocationChangedEvent -> {
                         state.lastPublisherLocation = event.location
-                        state.trackables.forEach { processRawLocationUpdate(event, state, it.id) }
+                        if (areRawLocationsEnabled == true) {
+                            state.trackables.forEach { processRawLocationUpdate(event, state, it.id) }
+                        }
                         state.rawLocationChangedCommands.apply {
                             if (isNotEmpty()) {
                                 forEach { command -> command(state) }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -712,7 +712,8 @@ constructor(
             }
         val rawLocationChangedCommands: MutableList<(State) -> Unit> = mutableListOf()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
-        val enhancedLocationsPublishingState: LocationsPublishingState = LocationsPublishingState()
+        val enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationChangedEvent> =
+            LocationsPublishingState()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field
         val duplicateTrackableGuard: DuplicateTrackableGuard = DuplicateTrackableGuard()
             get() = if (isDisposed) throw PublisherStateDisposedException() else field

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -385,7 +385,11 @@ constructor(
                             retrySendingEnhancedLocation(state, event.trackableId, event.locationUpdate)
                         } else {
                             state.enhancedLocationsPublishingState.unmarkMessageAsPending(event.trackableId)
-                            saveLocationForFurtherSending(state, event.trackableId, event.locationUpdate.location)
+                            saveEnhancedLocationForFurtherSending(
+                                state,
+                                event.trackableId,
+                                event.locationUpdate.location
+                            )
                             logHandler?.w(
                                 "Sending location update failed. Location saved for further sending",
                                 event.exception
@@ -432,7 +436,7 @@ constructor(
                 sendEnhancedLocationUpdate(event, state, trackableId)
             }
             else -> {
-                saveLocationForFurtherSending(state, trackableId, event.location)
+                saveEnhancedLocationForFurtherSending(state, trackableId, event.location)
                 processNextWaitingEnhancedLocationUpdate(state, trackableId)
             }
         }
@@ -465,7 +469,7 @@ constructor(
         }
     }
 
-    private fun saveLocationForFurtherSending(state: State, trackableId: String, location: Location) {
+    private fun saveEnhancedLocationForFurtherSending(state: State, trackableId: String, location: Location) {
         state.skippedEnhancedLocations.add(trackableId, location)
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -8,11 +8,11 @@ import com.ably.tracking.LocationUpdate
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.logging.LogHandler
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @SuppressLint("LogConditional")
 internal class DefaultPublisher
@@ -23,6 +23,7 @@ constructor(
     resolutionPolicyFactory: ResolutionPolicy.Factory,
     routingProfile: RoutingProfile,
     logHandler: LogHandler?,
+    areRawLocationsEnabled: Boolean?,
 ) :
     Publisher {
     private val core: CorePublisher
@@ -40,7 +41,14 @@ constructor(
         get() = core.locationHistory
 
     init {
-        core = createCorePublisher(ably, mapbox, resolutionPolicyFactory, routingProfile, logHandler)
+        core = createCorePublisher(
+            ably,
+            mapbox,
+            resolutionPolicyFactory,
+            routingProfile,
+            logHandler,
+            areRawLocationsEnabled
+        )
     }
 
     override suspend fun track(trackable: Trackable): StateFlow<TrackableState> {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationsPublishingState.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.publisher
 /**
  * Class responsible for managing state connected to location updates that are going to or are being published.
  */
-internal class LocationsPublishingState {
+internal class LocationsPublishingState<LocationUpdateEventType> {
     /**
      * The maximum number of retries after a location update is considered to be failed.
      */
@@ -17,7 +17,7 @@ internal class LocationsPublishingState {
     /**
      * Stores location updates that are waiting to be processed, for each trackable independently.
      */
-    private val waitingLocationUpdates: MutableMap<String, MutableList<EnhancedLocationChangedEvent>> = mutableMapOf()
+    private val waitingLocationUpdates: MutableMap<String, MutableList<LocationUpdateEventType>> = mutableMapOf()
 
     /**
      * Stores the number of retries of the current location update, for each trackable independently.
@@ -56,13 +56,13 @@ internal class LocationsPublishingState {
      * Adds the event to the waiting list for the specified trackable.
      *
      * @param trackableId The ID of the trackable.
-     * @param enhancedLocationChangedEvent The event that will be added to waiting list.
+     * @param locationUpdateEvent The event that will be added to waiting list.
      */
-    fun addToWaiting(trackableId: String, enhancedLocationChangedEvent: EnhancedLocationChangedEvent) {
+    fun addToWaiting(trackableId: String, locationUpdateEvent: LocationUpdateEventType) {
         if (waitingLocationUpdates[trackableId] == null) {
             waitingLocationUpdates[trackableId] = mutableListOf()
         }
-        waitingLocationUpdates[trackableId]!!.add(enhancedLocationChangedEvent)
+        waitingLocationUpdates[trackableId]!!.add(locationUpdateEvent)
     }
 
     /**
@@ -71,7 +71,7 @@ internal class LocationsPublishingState {
      * @param trackableId The ID of the trackable.
      * @return The next waiting event or null if no events are waiting.
      */
-    fun getNextWaiting(trackableId: String): EnhancedLocationChangedEvent? =
+    fun getNextWaiting(trackableId: String): LocationUpdateEventType? =
         waitingLocationUpdates[trackableId]?.removeFirstOrNull()
 
     /**

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -7,9 +7,9 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
-import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -199,6 +199,16 @@ interface Publisher {
             notificationProvider: PublisherNotificationProvider,
             notificationId: Int
         ): Builder
+
+        /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Enables sending of raw location updates. This should only be enabled for diagnostics.
+         * In the production environment this should be always disabled.
+         * By default this is disabled.
+         *
+         * @return A new instance of the builder with this property changed.
+         */
+        fun enableRawLocations(): Builder
 
         /**
          * Creates a [Publisher] and starts publishing.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -206,9 +206,10 @@ interface Publisher {
          * In the production environment this should be always disabled.
          * By default this is disabled.
          *
+         * @param enabled Whether the sending of raw location updates is enabled.
          * @return A new instance of the builder with this property changed.
          */
-        fun enableRawLocations(): Builder
+        fun rawLocations(enabled: Boolean): Builder
 
         /**
          * Creates a [Publisher] and starts publishing.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -49,8 +49,8 @@ internal data class PublisherBuilder(
     ): Publisher.Builder =
         this.copy(notificationProvider = notificationProvider, notificationId = notificationId)
 
-    override fun enableRawLocations(): Publisher.Builder =
-        this.copy(areRawLocationsEnabled = true)
+    override fun rawLocations(enabled: Boolean): Publisher.Builder =
+        this.copy(areRawLocationsEnabled = enabled)
 
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -18,7 +18,8 @@ internal data class PublisherBuilder(
     val logHandler: LogHandler? = null,
     val notificationProvider: PublisherNotificationProvider? = null,
     val notificationId: Int? = null,
-    val locationSource: LocationSource? = null
+    val locationSource: LocationSource? = null,
+    val areRawLocationsEnabled: Boolean? = null,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -48,6 +49,9 @@ internal data class PublisherBuilder(
     ): Publisher.Builder =
         this.copy(notificationProvider = notificationProvider, notificationId = notificationId)
 
+    override fun enableRawLocations(): Publisher.Builder =
+        this.copy(areRawLocationsEnabled = true)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -68,6 +72,7 @@ internal data class PublisherBuilder(
             resolutionPolicyFactory!!,
             routingProfile,
             logHandler,
+            areRawLocationsEnabled,
         )
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.publisher
 
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.Location
+import com.ably.tracking.LocationUpdate
 import com.ably.tracking.LocationUpdateType
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.ConnectionStateChange
@@ -70,6 +71,17 @@ internal class ConnectionForTrackableCreatedEvent(
 
 internal data class RawLocationChangedEvent(
     val location: Location,
+) : AdhocEvent()
+
+internal data class SendRawLocationSuccessEvent(
+    val location: Location,
+    val trackableId: String,
+) : AdhocEvent()
+
+internal data class SendRawLocationFailureEvent(
+    val locationUpdate: LocationUpdate,
+    val trackableId: String,
+    val exception: Throwable?,
 ) : AdhocEvent()
 
 internal data class EnhancedLocationChangedEvent(

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -12,6 +12,7 @@ import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationFailure
 import com.ably.tracking.test.common.mockSendEnhancedLocationFailureThenSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
+import com.ably.tracking.test.common.mockSendRawLocationSuccess
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -36,7 +37,7 @@ class CorePublisherLocationUpdatesPublishingTest {
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
 
     @Test
     fun `Should send a message only once if publishing it succeeds`() {
@@ -101,21 +102,75 @@ class CorePublisherLocationUpdatesPublishingTest {
         }
     }
 
+    @Test
+    fun `Should not send raw messages if they are disabled`() {
+        // given
+        val trackableId = UUID.randomUUID().toString()
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+        addTrackable(Trackable(trackableId))
+        ably.mockSendRawLocationSuccess(trackableId)
+
+        // when
+        corePublisher.enqueue(createRawLocationChangedEvent(createLocation()))
+
+        // then
+        runBlocking {
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            stopCorePublisher()
+        }
+        verify(exactly = 0) {
+            ably.sendRawLocation(trackableId, any(), any())
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    @Test
+    fun `Should send raw messages if they are enabled`() {
+        // given
+        val corePublisher =
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true)
+        val trackableId = UUID.randomUUID().toString()
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+        addTrackable(Trackable(trackableId), corePublisher)
+        ably.mockSendRawLocationSuccess(trackableId)
+
+        // when
+        corePublisher.enqueue(createRawLocationChangedEvent(createLocation()))
+
+        // then
+        runBlocking {
+            delay(500) // we're assuming that within this time all events will be processed or at least placed in the queue in the final order
+            stopCorePublisher(corePublisher)
+        }
+        verify(exactly = 1) {
+            ably.sendRawLocation(trackableId, any(), any())
+        }
+    }
+
     private fun createEnhancedLocationChangedEvent(location: Location) =
         EnhancedLocationChangedEvent(location, emptyList(), LocationUpdateType.ACTUAL)
+
+    private fun createRawLocationChangedEvent(location: Location) =
+        RawLocationChangedEvent(location)
 
     private fun mockAllTrackablesResolution(resolution: Resolution) {
         every { resolutionPolicy.resolve(any<TrackableResolutionRequest>()) } returns resolution
     }
 
-    private fun addTrackable(trackable: Trackable) {
+    private fun addTrackable(
+        trackable: Trackable,
+        corePublisher: CorePublisher = this.corePublisher
+    ) {
         ably.mockConnectSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
-            addTrackableToCorePublisher(trackable)
+            addTrackableToCorePublisher(trackable, corePublisher)
         }
     }
 
-    private suspend fun addTrackableToCorePublisher(trackable: Trackable): StateFlow<TrackableState> {
+    private suspend fun addTrackableToCorePublisher(
+        trackable: Trackable,
+        corePublisher: CorePublisher = this.corePublisher
+    ): StateFlow<TrackableState> {
         return suspendCoroutine { continuation ->
             corePublisher.request(
                 AddTrackableEvent(trackable) {
@@ -129,7 +184,7 @@ class CorePublisherLocationUpdatesPublishingTest {
         }
     }
 
-    private suspend fun stopCorePublisher() {
+    private suspend fun stopCorePublisher(corePublisher: CorePublisher = this.corePublisher) {
         suspendCoroutine<Unit> { continuation ->
             corePublisher.request(
                 StopEvent {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -1,0 +1,120 @@
+package com.ably.tracking.publisher
+
+import android.annotation.SuppressLint
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.test.common.mockConnectSuccess
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+@SuppressLint("MissingPermission")
+class CorePublisherPresenceDataTest {
+    private val ably = mockk<Ably>(relaxed = true)
+    private val mapbox = mockk<Mapbox>(relaxed = true)
+    private val resolutionPolicy = mockk<ResolutionPolicy>(relaxed = true)
+    private val resolutionPolicyFactory = object : ResolutionPolicy.Factory {
+        override fun createResolutionPolicy(hooks: ResolutionPolicy.Hooks, methods: ResolutionPolicy.Methods) =
+            resolutionPolicy
+    }
+
+    @Before
+    fun setup() {
+        mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
+    }
+
+    @Test
+    fun `Should se rawMessages to null in the presence data if they are disabled`() {
+        val corePublisher: CorePublisher =
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, null)
+        // given
+        val trackableId = UUID.randomUUID().toString()
+
+        // when
+        addTrackable(Trackable(trackableId), corePublisher)
+
+        // then
+        runBlocking {
+            stopCorePublisher(corePublisher)
+        }
+        val expectedPresenceData = PresenceData(ClientTypes.PUBLISHER, null, null)
+        verify(exactly = 1) {
+            ably.connect(trackableId, expectedPresenceData, any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `Should set rawMessages to true in the presence data if they are enabled`() {
+        val corePublisher: CorePublisher =
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true)
+        // given
+        val trackableId = UUID.randomUUID().toString()
+
+        // when
+        addTrackable(Trackable(trackableId), corePublisher)
+
+        // then
+        runBlocking {
+            stopCorePublisher(corePublisher)
+        }
+        val expectedPresenceData = PresenceData(ClientTypes.PUBLISHER, null, true)
+        verify(exactly = 1) {
+            ably.connect(trackableId, expectedPresenceData, any(), any(), any(), any())
+        }
+    }
+
+    private fun mockAllTrackablesResolution(resolution: Resolution) {
+        every { resolutionPolicy.resolve(any<TrackableResolutionRequest>()) } returns resolution
+    }
+
+    private fun addTrackable(trackable: Trackable, corePublisher: CorePublisher) {
+        ably.mockConnectSuccess(trackable.id)
+        runBlocking(Dispatchers.IO) {
+            addTrackableToCorePublisher(trackable, corePublisher)
+        }
+    }
+
+    private suspend fun addTrackableToCorePublisher(
+        trackable: Trackable,
+        corePublisher: CorePublisher
+    ): StateFlow<TrackableState> {
+        return suspendCoroutine { continuation ->
+            corePublisher.request(
+                AddTrackableEvent(trackable) {
+                    try {
+                        continuation.resume(it.getOrThrow())
+                    } catch (exception: Exception) {
+                        continuation.resumeWithException(exception)
+                    }
+                }
+            )
+        }
+    }
+
+    private suspend fun stopCorePublisher(corePublisher: CorePublisher) {
+        suspendCoroutine<Unit> { continuation ->
+            corePublisher.request(
+                StopEvent {
+                    try {
+                        continuation.resume(it.getOrThrow())
+                    } catch (exception: Exception) {
+                        continuation.resumeWithException(exception)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -112,7 +112,7 @@ class CorePublisherResolutionTest(
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
 
     @Test
     fun `Should send limited location updates`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -27,7 +27,7 @@ class DefaultPublisherTest {
 
     @SuppressLint("MissingPermission")
     private val publisher: Publisher =
-        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null)
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when adding a trackable with subscribing to presence error`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/LocationsPublishingStateTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/LocationsPublishingStateTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class LocationsPublishingStateTest {
     private val trackableId = "test-trackable-id"
-    private lateinit var locationsPublishingState: LocationsPublishingState
+    private lateinit var locationsPublishingState: LocationsPublishingState<EnhancedLocationChangedEvent>
 
     @Before
     fun beforeEach() {

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -77,4 +77,13 @@ fun Ably.mockSendEnhancedLocationFailureThenSuccess(trackableId: String) {
     }
 }
 
+fun Ably.mockSendRawLocationSuccess(trackableId: String) {
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every {
+        sendRawLocation(trackableId, any(), capture(callbackSlot))
+    } answers {
+        callbackSlot.captured(Result.success(Unit))
+    }
+}
+
 private fun anyConnectionException() = ConnectionException(ErrorInformation("Test"))


### PR DESCRIPTION
Enabled sending of the raw locations on the same channel on which the enhanced locations are being sent. The raw locations have all the mechanisms that the enhanced ones have, especially resolution and `skippedLocations`. As the raw locations shouldn't be normally published, there is a new option on the builder that enables the raw locations. The commentary on this method states clearly that this should not be enabled in the production environment. Additionally, information about whether the raw locations are enabled is added to the `PresenceData` of the publisher.