### PR TITLE
Add log statements to publisher SDK

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/logging/TagCreator.kt
+++ b/common/src/main/java/com/ably/tracking/common/logging/TagCreator.kt
@@ -1,0 +1,6 @@
+package com.ably.tracking.common.logging
+
+/**
+ * Creates logging tag based on the name of the [loggingObject]'s class.
+ */
+fun createLoggingTag(loggingObject: Any): String = "[${loggingObject::class.simpleName}]"

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -16,6 +16,8 @@ import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceAction
 import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.createSingleThreadDispatcher
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
 import com.ably.tracking.common.logging.w
 import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
@@ -82,6 +84,7 @@ constructor(
     private val areRawLocationsEnabled: Boolean?,
     private val sendResolutionEnabled: Boolean,
 ) : CorePublisher {
+    private val TAG = createLoggingTag(this)
     private val scope = CoroutineScope(singleThreadDispatcher + SupervisorJob())
     private val sendEventChannel: SendChannel<Event>
     private val _locations = MutableSharedFlow<LocationUpdate>(replay = 1)
@@ -117,10 +120,12 @@ constructor(
         ably.subscribeForAblyStateChange { enqueue(AblyConnectionStateChangeEvent(it)) }
         mapbox.registerLocationObserver(object : LocationUpdatesObserver {
             override fun onRawLocationChanged(rawLocation: Location) {
+                logHandler?.v("$TAG Raw location received: $rawLocation")
                 enqueue(RawLocationChangedEvent(rawLocation))
             }
 
             override fun onEnhancedLocationChanged(enhancedLocation: Location, intermediateLocations: List<Location>) {
+                logHandler?.v("$TAG Enhanced location received: $enhancedLocation")
                 val locationUpdateType =
                     if (intermediateLocations.isEmpty()) LocationUpdateType.ACTUAL else LocationUpdateType.PREDICTED
                 enqueue(EnhancedLocationChangedEvent(enhancedLocation, intermediateLocations, locationUpdateType))
@@ -167,6 +172,7 @@ constructor(
                             System.currentTimeMillis() + event.routeDurationInMilliseconds
                     }
                     is RawLocationChangedEvent -> {
+                        logHandler?.v("$TAG Raw location changed event received ${event.location}")
                         properties.lastPublisherLocation = event.location
                         if (areRawLocationsEnabled == true) {
                             properties.trackables.forEach { processRawLocationUpdate(event, properties, it.id) }
@@ -179,6 +185,7 @@ constructor(
                         }
                     }
                     is EnhancedLocationChangedEvent -> {
+                        logHandler?.v("$TAG Enhanced location changed event received ${event.location}")
                         properties.trackables.forEach { processEnhancedLocationUpdate(event, properties, it.id) }
                         scope.launch {
                             _locations.emit(
@@ -427,16 +434,19 @@ constructor(
                         }
                     }
                     is AblyConnectionStateChangeEvent -> {
+                        logHandler?.v("$TAG Ably connection state changed ${event.connectionStateChange.state}")
                         properties.lastConnectionStateChange = event.connectionStateChange
                         properties.trackables.forEach {
                             updateTrackableState(properties, it.id)
                         }
                     }
                     is ChannelConnectionStateChangeEvent -> {
+                        logHandler?.v("$TAG Trackable ${event.trackableId} connection state changed ${event.connectionStateChange.state}")
                         properties.lastChannelConnectionStateChanges[event.trackableId] = event.connectionStateChange
                         updateTrackableState(properties, event.trackableId)
                     }
                     is SendEnhancedLocationSuccessEvent -> {
+                        logHandler?.v("$TAG Trackable ${event.trackableId} successfully sent enhanced location ${event.location}")
                         properties.enhancedLocationsPublishingState.unmarkMessageAsPending(event.trackableId)
                         properties.lastSentEnhancedLocations[event.trackableId] = event.location
                         properties.skippedEnhancedLocations.clear(event.trackableId)
@@ -444,6 +454,10 @@ constructor(
                         processNextWaitingEnhancedLocationUpdate(properties, event.trackableId)
                     }
                     is SendEnhancedLocationFailureEvent -> {
+                        logHandler?.w(
+                            "$TAG Trackable ${event.trackableId} failed to send enhanced location ${event.locationUpdate.location}",
+                            event.exception
+                        )
                         if (properties.enhancedLocationsPublishingState.shouldRetryPublishing(event.trackableId)) {
                             retrySendingEnhancedLocation(properties, event.trackableId, event.locationUpdate)
                         } else {
@@ -453,20 +467,21 @@ constructor(
                                 event.trackableId,
                                 event.locationUpdate.location
                             )
-                            logHandler?.w(
-                                "Sending location update failed. Location saved for further sending",
-                                event.exception
-                            )
                             processNextWaitingEnhancedLocationUpdate(properties, event.trackableId)
                         }
                     }
                     is SendRawLocationSuccessEvent -> {
+                        logHandler?.v("$TAG Trackable ${event.trackableId} successfully sent raw location ${event.location}")
                         properties.rawLocationsPublishingState.unmarkMessageAsPending(event.trackableId)
                         properties.lastSentRawLocations[event.trackableId] = event.location
                         properties.skippedRawLocations.clear(event.trackableId)
                         processNextWaitingRawLocationUpdate(properties, event.trackableId)
                     }
                     is SendRawLocationFailureEvent -> {
+                        logHandler?.w(
+                            "$TAG Trackable ${event.trackableId} failed to send raw location ${event.locationUpdate.location}",
+                            event.exception
+                        )
                         if (properties.rawLocationsPublishingState.shouldRetryPublishing(event.trackableId)) {
                             retrySendingRawLocation(properties, event.trackableId, event.locationUpdate)
                         } else {
@@ -475,10 +490,6 @@ constructor(
                                 properties,
                                 event.trackableId,
                                 event.locationUpdate.location
-                            )
-                            logHandler?.w(
-                                "Sending raw location update failed. Location saved for further sending",
-                                event.exception
                             )
                             processNextWaitingRawLocationUpdate(properties, event.trackableId)
                         }
@@ -493,6 +504,7 @@ constructor(
         trackableId: String,
         locationUpdate: EnhancedLocationUpdate
     ) {
+        logHandler?.v("$TAG Trackable $trackableId retry sending enhanced location ${locationUpdate.location}")
         properties.enhancedLocationsPublishingState.incrementRetryCount(trackableId)
         sendEnhancedLocationUpdate(
             EnhancedLocationChangedEvent(
@@ -510,8 +522,10 @@ constructor(
         properties: Properties,
         trackableId: String
     ) {
+        logHandler?.v("$TAG Processing enhanced location for trackable: $trackableId. ${event.location}")
         when {
             properties.enhancedLocationsPublishingState.hasPendingMessage(trackableId) -> {
+                logHandler?.v("$TAG Trackable: $trackableId has pending message. Adding enhanced location to waiting ${event.location}")
                 properties.enhancedLocationsPublishingState.addToWaiting(trackableId, event)
             }
             shouldSendLocation(
@@ -530,6 +544,7 @@ constructor(
 
     private fun processNextWaitingEnhancedLocationUpdate(properties: Properties, trackableId: String) {
         properties.enhancedLocationsPublishingState.getNextWaiting(trackableId)?.let {
+            logHandler?.v("$TAG Trackable: $trackableId. Process next waiting enhanced location ${it.location}")
             processEnhancedLocationUpdate(it, properties, trackableId)
         }
     }
@@ -539,6 +554,7 @@ constructor(
         properties: Properties,
         trackableId: String
     ) {
+        logHandler?.v("$TAG Trackable: $trackableId will send enhanced location ${event.location}")
         val locationUpdate = EnhancedLocationUpdate(
             event.location,
             properties.skippedEnhancedLocations.toList(trackableId),
@@ -556,10 +572,12 @@ constructor(
     }
 
     private fun saveEnhancedLocationForFurtherSending(properties: Properties, trackableId: String, location: Location) {
+        logHandler?.v("$TAG Trackable: $trackableId. Put enhanced location to the skippedLocations $location")
         properties.skippedEnhancedLocations.add(trackableId, location)
     }
 
     private fun retrySendingRawLocation(properties: Properties, trackableId: String, locationUpdate: LocationUpdate) {
+        logHandler?.v("$TAG Trackable $trackableId retry sending raw location ${locationUpdate.location}")
         properties.rawLocationsPublishingState.incrementRetryCount(trackableId)
         sendRawLocationUpdate(RawLocationChangedEvent(locationUpdate.location), properties, trackableId)
     }
@@ -569,8 +587,10 @@ constructor(
         properties: Properties,
         trackableId: String
     ) {
+        logHandler?.v("$TAG Processing raw location for trackable: $trackableId. ${event.location}")
         when {
             properties.rawLocationsPublishingState.hasPendingMessage(trackableId) -> {
+                logHandler?.v("$TAG Trackable: $trackableId has pending message. Adding raw location to waiting ${event.location}")
                 properties.rawLocationsPublishingState.addToWaiting(trackableId, event)
             }
             shouldSendLocation(
@@ -589,6 +609,7 @@ constructor(
 
     private fun processNextWaitingRawLocationUpdate(properties: Properties, trackableId: String) {
         properties.rawLocationsPublishingState.getNextWaiting(trackableId)?.let {
+            logHandler?.v("$TAG Trackable: $trackableId. Process next waiting raw location ${it.location}")
             processRawLocationUpdate(it, properties, trackableId)
         }
     }
@@ -598,6 +619,7 @@ constructor(
         properties: Properties,
         trackableId: String
     ) {
+        logHandler?.v("$TAG Trackable: $trackableId will send raw location ${event.location}")
         val locationUpdate = LocationUpdate(
             event.location,
             properties.skippedRawLocations.toList(trackableId),
@@ -613,6 +635,7 @@ constructor(
     }
 
     private fun saveRawLocationForFurtherSending(properties: Properties, trackableId: String, location: Location) {
+        logHandler?.v("$TAG Trackable: $trackableId. Put raw location to the skippedLocations $location")
         properties.skippedRawLocations.add(trackableId, location)
     }
 


### PR DESCRIPTION
I've added a few verbose log statements to the `Mapbox` and `CorePublisher` classes to help us debug issues with location updates.

Here's an example of log output from receiving location to sending it:
```
14:38:00.786 [DefaultMapbox] Enhanced location received from Mapbox: Location[null 37.274426,-121.946426 acc=20 et=+18h22m11s583ms alt=0.0 vel=54.06 bear=10.857853]
14:38:00.786 [DefaultCorePublisher] Enhanced location received: Location(latitude=37.2744264173863, longitude=-121.94642617300786, altitude=0.0, accuracy=20.0, bearing=10.857853, speed=54.06, time=1637761080786)
14:38:00.786 [DefaultCorePublisher] Enhanced location changed event received Location(latitude=37.2744264173863, longitude=-121.94642617300786, altitude=0.0, accuracy=20.0, bearing=10.857853, speed=54.06, time=1637761080786)
14:38:00.786 [DefaultCorePublisher] Processing enhanced location for trackable: xxxxx. Location(latitude=37.2744264173863, longitude=-121.94642617300786, altitude=0.0, accuracy=20.0, bearing=10.857853, speed=54.06, time=1637761080786)
14:38:00.787 [DefaultCorePublisher] Trackable: xxxxx will send enhanced location Location(latitude=37.2744264173863, longitude=-121.94642617300786, altitude=0.0, accuracy=20.0, bearing=10.857853, speed=54.06, time=1637761080786)
14:38:00.788 sendEnhancedLocationMessage: publishing: {"intermediateLocations":[{"geometry":{"coordinates":[-121.94654799999999,37.273921,0.0],"type":"Point"},"properties":{"accuracyHorizontal":0.0,"bearing":10.431928,"speed":0.0,"time":1.637761080128E9},"type":"Feature"}],"location":{"geometry":{"coordinates":[-121.94642617300786,37.2744264173863,0.0],"type":"Point"},"properties":{"accuracyHorizontal":20.0,"bearing":10.857853,"speed":54.06,"time":1.637761080786E9},"type":"Feature"},"skippedLocations":[],"type":"PREDICTED"}

```