### PR TITLE
Add raw locations to the Subscriber SDK

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -115,6 +115,7 @@ interface Ably {
 
     /**
      * Adds a listener for the raw location updates that are received from the channel.
+     * The raw locations publishing needs to be enabled in the Publisher builder API in order to receive them here.
      * If a channel for the [trackableId] doesn't exist then nothing happens.
      *
      * @param trackableId The ID of the trackable channel.

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -71,6 +71,15 @@ fun Message.getEnhancedLocationUpdate(gson: Gson): EnhancedLocationUpdate =
             )
         }
 
+fun Message.getRawLocationUpdate(gson: Gson): LocationUpdate =
+    gson.fromJson(data as String, LocationUpdateMessage::class.java)
+        .let { message ->
+            LocationUpdate(
+                message.location.toTracking(),
+                message.skippedLocations.map { it.toTracking() },
+            )
+        }
+
 fun LocationUpdateTypeMessage.toTracking(): LocationUpdateType =
     when (this) {
         LocationUpdateTypeMessage.PREDICTED -> LocationUpdateType.PREDICTED

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
@@ -62,13 +62,11 @@ suspend fun createAndStartSubscriber(
     trackingId: String,
     resolution: Resolution = Resolution(Accuracy.BALANCED, 1L, 0.0),
     authentication: Authentication = defaultConnectionConfiguration,
-    rawLocations: Boolean = false,
 ) =
     Subscriber.subscribers()
         .connection(ConnectionConfiguration(authentication))
         .resolution(resolution)
         .trackingId(trackingId)
-        .rawLocations(rawLocations)
         .start()
 
 private fun getLocationData(context: Context): LocationHistoryData {

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/Helpers.kt
@@ -32,6 +32,7 @@ fun createAndStartPublisher(
     resolution: Resolution = Resolution(Accuracy.BALANCED, 1L, 0.0),
     authentication: Authentication = defaultConnectionConfiguration,
     locationData: LocationHistoryData = getLocationData(context),
+    rawLocations: Boolean = false,
     onLocationDataEnded: () -> Unit = {}
 ): Publisher {
     createNotificationChannel(context)
@@ -53,18 +54,21 @@ fun createAndStartPublisher(
             },
             1234
         )
+        .rawLocations(rawLocations)
         .start()
 }
 
 suspend fun createAndStartSubscriber(
     trackingId: String,
     resolution: Resolution = Resolution(Accuracy.BALANCED, 1L, 0.0),
-    authentication: Authentication = defaultConnectionConfiguration
+    authentication: Authentication = defaultConnectionConfiguration,
+    rawLocations: Boolean = false,
 ) =
     Subscriber.subscribers()
         .connection(ConnectionConfiguration(authentication))
         .resolution(resolution)
         .trackingId(trackingId)
+        .rawLocations(rawLocations)
         .start()
 
 private fun getLocationData(context: Context): LocationHistoryData {

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -8,8 +8,10 @@ import com.ably.tracking.subscriber.Subscriber
 import com.ably.tracking.test.android.common.BooleanExpectation
 import com.ably.tracking.test.android.common.UnitExpectation
 import com.ably.tracking.test.android.common.testLogD
+import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -17,7 +19,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class PublisherAndSubscriberTests {
@@ -108,5 +109,54 @@ class PublisherAndSubscriberTests {
                 receivedLocation
             )
         }
+    }
+
+    @Test
+    fun shouldSendRawLocationsWhenTheyAreEnabled() {
+        // given
+        var hasNotReceivedLocationUpdate = true
+        val subscriberReceivedLocationUpdateExpectation = UnitExpectation("subscriber received a location update")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val trackableId = UUID.randomUUID().toString()
+        val scope = CoroutineScope(Dispatchers.Default)
+
+        // when
+        // create subscriber and publisher
+        var subscriber: Subscriber
+        runBlocking {
+            subscriber = createAndStartSubscriber(trackableId, rawLocations = true)
+        }
+
+        val publisher = createAndStartPublisher(context, rawLocations = true)
+
+        // listen for location updates
+        subscriber.rawLocations
+            .onEach {
+                // UnitExpectation throws an error if it's fulfilled more than once so we need to have this check
+                if (hasNotReceivedLocationUpdate) {
+                    hasNotReceivedLocationUpdate = false
+                    subscriberReceivedLocationUpdateExpectation.fulfill()
+                }
+            }
+            .launchIn(scope)
+
+        // start publishing location updates
+        runBlocking {
+            publisher.track(Trackable(trackableId))
+        }
+
+        // await for at least one received location update
+        subscriberReceivedLocationUpdateExpectation.await()
+
+        // cleanup
+        runBlocking {
+            coroutineScope {
+                launch { publisher.stop() }
+                launch { subscriber.stop() }
+            }
+        }
+
+        // then
+        subscriberReceivedLocationUpdateExpectation.assertFulfilled()
     }
 }

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -124,7 +124,7 @@ class PublisherAndSubscriberTests {
         // create subscriber and publisher
         var subscriber: Subscriber
         runBlocking {
-            subscriber = createAndStartSubscriber(trackableId, rawLocations = true)
+            subscriber = createAndStartSubscriber(trackableId)
         }
 
         val publisher = createAndStartPublisher(context, rawLocations = true)

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -4,13 +4,13 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.java.TrackableStateListener
 import com.ably.tracking.subscriber.Subscriber
+import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.future.future
-import java.util.concurrent.CompletableFuture
 
 internal class DefaultSubscriberFacade(
     private val subscriber: Subscriber
@@ -23,6 +23,12 @@ internal class DefaultSubscriberFacade(
 
     override fun addLocationListener(listener: LocationUpdateListener) {
         subscriber.locations
+            .onEach { listener.onLocationUpdate(it) }
+            .launchIn(scope)
+    }
+
+    override fun addRawLocationListener(listener: LocationUpdateListener) {
+        subscriber.rawLocations
             .onEach { listener.onLocationUpdate(it) }
             .launchIn(scope)
     }

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -37,6 +37,13 @@ interface SubscriberFacade : Subscriber {
     fun addLocationListener(listener: LocationUpdateListener)
 
     /**
+     * Adds a handler to be notified when a raw location update is available.
+     *
+     * @param listener The listening function to be notified.
+     */
+    fun addRawLocationListener(listener: LocationUpdateListener)
+
+    /**
      * Adds a handler to be notified when the online state of the trackable changes.
      *
      * @param listener the listening function to be notified.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -37,9 +37,8 @@ internal fun createCoreSubscriber(
     ably: Ably,
     initialResolution: Resolution? = null,
     trackableId: String,
-    areRawLocationsEnabled: Boolean?,
 ): CoreSubscriber {
-    return DefaultCoreSubscriber(ably, initialResolution, trackableId, areRawLocationsEnabled)
+    return DefaultCoreSubscriber(ably, initialResolution, trackableId)
 }
 
 /**
@@ -51,7 +50,6 @@ private class DefaultCoreSubscriber(
     private val ably: Ably,
     private val initialResolution: Resolution?,
     private val trackableId: String,
-    private val areRawLocationsEnabled: Boolean?,
 ) :
     CoreSubscriber {
     private val scope = CoroutineScope(singleThreadDispatcher + SupervisorJob())
@@ -138,9 +136,7 @@ private class DefaultCoreSubscriber(
                     is ConnectionReadyEvent -> {
                         subscribeForChannelState()
                         subscribeForEnhancedEvents()
-                        if (areRawLocationsEnabled == true) {
-                            subscribeForRawEvents()
-                        }
+                        subscribeForRawEvents()
                         event.handler(Result.success(Unit))
                     }
                     is PresenceMessageEvent -> {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -14,7 +14,6 @@ internal class DefaultSubscriber(
     ably: Ably,
     resolution: Resolution?,
     trackableId: String,
-    areRawLocationsEnabled: Boolean?,
 ) : Subscriber {
     private val core: CoreSubscriber
 
@@ -28,7 +27,7 @@ internal class DefaultSubscriber(
         get() = core.trackableStates
 
     init {
-        core = createCoreSubscriber(ably, resolution, trackableId, areRawLocationsEnabled)
+        core = createCoreSubscriber(ably, resolution, trackableId)
     }
 
     /**

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -4,27 +4,31 @@ import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 
 internal class DefaultSubscriber(
     ably: Ably,
     resolution: Resolution?,
-    trackableId: String
+    trackableId: String,
+    areRawLocationsEnabled: Boolean?,
 ) : Subscriber {
     private val core: CoreSubscriber
 
     override val locations: SharedFlow<LocationUpdate>
         get() = core.enhancedLocations
 
+    override val rawLocations: SharedFlow<LocationUpdate>
+        get() = core.rawLocations
+
     override val trackableStates: StateFlow<TrackableState>
         get() = core.trackableStates
 
     init {
-        core = createCoreSubscriber(ably, resolution, trackableId)
+        core = createCoreSubscriber(ably, resolution, trackableId, areRawLocationsEnabled)
     }
 
     /**

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -3,10 +3,10 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
-import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -46,6 +46,13 @@ interface Subscriber {
      * The shared flow emitting enhanced location values when they become available.
      */
     val locations: SharedFlow<LocationUpdate>
+        @JvmSynthetic get
+
+    /**
+     * The shared flow emitting raw location values when they become available.
+     * Raw locations are disabled by default. To enable them use [].
+     */
+    val rawLocations: SharedFlow<LocationUpdate>
         @JvmSynthetic get
 
     /**
@@ -103,6 +110,17 @@ interface Subscriber {
          * @return A new instance of the builder with this property changed.
          */
         fun logHandler(logHandler: LogHandler): Builder
+
+        /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Enables subscribing for raw location updates. This should only be enabled for diagnostics.
+         * In the production environment this should be always disabled.
+         * By default this is disabled.
+         *
+         * @param enabled Whether subscribing for raw location updates is enabled.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun rawLocations(enabled: Boolean): Builder
 
         /**
          * Creates a [Subscriber] and starts listening for location updates.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -112,17 +112,6 @@ interface Subscriber {
         fun logHandler(logHandler: LogHandler): Builder
 
         /**
-         * EXPERIMENTAL API
-         * **OPTIONAL** Enables subscribing for raw location updates. This should only be enabled for diagnostics.
-         * In the production environment this should be always disabled.
-         * By default this is disabled.
-         *
-         * @param enabled Whether subscribing for raw location updates is enabled.
-         * @return A new instance of the builder with this property changed.
-         */
-        fun rawLocations(enabled: Boolean): Builder
-
-        /**
          * Creates a [Subscriber] and starts listening for location updates.
          *
          * @return A new subscriber instance.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -1,16 +1,17 @@
 package com.ably.tracking.subscriber
 
 import com.ably.tracking.BuilderConfigurationIncompleteException
-import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.connection.ConnectionConfiguration
+import com.ably.tracking.logging.LogHandler
 
 internal data class SubscriberBuilder(
     val connectionConfiguration: ConnectionConfiguration? = null,
     val resolution: Resolution? = null,
     val logHandler: LogHandler? = null,
-    val trackingId: String? = null
+    val trackingId: String? = null,
+    val areRawLocationsEnabled: Boolean? = null,
 ) : Subscriber.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Subscriber.Builder =
@@ -25,6 +26,9 @@ internal data class SubscriberBuilder(
     override fun logHandler(logHandler: LogHandler): Subscriber.Builder =
         this.copy(logHandler = logHandler)
 
+    override fun rawLocations(enabled: Boolean): Subscriber.Builder =
+        this.copy(areRawLocationsEnabled = enabled)
+
     override suspend fun start(): Subscriber {
         if (isMissingRequiredFields()) {
             throw BuilderConfigurationIncompleteException()
@@ -33,7 +37,8 @@ internal data class SubscriberBuilder(
         return DefaultSubscriber(
             DefaultAbly(connectionConfiguration!!, logHandler),
             resolution,
-            trackingId!!
+            trackingId!!,
+            areRawLocationsEnabled,
         ).apply {
             start()
         }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -11,7 +11,6 @@ internal data class SubscriberBuilder(
     val resolution: Resolution? = null,
     val logHandler: LogHandler? = null,
     val trackingId: String? = null,
-    val areRawLocationsEnabled: Boolean? = null,
 ) : Subscriber.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Subscriber.Builder =
@@ -26,9 +25,6 @@ internal data class SubscriberBuilder(
     override fun logHandler(logHandler: LogHandler): Subscriber.Builder =
         this.copy(logHandler = logHandler)
 
-    override fun rawLocations(enabled: Boolean): Subscriber.Builder =
-        this.copy(areRawLocationsEnabled = enabled)
-
     override suspend fun start(): Subscriber {
         if (isMissingRequiredFields()) {
             throw BuilderConfigurationIncompleteException()
@@ -38,7 +34,6 @@ internal data class SubscriberBuilder(
             DefaultAbly(connectionConfiguration!!, logHandler),
             resolution,
             trackingId!!,
-            areRawLocationsEnabled,
         ).apply {
             start()
         }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockCreateConnectionSuccess
 import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID
@@ -14,7 +15,7 @@ import org.junit.Test
 class DefaultSubscriberTest {
     private val ably = mockk<Ably>(relaxed = true)
     private val trackableId = UUID.randomUUID().toString()
-    private val subscriber = DefaultSubscriber(ably, null, trackableId)
+    private val subscriber = DefaultSubscriber(ably, null, trackableId, null)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when starting the subscriber with subscribing to presence error`() {
@@ -50,6 +51,52 @@ class DefaultSubscriberTest {
         // then
         verify(exactly = 1) {
             ably.disconnect(trackableId, any(), any())
+        }
+    }
+
+    @Test()
+    fun `should not listen for the raw locations if they are disabled`() {
+        // given
+        val subscriber = DefaultSubscriber(ably, null, trackableId, false)
+        ably.mockCreateConnectionSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
+
+        // when
+        runBlocking {
+            try {
+                subscriber.start()
+            } catch (exception: ConnectionException) {
+                // ignoring exception in this test
+            }
+        }
+
+        // then
+        verify(exactly = 0) {
+            ably.subscribeForRawEvents(trackableId, any())
+        }
+    }
+
+    @Test()
+    fun `should listen for the raw locations if they are enabled`() {
+        // given
+        val subscriber = DefaultSubscriber(ably, null, trackableId, true)
+        ably.mockCreateConnectionSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
+
+        // when
+        runBlocking {
+            try {
+                subscriber.start()
+            } catch (exception: ConnectionException) {
+                // ignoring exception in this test
+            }
+        }
+
+        // then
+        verify(exactly = 1) {
+            ably.subscribeForRawEvents(trackableId, any())
         }
     }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
@@ -5,7 +5,6 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockCreateConnectionSuccess
 import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
-import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID
@@ -15,7 +14,7 @@ import org.junit.Test
 class DefaultSubscriberTest {
     private val ably = mockk<Ably>(relaxed = true)
     private val trackableId = UUID.randomUUID().toString()
-    private val subscriber = DefaultSubscriber(ably, null, trackableId, null)
+    private val subscriber = DefaultSubscriber(ably, null, trackableId)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when starting the subscriber with subscribing to presence error`() {
@@ -51,52 +50,6 @@ class DefaultSubscriberTest {
         // then
         verify(exactly = 1) {
             ably.disconnect(trackableId, any(), any())
-        }
-    }
-
-    @Test()
-    fun `should not listen for the raw locations if they are disabled`() {
-        // given
-        val subscriber = DefaultSubscriber(ably, null, trackableId, false)
-        ably.mockCreateConnectionSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
-        ably.mockSubscribeToPresenceSuccess(trackableId)
-
-        // when
-        runBlocking {
-            try {
-                subscriber.start()
-            } catch (exception: ConnectionException) {
-                // ignoring exception in this test
-            }
-        }
-
-        // then
-        verify(exactly = 0) {
-            ably.subscribeForRawEvents(trackableId, any())
-        }
-    }
-
-    @Test()
-    fun `should listen for the raw locations if they are enabled`() {
-        // given
-        val subscriber = DefaultSubscriber(ably, null, trackableId, true)
-        ably.mockCreateConnectionSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
-        ably.mockSubscribeToPresenceSuccess(trackableId)
-
-        // when
-        runBlocking {
-            try {
-                subscriber.start()
-            } catch (exception: ConnectionException) {
-                // ignoring exception in this test
-            }
-        }
-
-        // then
-        verify(exactly = 1) {
-            ably.subscribeForRawEvents(trackableId, any())
         }
     }
 }


### PR DESCRIPTION
I've enabled listening for raw locations in the Subscriber SDK. I've also added this to the Java facade of Subscriber. Additionally, I've added an integration test that checks if there is a raw data flow between publisher and subscriber.