### PR TITLE
Show publisher's resolution in the subscriber example app

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -30,6 +30,7 @@ class AppPreferences private constructor(context: Context) {
     private val RESOLUTION_MINIMUM_DISPLACEMENT_KEY =
         context.getString(R.string.preferences_resolution_minimum_displacement_key)
     private val SEND_RAW_LOCATIONS_KEY = context.getString(R.string.preferences_send_raw_locations_key)
+    private val SEND_RESOLUTION_KEY = context.getString(R.string.preferences_send_resolution_key)
     private val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
@@ -37,6 +38,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
     private val DEFAULT_SEND_RAW_LOCATIONS = false
+    private val DEFAULT_SEND_RESOLUTION = false
 
     fun getLocationSource(): LocationSourceType =
         LocationSourceType.valueOf(preferences.getString(LOCATION_SOURCE_KEY, DEFAULT_LOCATION_SOURCE)!!)
@@ -60,4 +62,7 @@ class AppPreferences private constructor(context: Context) {
 
     fun shouldSendRawLocations() =
         preferences.getBoolean(SEND_RAW_LOCATIONS_KEY, DEFAULT_SEND_RAW_LOCATIONS)
+
+    fun shouldSendResolution() =
+        preferences.getBoolean(SEND_RESOLUTION_KEY, DEFAULT_SEND_RESOLUTION)
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -119,6 +119,7 @@ class PublisherService : Service() {
                 NOTIFICATION_ID
             )
             .rawLocations(appPreferences.shouldSendRawLocations())
+            .sendResolution(appPreferences.shouldSendResolution())
             .start()
 
     private fun createDefaultResolution(): Resolution =

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
   <string name="preferences_debug_category_title">Debug</string>
   <string name="preferences_send_raw_locations_key">send_raw_locations</string>
   <string name="preferences_send_raw_locations_label">Send raw location updates</string>
+  <string name="preferences_send_resolution_key">send_resolution</string>
+  <string name="preferences_send_resolution_label">Send resolution</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>
   <string name="service_not_started_dialog_title">Publisher service not started</string>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -71,6 +71,12 @@
       android:layout="@layout/switch_preference_layout"
       android:title="@string/preferences_send_raw_locations_label" />
 
+    <SwitchPreferenceCompat
+      android:defaultValue="false"
+      android:key="@string/preferences_send_resolution_key"
+      android:layout="@layout/switch_preference_layout"
+      android:title="@string/preferences_send_resolution_label" />
+
   </PreferenceCategory>
 
 </PreferenceScreen>

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -33,6 +33,9 @@ import kotlinx.android.synthetic.main.activity_main.mapFragment
 import kotlinx.android.synthetic.main.activity_main.rootContainer
 import kotlinx.android.synthetic.main.asset_information_view.animationSwitch
 import kotlinx.android.synthetic.main.asset_information_view.assetStateTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionAccuracyTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionDisplacementTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionIntervalTextView
 import kotlinx.android.synthetic.main.asset_information_view.resolutionAccuracyTextView
 import kotlinx.android.synthetic.main.asset_information_view.resolutionDisplacementTextView
 import kotlinx.android.synthetic.main.asset_information_view.resolutionIntervalTextView
@@ -160,6 +163,9 @@ class MainActivity : AppCompatActivity() {
                 trackableStates
                     .onEach { updateAssetState(it) }
                     .launchIn(scope)
+                resolutions
+                    .onEach { updatePublisherResolutionInfo(it) }
+                    .launchIn(scope)
             }
     }
 
@@ -211,10 +217,22 @@ class MainActivity : AppCompatActivity() {
             getString(R.string.resolution_desired_interval_value, resolution.desiredInterval)
     }
 
-    private fun clearResolutionInfo() {
+    private fun updatePublisherResolutionInfo(resolution: Resolution) {
+        publisherResolutionAccuracyTextView.text =
+            resolution.accuracy.name.lowercase().replaceFirstChar { it.uppercase() }
+        publisherResolutionDisplacementTextView.text =
+            getString(R.string.resolution_minimum_displacement_value, resolution.minimumDisplacement)
+        publisherResolutionIntervalTextView.text =
+            getString(R.string.resolution_desired_interval_value, resolution.desiredInterval)
+    }
+
+    private fun clearResolutionsInfo() {
         resolutionAccuracyTextView.text = ""
         resolutionDisplacementTextView.text = ""
         resolutionIntervalTextView.text = ""
+        publisherResolutionAccuracyTextView.text = ""
+        publisherResolutionDisplacementTextView.text = ""
+        publisherResolutionIntervalTextView.text = ""
     }
 
     private fun updateAssetState(trackableState: TrackableState) {
@@ -354,7 +372,7 @@ class MainActivity : AppCompatActivity() {
         googleMap?.setOnCameraIdleListener { }
         hideAssetInformation()
         trackableIdEditText.isEnabled = true
-        clearResolutionInfo()
+        clearResolutionsInfo()
         changeStartButtonText(false)
     }
 

--- a/subscribing-example-app/src/main/res/layout/activity_main.xml
+++ b/subscribing-example-app/src/main/res/layout/activity_main.xml
@@ -34,16 +34,16 @@
     android:visibility="gone" />
 
   <include
+    android:id="@+id/controlsContainer"
+    layout="@layout/trackable_input_controls_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+
+  <include
     android:id="@+id/assetInformationContainer"
     layout="@layout/asset_information_view"
     android:layout_width="match_parent"
     android:layout_height="@dimen/asset_information_container_height"
     android:visibility="gone" />
-
-  <include
-    android:id="@+id/controlsContainer"
-    layout="@layout/trackable_input_controls_view"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
 
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/subscribing-example-app/src/main/res/layout/activity_main.xml
+++ b/subscribing-example-app/src/main/res/layout/activity_main.xml
@@ -39,11 +39,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />
 
+  <androidx.constraintlayout.widget.Guideline
+    android:id="@+id/collapsedInformationContainerGuideline"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"/>
+
   <include
     android:id="@+id/assetInformationContainer"
     layout="@layout/asset_information_view"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/asset_information_container_height"
+    android:layout_height="@dimen/asset_information_container_full_height"
     android:visibility="gone" />
 
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/subscribing-example-app/src/main/res/layout/asset_information_view.xml
+++ b/subscribing-example-app/src/main/res/layout/asset_information_view.xml
@@ -65,16 +65,28 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
+    android:id="@+id/subscriberResolutionTitleTextView"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/medium_margin"
+    android:layout_marginTop="10dp"
+    android:text="@string/subscriber_resolution_title"
+    android:textColor="@color/asset_information_label"
+    android:textStyle="bold"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/assetStateLabelTextView" />
+
+  <TextView
     android:id="@+id/resolutionAccuracyLabelTextView"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:layout_marginTop="22dp"
+    android:layout_marginTop="5dp"
     android:text="@string/resolution_accuracy"
     android:textAlignment="center"
     android:textColor="@color/asset_information_label"
     app:layout_constraintEnd_toStartOf="@id/resolutionDisplacementLabelTextView"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/assetStateLabelTextView" />
+    app:layout_constraintTop_toBottomOf="@id/subscriberResolutionTitleTextView" />
 
   <View
     android:id="@+id/accuracyDisplacementDividerView"
@@ -142,6 +154,98 @@
     app:layout_constraintEnd_toEndOf="@id/resolutionIntervalLabelTextView"
     app:layout_constraintStart_toStartOf="@id/resolutionIntervalLabelTextView"
     app:layout_constraintTop_toTopOf="@id/resolutionDisplacementTextView"
+    tools:text="100ms" />
+
+  <TextView
+    android:id="@+id/publisherResolutionTitleTextView"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/medium_margin"
+    android:layout_marginTop="10dp"
+    android:text="@string/publisher_resolution_title"
+    android:textColor="@color/asset_information_label"
+    android:textStyle="bold"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/resolutionAccuracyTextView" />
+
+  <TextView
+    android:id="@+id/publisherResolutionAccuracyLabelTextView"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:text="@string/resolution_accuracy"
+    android:textAlignment="center"
+    android:textColor="@color/asset_information_label"
+    app:layout_constraintEnd_toStartOf="@id/resolutionDisplacementLabelTextView"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/publisherResolutionTitleTextView" />
+
+  <View
+    android:id="@+id/publisherAccuracyDisplacementDividerView"
+    android:layout_width="1dp"
+    android:layout_height="0dp"
+    android:background="@color/asset_information_divider"
+    app:layout_constraintBottom_toBottomOf="@id/publisherResolutionAccuracyTextView"
+    app:layout_constraintEnd_toStartOf="@id/publisherResolutionDisplacementLabelTextView"
+    app:layout_constraintStart_toEndOf="@id/publisherResolutionAccuracyLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherResolutionAccuracyLabelTextView" />
+
+  <TextView
+    android:id="@+id/publisherResolutionDisplacementLabelTextView"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:text="@string/resolution_minimum_displacement"
+    android:textAlignment="center"
+    android:textColor="@color/asset_information_label"
+    app:layout_constraintEnd_toStartOf="@id/publisherResolutionIntervalLabelTextView"
+    app:layout_constraintStart_toEndOf="@id/publisherResolutionAccuracyLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherResolutionAccuracyLabelTextView" />
+
+  <View
+    android:layout_width="1dp"
+    android:layout_height="0dp"
+    android:background="@color/asset_information_divider"
+    app:layout_constraintBottom_toBottomOf="@id/publisherAccuracyDisplacementDividerView"
+    app:layout_constraintEnd_toStartOf="@id/publisherResolutionIntervalLabelTextView"
+    app:layout_constraintStart_toEndOf="@id/publisherResolutionDisplacementLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherAccuracyDisplacementDividerView" />
+
+  <TextView
+    android:id="@+id/publisherResolutionIntervalLabelTextView"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:text="@string/resolution_desired_interval"
+    android:textAlignment="center"
+    android:textColor="@color/asset_information_label"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toEndOf="@id/publisherResolutionDisplacementLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherResolutionAccuracyLabelTextView" />
+
+  <TextView
+    android:id="@+id/publisherResolutionAccuracyTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintEnd_toEndOf="@id/publisherResolutionAccuracyLabelTextView"
+    app:layout_constraintStart_toStartOf="@id/publisherResolutionAccuracyLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherResolutionDisplacementTextView"
+    tools:text="Balanced" />
+
+  <TextView
+    android:id="@+id/publisherResolutionDisplacementTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintEnd_toEndOf="@id/publisherResolutionDisplacementLabelTextView"
+    app:layout_constraintStart_toStartOf="@id/publisherResolutionDisplacementLabelTextView"
+    app:layout_constraintTop_toBottomOf="@id/publisherResolutionDisplacementLabelTextView"
+    tools:text="10.0m" />
+
+  <TextView
+    android:id="@+id/publisherResolutionIntervalTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintEnd_toEndOf="@id/publisherResolutionIntervalLabelTextView"
+    app:layout_constraintStart_toStartOf="@id/publisherResolutionIntervalLabelTextView"
+    app:layout_constraintTop_toTopOf="@id/publisherResolutionDisplacementTextView"
     tools:text="100ms" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/subscribing-example-app/src/main/res/layout/asset_information_view.xml
+++ b/subscribing-example-app/src/main/res/layout/asset_information_view.xml
@@ -3,7 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/asset_information_container_height"
+  android:layout_height="@dimen/asset_information_container_full_height"
   android:background="@color/asset_information_background"
   tools:ignore="Overdraw">
 

--- a/subscribing-example-app/src/main/res/values/dimens.xml
+++ b/subscribing-example-app/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
 <resources>
   <dimen name="medium_margin">16dp</dimen>
   <dimen name="start_button_margin">@dimen/medium_margin</dimen>
-  <dimen name="asset_information_container_full_height">130dp</dimen>
+  <dimen name="asset_information_container_full_height">200dp</dimen>
   <dimen name="asset_information_container_collapsed_height">60dp</dimen>
   <dimen name="header_full_height">57dp</dimen>
   <dimen name="header_collapsed_height">32dp</dimen>

--- a/subscribing-example-app/src/main/res/values/dimens.xml
+++ b/subscribing-example-app/src/main/res/values/dimens.xml
@@ -2,7 +2,8 @@
 <resources>
   <dimen name="medium_margin">16dp</dimen>
   <dimen name="start_button_margin">@dimen/medium_margin</dimen>
-  <dimen name="asset_information_container_height">130dp</dimen>
+  <dimen name="asset_information_container_full_height">130dp</dimen>
+  <dimen name="asset_information_container_collapsed_height">60dp</dimen>
   <dimen name="header_full_height">57dp</dimen>
   <dimen name="header_collapsed_height">32dp</dimen>
   <dimen name="header_logo_collapsed_height">16dp</dimen>

--- a/subscribing-example-app/src/main/res/values/strings.xml
+++ b/subscribing-example-app/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
   <string name="error_stopping_subscriber_failed">Stopping subscriber error</string>
   <string name="error_no_trackable_id">Insert trackable ID</string>
   <string name="error_changing_resolution_failed">Changing resolution error</string>
+    <string name="subscriber_resolution_title">Subscriber\'s requested resolution</string>
+  <string name="publisher_resolution_title">Publisher\'s calculated resolution</string>
 </resources>

--- a/subscribing-example-app/src/main/res/xml/enlarge_map_motion_scene.xml
+++ b/subscribing-example-app/src/main/res/xml/enlarge_map_motion_scene.xml
@@ -37,6 +37,12 @@
       motion:layout_constraintTop_toBottomOf="@id/headerBackground" />
     <!-- ASSET INFORMATION -->
     <Constraint
+      android:id="@+id/collapsedInformationContainerGuideline"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      motion:layout_constraintGuide_end="@dimen/asset_information_container_collapsed_height" />
+    <Constraint
       android:id="@+id/draggingAreaView"
       android:layout_width="match_parent"
       android:layout_height="@dimen/dragging_area_height"
@@ -45,7 +51,7 @@
     <Constraint
       android:id="@+id/assetInformationContainer"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/asset_information_container_height"
+      android:layout_height="@dimen/asset_information_container_full_height"
       motion:layout_constraintBottom_toTopOf="@+id/controlsContainer"
       motion:visibilityMode="ignore" />
     <!-- INPUT CONTROLS -->
@@ -79,6 +85,12 @@
       motion:layout_constraintTop_toBottomOf="@id/headerBackground" />
     <!-- ASSET INFORMATION -->
     <Constraint
+      android:id="@+id/collapsedInformationContainerGuideline"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      motion:layout_constraintGuide_end="@dimen/asset_information_container_collapsed_height" />
+    <Constraint
       android:id="@+id/draggingAreaView"
       android:layout_width="match_parent"
       android:layout_height="@dimen/dragging_area_height"
@@ -86,9 +98,8 @@
     <Constraint
       android:id="@+id/assetInformationContainer"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/asset_information_container_height"
-      motion:layout_constraintBottom_toBottomOf="parent"
-      motion:layout_constraintTop_toBottomOf="parent" />
+      android:layout_height="@dimen/asset_information_container_full_height"
+      motion:layout_constraintTop_toBottomOf="@id/collapsedInformationContainerGuideline" />
     <!-- INPUT CONTROLS -->
     <Constraint
       android:id="@+id/controlsContainer"


### PR DESCRIPTION
To show the publisher's resolution in the subscriber example app, firstly, I had to enable resolution sending in the publisher example app (https://github.com/ably/ably-asset-tracking-android/pull/517/commits/49dab1c8a9398766b2dbc98e87461830501f94ca).
Secondly, I had to make some adjustments to the asset information container collapse animation in the subscriber example app to make it more flexible and handle new data to show (https://github.com/ably/ably-asset-tracking-android/pull/517/commits/c1d1b4fe207107d88bed29e7c81b423d2855fc15).
Additionally, I noticed that a simple ordering change in the XML file would fix views overlapping each other during collapse animation so I did the fix (https://github.com/ably/ably-asset-tracking-android/pull/517/commits/0b4f4dc7e7cf3c7f053391c0a75c834ca03d44bf).
Finally, I was able to display the resolution in the subscriber example app (https://github.com/ably/ably-asset-tracking-android/pull/517/commits/3f85d013dbda9594f6cdb5006821af92cf80a955). The new data is present in the asset information container below the subscriber's resolution. If there is no publisher's resolution then we don't show any values, but the data labels stay.

**Publisher example app settings screen change**
![Screenshot from 2021-11-18 15-58-29](https://user-images.githubusercontent.com/62378170/142441088-8a3c399f-d271-4f81-873f-027ac23c0572.png)

**Subscriber example app changes**
No publisher resolution data
![Screenshot from 2021-11-18 14-28-31](https://user-images.githubusercontent.com/62378170/142441199-786080ce-7eaa-4d0f-b966-52933e04f695.png)

Publisher resolution data received
![Screenshot from 2021-11-18 14-37-42](https://user-images.githubusercontent.com/62378170/142441238-2eeabbc7-553e-4823-a868-8970b7f05a53.png)

Collapsed asset information container
![Screenshot from 2021-11-18 14-37-57](https://user-images.githubusercontent.com/62378170/142441300-c6c97cfb-7690-4dea-a611-a6218c9c2629.png)