### PR TITLE
Send resolution data from publisher to subscribers

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.common
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.Resolution
 import com.ably.tracking.common.logging.d
 import com.ably.tracking.common.logging.e
 import com.ably.tracking.common.logging.i
@@ -99,6 +100,21 @@ interface Ably {
     fun sendRawLocation(
         trackableId: String,
         locationUpdate: LocationUpdate,
+        callback: (Result<Unit>) -> Unit
+    )
+
+    /**
+     * Sends a resolution to the channel.
+     * Should be called only when there's an existing channel for the [trackableId].
+     * If a channel for the [trackableId] doesn't exist then it just calls [callback] with success.
+     *
+     * @param trackableId The ID of the trackable channel.
+     * @param resolution The resolution that is sent to the channel.
+     * @param callback The function that will be called when sending completes. If something goes wrong it will be called with [ConnectionException].
+     */
+    fun sendResolution(
+        trackableId: String,
+        resolution: Resolution,
         callback: (Result<Unit>) -> Unit
     )
 
@@ -341,24 +357,14 @@ constructor(
         if (trackableChannel != null) {
             val locationUpdateJson = locationUpdate.toMessageJson(gson)
             logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
-            try {
-                trackableChannel.publish(
-                    Message(EventNames.ENHANCED, locationUpdateJson).apply {
-                        id = "$trackableId${locationUpdate.hashCode()}"
-                    },
-                    object : CompletionListener {
-                        override fun onSuccess() {
-                            callback(Result.success(Unit))
-                        }
-
-                        override fun onError(reason: ErrorInfo) {
-                            callback(Result.failure(reason.toTrackingException()))
-                        }
-                    }
-                )
-            } catch (exception: AblyException) {
-                callback(Result.failure(exception.errorInfo.toTrackingException()))
-            }
+            sendMessage(
+                trackableChannel,
+                trackableId,
+                EventNames.ENHANCED,
+                locationUpdate,
+                locationUpdateJson,
+                callback
+            )
         } else {
             callback(Result.success(Unit))
         }
@@ -373,26 +379,62 @@ constructor(
         if (trackableChannel != null) {
             val locationUpdateJson = locationUpdate.toMessageJson(gson)
             logHandler?.d("sendRawLocationMessage: publishing: $locationUpdateJson")
-            try {
-                trackableChannel.publish(
-                    Message(EventNames.RAW, locationUpdateJson).apply {
-                        id = "$trackableId${locationUpdate.hashCode()}"
-                    },
-                    object : CompletionListener {
-                        override fun onSuccess() {
-                            callback(Result.success(Unit))
-                        }
-
-                        override fun onError(reason: ErrorInfo) {
-                            callback(Result.failure(reason.toTrackingException()))
-                        }
-                    }
-                )
-            } catch (exception: AblyException) {
-                callback(Result.failure(exception.errorInfo.toTrackingException()))
-            }
+            sendMessage(
+                trackableChannel,
+                trackableId,
+                EventNames.RAW,
+                locationUpdate,
+                locationUpdateJson,
+                callback
+            )
         } else {
             callback(Result.success(Unit))
+        }
+    }
+
+    override fun sendResolution(trackableId: String, resolution: Resolution, callback: (Result<Unit>) -> Unit) {
+        val trackableChannel = channels[trackableId]
+        if (trackableChannel != null) {
+            val resolutionJson = resolution.toMessageJson(gson)
+            logHandler?.d("sendResolution: publishing: $resolutionJson")
+            sendMessage(
+                trackableChannel,
+                trackableId,
+                EventNames.RESOLUTION,
+                resolution,
+                resolutionJson,
+                callback
+            )
+        } else {
+            callback(Result.success(Unit))
+        }
+    }
+
+    private fun sendMessage(
+        channel: Channel,
+        trackableId: String,
+        eventName: String,
+        messageObject: Any,
+        messageJson: String,
+        callback: (Result<Unit>) -> Unit
+    ) {
+        try {
+            channel.publish(
+                Message(eventName, messageJson).apply {
+                    id = "$trackableId${messageObject.hashCode()}"
+                },
+                object : CompletionListener {
+                    override fun onSuccess() {
+                        callback(Result.success(Unit))
+                    }
+
+                    override fun onError(reason: ErrorInfo) {
+                        callback(Result.failure(reason.toTrackingException()))
+                    }
+                }
+            )
+        } catch (exception: AblyException) {
+            callback(Result.failure(exception.errorInfo.toTrackingException()))
         }
     }
 

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -372,10 +372,9 @@ constructor(
             logHandler?.d("sendEnhancedLocationMessage: publishing: $locationUpdateJson")
             sendMessage(
                 trackableChannel,
-                trackableId,
-                EventNames.ENHANCED,
-                locationUpdate,
-                locationUpdateJson,
+                Message(EventNames.ENHANCED, locationUpdateJson).apply {
+                    id = "$trackableId${locationUpdate.hashCode()}"
+                },
                 callback
             )
         } else {
@@ -394,10 +393,9 @@ constructor(
             logHandler?.d("sendRawLocationMessage: publishing: $locationUpdateJson")
             sendMessage(
                 trackableChannel,
-                trackableId,
-                EventNames.RAW,
-                locationUpdate,
-                locationUpdateJson,
+                Message(EventNames.RAW, locationUpdateJson).apply {
+                    id = "$trackableId${locationUpdate.hashCode()}"
+                },
                 callback
             )
         } else {
@@ -412,10 +410,7 @@ constructor(
             logHandler?.d("sendResolution: publishing: $resolutionJson")
             sendMessage(
                 trackableChannel,
-                trackableId,
-                EventNames.RESOLUTION,
-                resolution,
-                resolutionJson,
+                Message(EventNames.RESOLUTION, resolutionJson),
                 callback
             )
         } else {
@@ -423,19 +418,10 @@ constructor(
         }
     }
 
-    private fun sendMessage(
-        channel: Channel,
-        trackableId: String,
-        eventName: String,
-        messageObject: Any,
-        messageJson: String,
-        callback: (Result<Unit>) -> Unit
-    ) {
+    private fun sendMessage(channel: Channel, message: Message?, callback: (Result<Unit>) -> Unit) {
         try {
             channel.publish(
-                Message(eventName, messageJson).apply {
-                    id = "$trackableId${messageObject.hashCode()}"
-                },
+                message,
                 object : CompletionListener {
                     override fun onSuccess() {
                         callback(Result.success(Unit))

--- a/common/src/main/java/com/ably/tracking/common/Constants.kt
+++ b/common/src/main/java/com/ably/tracking/common/Constants.kt
@@ -16,6 +16,7 @@ const val METERS_PER_KILOMETER = 1000
 object EventNames {
     const val ENHANCED = "enhanced"
     const val RAW = "raw"
+    const val RESOLUTION = "resolution"
 }
 
 object ClientTypes {

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -83,6 +83,9 @@ fun Message.getRawLocationUpdate(gson: Gson): LocationUpdate =
             )
         }
 
+fun Message.getResolution(gson: Gson): Resolution =
+    gson.fromJson(data as String, ResolutionMessage::class.java).toTracking()
+
 fun LocationUpdateTypeMessage.toTracking(): LocationUpdateType =
     when (this) {
         LocationUpdateTypeMessage.PREDICTED -> LocationUpdateType.PREDICTED

--- a/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
+++ b/common/src/main/java/com/ably/tracking/common/message/MessageMappers.kt
@@ -26,6 +26,9 @@ fun ResolutionMessage.toTracking(): Resolution =
 fun Resolution.toMessage(): ResolutionMessage =
     ResolutionMessage(accuracy.toMessage(), desiredInterval, minimumDisplacement)
 
+fun Resolution.toMessageJson(gson: Gson): String =
+    gson.toJson(this.toMessage())
+
 fun AccuracyMessage.toTracking(): Accuracy = when (this) {
     AccuracyMessage.MINIMUM -> Accuracy.MINIMUM
     AccuracyMessage.LOW -> Accuracy.LOW

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -24,6 +24,7 @@ constructor(
     routingProfile: RoutingProfile,
     logHandler: LogHandler?,
     areRawLocationsEnabled: Boolean?,
+    sendResolutionEnabled: Boolean,
 ) :
     Publisher {
     private val core: CorePublisher
@@ -47,7 +48,8 @@ constructor(
             resolutionPolicyFactory,
             routingProfile,
             logHandler,
-            areRawLocationsEnabled
+            areRawLocationsEnabled,
+            sendResolutionEnabled,
         )
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -212,6 +212,17 @@ interface Publisher {
         fun rawLocations(enabled: Boolean): Builder
 
         /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Enables sending of calculated resolutions. This should only be enabled for diagnostics.
+         * In the production environment this should be always disabled.
+         * By default this is disabled.
+         *
+         * @param enabled Whether the sending of calculated resolutions is enabled.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun sendResolution(enabled: Boolean): Builder
+
+        /**
          * Creates a [Publisher] and starts publishing.
          *
          * The returned publisher instance does not start in a state whereby it is actively tracking anything. If

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -20,6 +20,7 @@ internal data class PublisherBuilder(
     val notificationId: Int? = null,
     val locationSource: LocationSource? = null,
     val areRawLocationsEnabled: Boolean? = null,
+    val sendResolutionEnabled: Boolean = false,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -52,6 +53,9 @@ internal data class PublisherBuilder(
     override fun rawLocations(enabled: Boolean): Publisher.Builder =
         this.copy(areRawLocationsEnabled = enabled)
 
+    override fun sendResolution(enabled: Boolean): Publisher.Builder =
+        this.copy(sendResolutionEnabled = enabled)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -73,6 +77,7 @@ internal data class PublisherBuilder(
             routingProfile,
             logHandler,
             areRawLocationsEnabled,
+            sendResolutionEnabled,
         )
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -37,7 +37,7 @@ class CorePublisherLocationUpdatesPublishingTest {
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
 
     @Test
     fun `Should send a message only once if publishing it succeeds`() {
@@ -128,7 +128,7 @@ class CorePublisherLocationUpdatesPublishingTest {
     fun `Should send raw messages if they are enabled`() {
         // given
         val corePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false)
         val trackableId = UUID.randomUUID().toString()
         mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
         addTrackable(Trackable(trackableId), corePublisher)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -39,7 +39,7 @@ class CorePublisherPresenceDataTest {
     @Test
     fun `Should se rawMessages to null in the presence data if they are disabled`() {
         val corePublisher: CorePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, null)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, null, false)
         // given
         val trackableId = UUID.randomUUID().toString()
 
@@ -59,7 +59,7 @@ class CorePublisherPresenceDataTest {
     @Test
     fun `Should set rawMessages to true in the presence data if they are enabled`() {
         val corePublisher: CorePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false)
         // given
         val trackableId = UUID.randomUUID().toString()
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -112,7 +112,7 @@ class CorePublisherResolutionTest(
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
 
     @Test
     fun `Should send limited location updates`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -29,7 +29,7 @@ class DefaultPublisherTest {
 
     @SuppressLint("MissingPermission")
     private val publisher: Publisher =
-        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false)
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when adding a trackable with subscribing to presence error`() {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -31,6 +31,7 @@ internal interface CoreSubscriber {
     val enhancedLocations: SharedFlow<LocationUpdate>
     val rawLocations: SharedFlow<LocationUpdate>
     val trackableStates: StateFlow<TrackableState>
+    val resolutions: SharedFlow<Resolution>
 }
 
 internal fun createCoreSubscriber(
@@ -57,6 +58,7 @@ private class DefaultCoreSubscriber(
     private val _trackableStates: MutableStateFlow<TrackableState> = MutableStateFlow(TrackableState.Offline())
     private val _enhancedLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
     private val _rawLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
+    private val _resolutions: MutableSharedFlow<Resolution> = MutableSharedFlow(replay = 1)
 
     override val enhancedLocations: SharedFlow<LocationUpdate>
         get() = _enhancedLocations.asSharedFlow()
@@ -66,6 +68,9 @@ private class DefaultCoreSubscriber(
 
     override val trackableStates: StateFlow<TrackableState>
         get() = _trackableStates.asStateFlow()
+
+    override val resolutions: SharedFlow<Resolution>
+        get() = _resolutions.asSharedFlow()
 
     init {
         val channel = Channel<Event>()
@@ -137,6 +142,7 @@ private class DefaultCoreSubscriber(
                         subscribeForChannelState()
                         subscribeForEnhancedEvents()
                         subscribeForRawEvents()
+                        subscribeForResolutionEvents()
                         event.handler(Result.success(Unit))
                     }
                     is PresenceMessageEvent -> {
@@ -218,6 +224,12 @@ private class DefaultCoreSubscriber(
     private fun subscribeForRawEvents() {
         ably.subscribeForRawEvents(trackableId) {
             scope.launch { _rawLocations.emit(it) }
+        }
+    }
+
+    private fun subscribeForResolutionEvents() {
+        ably.subscribeForResolutionEvents(trackableId) {
+            scope.launch { _resolutions.emit(it) }
         }
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -26,6 +26,9 @@ internal class DefaultSubscriber(
     override val trackableStates: StateFlow<TrackableState>
         get() = core.trackableStates
 
+    override val resolutions: StateFlow<Resolution>
+        get() = core.resolutions
+
     init {
         core = createCoreSubscriber(ably, resolution, trackableId)
     }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -26,7 +26,7 @@ internal class DefaultSubscriber(
     override val trackableStates: StateFlow<TrackableState>
         get() = core.trackableStates
 
-    override val resolutions: StateFlow<Resolution>
+    override val resolutions: SharedFlow<Resolution>
         get() = core.resolutions
 
     init {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -50,7 +50,7 @@ interface Subscriber {
 
     /**
      * The shared flow emitting raw location values when they become available.
-     * Raw locations are disabled by default. To enable them use [].
+     * Raw locations are disabled by default. You need to enable them in the Publishing SDK.
      */
     val rawLocations: SharedFlow<LocationUpdate>
         @JvmSynthetic get
@@ -59,6 +59,13 @@ interface Subscriber {
      * The shared flow emitting values when the state of the trackable changes.
      */
     val trackableStates: StateFlow<TrackableState>
+        @JvmSynthetic get
+
+    /**
+     * The shared flow emitting resolution values when they become available.
+     * Resolutions are disabled by default. You need to enable them in the Publishing SDK.
+     */
+    val resolutions: SharedFlow<Resolution>
         @JvmSynthetic get
 
     /**


### PR DESCRIPTION
We've decided that we will send the calculated resolution as separate messages on the same channel that is used to send location update messages. This should serve as a debug feature, therefore, you have to enable it in the publisher's builder to make it work. As this is a debug feature, I've not implemented any retry or sending of failed resolutions mechanisms, to keep things simple.