### PR TITLE
Send raw locations from the publisher example app

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -29,12 +29,14 @@ class AppPreferences private constructor(context: Context) {
         context.getString(R.string.preferences_resolution_desired_interval_key)
     private val RESOLUTION_MINIMUM_DISPLACEMENT_KEY =
         context.getString(R.string.preferences_resolution_minimum_displacement_key)
+    private val SEND_RAW_LOCATIONS_KEY = context.getString(R.string.preferences_send_raw_locations_key)
     private val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
     private val DEFAULT_RESULTION_ACCURACY = Accuracy.BALANCED.name
     private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
+    private val DEFAULT_SEND_RAW_LOCATIONS = false
 
     fun getLocationSource(): LocationSourceType =
         LocationSourceType.valueOf(preferences.getString(LOCATION_SOURCE_KEY, DEFAULT_LOCATION_SOURCE)!!)
@@ -55,4 +57,7 @@ class AppPreferences private constructor(context: Context) {
     fun getResolutionMinimumDisplacement(): Float =
         preferences.getString(RESOLUTION_MINIMUM_DISPLACEMENT_KEY, null)?.toFloat()
             ?: DEFAULT_RESULTION_MINIMUM_DISPLACEMENT
+
+    fun shouldSendRawLocations() =
+        preferences.getBoolean(SEND_RAW_LOCATIONS_KEY, DEFAULT_SEND_RAW_LOCATIONS)
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -118,6 +118,7 @@ class PublisherService : Service() {
                 },
                 NOTIFICATION_ID
             )
+            .rawLocations(appPreferences.shouldSendRawLocations())
             .start()
 
     private fun createDefaultResolution(): Resolution =

--- a/publishing-example-app/src/main/res/layout/switch_preference_layout.xml
+++ b/publishing-example-app/src/main/res/layout/switch_preference_layout.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:paddingHorizontal="@dimen/medium_margin"
+  android:paddingVertical="@dimen/small_margin">
+
+  <TextView
+    android:id="@android:id/title"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="start|center_vertical"
+    android:textColor="@color/black"
+    android:textSize="16sp"
+    tools:text="Preference title" />
+
+  <androidx.appcompat.widget.SwitchCompat
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="end|center_vertical" />
+
+</FrameLayout>

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
   <string name="preferences_resolution_minimum_displacement_label">Minimum displacement</string>
   <string name="preferences_update_resolution_minimum_displacement_message">Minimum Displacement [m]</string>
   <string name="preferences_update_resolution_minimum_displacement_title">Set Minimum Displacement</string>
+  <string name="preferences_debug_category_title">Debug</string>
+  <string name="preferences_send_raw_locations_key">send_raw_locations</string>
+  <string name="preferences_send_raw_locations_label">Send raw location updates</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>
   <string name="service_not_started_dialog_title">Publisher service not started</string>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -61,4 +61,16 @@
 
   </PreferenceCategory>
 
+  <PreferenceCategory
+    android:layout="@layout/preference_category_layout"
+    android:title="@string/preferences_debug_category_title">
+
+    <SwitchPreferenceCompat
+      android:defaultValue="false"
+      android:key="@string/preferences_send_raw_locations_key"
+      android:layout="@layout/switch_preference_layout"
+      android:title="@string/preferences_send_raw_locations_label" />
+
+  </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
I've added a switch in the settings that enables or disables raw locations. It is placed under a new `Debug` section to indicate that this is not meant to be used in the production environment. By default raw locations are disabled.
![Screenshot from 2021-11-04 11-15-01](https://user-images.githubusercontent.com/62378170/140297001-f3b88192-fd03-4688-aecf-b00f05348964.png)

