### PR TITLE
Send resolution data as a part of the location updates

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -47,6 +47,7 @@ fun LocationUpdate.toMessageJson(gson: Gson): String =
         LocationUpdateMessage(
             location.toMessage(),
             skippedLocations.map { it.toMessage() },
+            resolution?.toMessage(),
         )
     )
 
@@ -55,6 +56,7 @@ fun EnhancedLocationUpdate.toMessageJson(gson: Gson): String =
         EnhancedLocationUpdateMessage(
             location.toMessage(),
             skippedLocations.map { it.toMessage() },
+            resolution?.toMessage(),
             intermediateLocations.map { it.toMessage() },
             type.toMessage()
         )
@@ -66,6 +68,7 @@ fun Message.getEnhancedLocationUpdate(gson: Gson): EnhancedLocationUpdate =
             EnhancedLocationUpdate(
                 message.location.toTracking(),
                 message.skippedLocations.map { it.toTracking() },
+                message.resolution?.toTracking(),
                 message.intermediateLocations.map { it.toTracking() },
                 message.type.toTracking()
             )
@@ -77,6 +80,7 @@ fun Message.getRawLocationUpdate(gson: Gson): LocationUpdate =
             LocationUpdate(
                 message.location.toTracking(),
                 message.skippedLocations.map { it.toTracking() },
+                message.resolution?.toTracking(),
             )
         }
 

--- a/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageModels.kt
@@ -51,6 +51,7 @@ enum class AccuracyMessage {
 data class EnhancedLocationUpdateMessage(
     @SerializedName("location") val location: LocationMessage,
     @SerializedName("skippedLocations") val skippedLocations: List<LocationMessage>,
+    @SerializedName("resolution") val resolution: ResolutionMessage?,
     @SerializedName("intermediateLocations") val intermediateLocations: List<LocationMessage>,
     @SerializedName("type") val type: LocationUpdateTypeMessage
 )
@@ -68,6 +69,7 @@ enum class LocationUpdateTypeMessage {
 data class LocationUpdateMessage(
     @SerializedName("location") val location: LocationMessage,
     @SerializedName("skippedLocations") val skippedLocations: List<LocationMessage>,
+    @SerializedName("resolution") val resolution: ResolutionMessage?,
 )
 
 @Shared

--- a/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/LocationUpdateModels.kt
@@ -1,15 +1,19 @@
 package com.ably.tracking
 
-open class LocationUpdate(val location: Location, val skippedLocations: List<Location>) {
+open class LocationUpdate(val location: Location, val skippedLocations: List<Location>, val resolution: Resolution?) {
     override fun equals(other: Any?): Boolean =
         when (other) {
-            is LocationUpdate -> location == other.location && skippedLocations == other.skippedLocations
+            is LocationUpdate ->
+                location == other.location &&
+                    skippedLocations == other.skippedLocations &&
+                    resolution == other.resolution
             else -> false
         }
 
     override fun hashCode(): Int {
         var result = location.hashCode()
         result = 31 * result + skippedLocations.hashCode()
+        result = 31 * result + resolution.hashCode()
         return result
     }
 }
@@ -17,9 +21,10 @@ open class LocationUpdate(val location: Location, val skippedLocations: List<Loc
 class EnhancedLocationUpdate(
     location: Location,
     skippedLocations: List<Location>,
+    resolution: Resolution?,
     val intermediateLocations: List<Location>,
     val type: LocationUpdateType
-) : LocationUpdate(location, skippedLocations) {
+) : LocationUpdate(location, skippedLocations, resolution) {
     override fun equals(other: Any?): Boolean =
         when (other) {
             !super.equals(other) -> false

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -181,6 +181,7 @@ constructor(
                                 EnhancedLocationUpdate(
                                     event.location,
                                     emptyList(),
+                                    null,
                                     event.intermediateLocations,
                                     event.type
                                 )
@@ -496,6 +497,7 @@ constructor(
         val locationUpdate = EnhancedLocationUpdate(
             event.location,
             state.skippedEnhancedLocations.toList(trackableId),
+            state.resolutions[trackableId],
             event.intermediateLocations,
             event.type
         )
@@ -555,6 +557,7 @@ constructor(
         val locationUpdate = LocationUpdate(
             event.location,
             state.skippedRawLocations.toList(trackableId),
+            state.resolutions[trackableId],
         )
         state.rawLocationsPublishingState.markMessageAsPending(trackableId)
         ably.sendRawLocation(trackableId, locationUpdate) {


### PR DESCRIPTION
I've added the resolution data as an optional part of both raw and enhanced location updates.