### PR TITLE
Make ably wrapper safer

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -293,11 +293,12 @@ constructor(
                                 callback(Result.failure(reason.toTrackingException()))
                                 // reenter but do not handle reenter results as it will make things more complicated
                                 // for now
-                                channelToRemove.presence.enter(Gson().toJson(presenceData),object :CompletionListener{
-                                    override fun onSuccess() { }
+                                channelToRemove.presence.enter(Gson().toJson(presenceData),
+                                    object : CompletionListener {
+                                        override fun onSuccess() {}
 
-                                    override fun onError(reason: ErrorInfo?) { }
-                                })
+                                        override fun onError(reason: ErrorInfo?) {}
+                                    })
                             }
                         })
                     }

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -9,8 +9,8 @@ import com.ably.tracking.common.logging.i
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.common.logging.w
 import com.ably.tracking.common.message.getEnhancedLocationUpdate
-import com.ably.tracking.common.message.toMessageJson
 import com.ably.tracking.common.message.toMessage
+import com.ably.tracking.common.message.toMessageJson
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import com.google.gson.Gson
@@ -24,15 +24,16 @@ import io.ably.lib.types.ChannelOptions
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Message
 import io.ably.lib.util.Log
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
+import kotlin.collections.HashMap
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * Wrapper for the [AblyRealtime] that's used to interact with the Ably SDK.
@@ -178,7 +179,7 @@ constructor(
 ) : Ably {
     private val gson = Gson()
     private val ably: AblyRealtime
-    private val channels: ConcurrentHashMap<String, Channel> = ConcurrentHashMap()
+    private val channels = Collections.synchronizedMap(HashMap<String,Channel>())
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -270,37 +270,38 @@ constructor(
     }
 
     override fun disconnect(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
-        if (channels.contains(trackableId)) {
-            val channelToRemove = channels[trackableId]!!
-            try {
-                channelToRemove.presence.leave(
-                    gson.toJson(presenceData.toMessage()),
-                    object : CompletionListener {
-                        override fun onSuccess() {
-                            channelToRemove.unsubscribe()
-                            channelToRemove.presence.unsubscribe()
-                            channelToRemove.detach(object : CompletionListener {
-                                override fun onSuccess() {
-                                    channels.remove(trackableId)
-                                    callback(Result.success(Unit))
-                                }
-
-                                override fun onError(reason: ErrorInfo) {
-                                    callback(Result.failure(reason.toTrackingException()))
-                                }
-                            })
-                        }
-
-                        override fun onError(reason: ErrorInfo) {
-                            callback(Result.failure(reason.toTrackingException()))
-                        }
-                    }
-                )
-            } catch (ablyException: AblyException) {
-                callback(Result.failure(ablyException.errorInfo.toTrackingException()))
-            }
-        } else {
+        if (!channels.contains(trackableId)) {
             callback(Result.success(Unit))
+            return
+        }
+
+        val channelToRemove = channels[trackableId]!!
+        try {
+            channelToRemove.presence.leave(
+                gson.toJson(presenceData.toMessage()),
+                object : CompletionListener {
+                    override fun onSuccess() {
+                        channelToRemove.detach(object : CompletionListener {
+                            override fun onSuccess() {
+                                channelToRemove.unsubscribe()
+                                channelToRemove.presence.unsubscribe()
+                                channels.remove(trackableId)
+                                callback(Result.success(Unit))
+                            }
+
+                            override fun onError(reason: ErrorInfo) {
+                                callback(Result.failure(reason.toTrackingException()))
+                            }
+                        })
+                    }
+
+                    override fun onError(reason: ErrorInfo) {
+                        callback(Result.failure(reason.toTrackingException()))
+                    }
+                }
+            )
+        } catch (ablyException: AblyException) {
+            callback(Result.failure(ablyException.errorInfo.toTrackingException()))
         }
     }
 

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -291,6 +291,11 @@ constructor(
 
                             override fun onError(reason: ErrorInfo) {
                                 callback(Result.failure(reason.toTrackingException()))
+                                // reconnect
+                                connect(trackableId, presenceData) {
+                                    // dealing with connection result will make things more complicated here so leaving
+                                    // it blank
+                                }
                             }
                         })
                     }

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Wrapper for the [AblyRealtime] that's used to interact with the Ably SDK.
@@ -177,7 +178,7 @@ constructor(
 ) : Ably {
     private val gson = Gson()
     private val ably: AblyRealtime
-    private val channels: MutableMap<String, Channel> = mutableMapOf()
+    private val channels: ConcurrentHashMap<String, Channel> = ConcurrentHashMap()
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -291,11 +291,13 @@ constructor(
 
                             override fun onError(reason: ErrorInfo) {
                                 callback(Result.failure(reason.toTrackingException()))
-                                // reconnect
-                                connect(trackableId, presenceData) {
-                                    // dealing with connection result will make things more complicated here so leaving
-                                    // it blank
-                                }
+                                // reenter but do not handle reenter results as it will make things more complicated
+                                // for now
+                                channelToRemove.presence.enter(Gson().toJson(presenceData),object :CompletionListener{
+                                    override fun onSuccess() { }
+
+                                    override fun onError(reason: ErrorInfo?) { }
+                                })
                             }
                         })
                     }

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -179,7 +179,7 @@ constructor(
 ) : Ably {
     private val gson = Gson()
     private val ably: AblyRealtime
-    private val channels = Collections.synchronizedMap(HashMap<String,Channel>())
+    private val channels = Collections.synchronizedMap(HashMap<String, Channel>())
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {
@@ -294,12 +294,14 @@ constructor(
                                 callback(Result.failure(reason.toTrackingException()))
                                 // reenter but do not handle reenter results as it will make things more complicated
                                 // for now
-                                channelToRemove.presence.enter(Gson().toJson(presenceData),
+                                channelToRemove.presence.enter(
+                                    Gson().toJson(presenceData),
                                     object : CompletionListener {
                                         override fun onSuccess() {}
 
                                         override fun onError(reason: ErrorInfo?) {}
-                                    })
+                                    }
+                                )
                             }
                         })
                     }


### PR DESCRIPTION
This pull request aims to improve Ably wrapper (for a little bit) by
* Using a Collections.synchronisedMap to synchronise the underlying map  for channels in order to make it  thread safe
* Moving unsubscription operations to detach success callback to maintain a single point for success.
* Re-enter to presence if detach fails.

For now, reconnection happens with an empty listener. That is because it's solely to undo effect of presence.leave and registering a listener will highly complicate the situation. However it's still not completely safe as reconnection might also fail and thus the channel is in inconsistent state. I think we should aim to reduce the amount of state changing operations to 1 but it does not seem possible for now. 