### PR TITLE
Add GitHub Packages installation instruction to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,57 @@ GOOGLE_MAPS_API_KEY=create_api_key_with_geolocation_maps_sdk
 
 ### Maven / Gradle Dependencies
 
-We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
-
 Kotlin users will want to add either `publishing-sdk` or `subscribing-sdk`, according to the needs of their project.
 Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
+
+#### GitHub Packages
+We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
+
+To install the dependency you will first need to create a "Personal Access Token" in your GitHub account. The token must have the `read:packages` permission.
+Then use your generated token to authenticate in the AAT GitHub Packages repository:
+
+```gradle
+repositories {
+    maven {
+        name = "Ably Asset Tracking"
+        url = uri("https://maven.pkg.github.com/ably/ably-asset-tracking-android")
+        credentials {
+            username = '<GITHUB_USERNAME>'
+            password = '<GITHUB_PERSONAL_ACCESS_TOKEN>'
+        }
+    }
+}
+```
+
+In order to resolve all AAT dependencies you will also need to authenticate in the Mapbox repository:
+
+```gradle
+repositories {
+    maven {
+        name = "Mapbox"
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+            basic(BasicAuthentication)
+        }
+        credentials {
+            username = '<MAPBOX_USERNAME>'
+            password = '<MAPBOX_DOWNLOADS_TOKEN>'
+        }
+    }
+}
+```
+
+Finally, you can add the AAT dependency in the Gradle build script
+```gradle
+dependencies {
+    // Publishing SDK for publishers
+    implementation 'com.ably.tracking:publishing-sdk:1.0.0-beta.11'
+
+    // Subscribing SDK for subscribers
+    implementation 'com.ably.tracking:subscribing-sdk:1.0.0-beta.11'
+}
+```
 
 ### Publishing SDK
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ See [Android Runtime Requirements](#android-runtime-requirements) for more detai
 
 We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
 
-To install the dependency you will first need to create a "Personal Access Token" in your GitHub account. The token must have the `read:packages` permission.
-Then use your generated token to authenticate in the AAT GitHub Packages repository:
+To install the dependency you will first need to create a "Personal Access Token" in your GitHub account. That token must have the `read:packages` permission.
+Then use your generated token to authenticate with the AAT GitHub Packages repository:
 
 ```gradle
 repositories {

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
 #### GitHub Packages
+
 We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
 
 To install the dependency you will first need to create a "Personal Access Token" in your GitHub account. The token must have the `read:packages` permission.
@@ -97,6 +98,7 @@ repositories {
 ```
 
 Finally, you can add the AAT dependency in the Gradle build script
+
 ```gradle
 dependencies {
     // Publishing SDK for publishers

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ See [Android Runtime Requirements](#android-runtime-requirements) for more detai
 
 We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
 
-To install the dependency you will first need to create a "Personal Access Token" in your GitHub account. That token must have the `read:packages` permission.
-Then use your generated token to authenticate with the AAT GitHub Packages repository:
+To [install the dependency](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package) you will first need to [authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#authenticating-to-github-packages).
+You have to get either a `GITHUB_TOKEN` or a "Personal Access Token" (with the `read:packages` permission).
+Then use that token to authenticate with the AAT GitHub Packages repository:
 
 ```gradle
 repositories {
@@ -73,7 +74,7 @@ repositories {
         url = uri("https://maven.pkg.github.com/ably/ably-asset-tracking-android")
         credentials {
             username = '<GITHUB_USERNAME>'
-            password = '<GITHUB_PERSONAL_ACCESS_TOKEN>'
+            password = '<GITHUB_TOKEN>'
         }
     }
 }


### PR DESCRIPTION
I've added the steps required to add AAT as a dependency in Gradle. It isn't as straightforward as one might think so it's great that we will have this information in our README :wink: