### PR TITLE
Fix NPE when converting Ably's ChannelStateChange to AAT's one

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -167,7 +167,7 @@ fun ChannelState.toTracking() = when (this) {
 fun io.ably.lib.realtime.ChannelStateListener.ChannelStateChange.toTracking() =
     ConnectionStateChange(
         this.current.toTracking(),
-        this.reason.toTracking()
+        this.reason?.toTracking()
     )
 
 /**


### PR DESCRIPTION
While working on the additional log statements I've noticed a log with an error. Here's the log:
```
io.ably.lib.realtime.Channel: Unexpected exception calling ChannelStateListener
    java.lang.NullPointerException: this.reason must not be null
        at com.ably.tracking.common.AblyHelpersKt.toTracking(AblyHelpers.kt:170)
        at com.ably.tracking.common.DefaultAbly.subscribeForChannelStateChange$lambda-5$lambda-4(Ably.kt:261)
        at com.ably.tracking.common.DefaultAbly.$r8$lambda$2SV8qDKsM0sB-tG3x2rEJ613YRE(Ably.kt)
        at com.ably.tracking.common.DefaultAbly$$ExternalSyntheticLambda3.onChannelStateChanged(Unknown Source)
        at io.ably.lib.realtime.ChannelBase.apply(ChannelBase.java:570)
        at io.ably.lib.realtime.ChannelBase.apply(ChannelBase.java:47)
        at io.ably.lib.util.EventEmitter.emit(EventEmitter.java:93)
        at io.ably.lib.realtime.ChannelBase.emit(ChannelBase.java:1181)
        at io.ably.lib.realtime.ChannelBase.setState(ChannelBase.java:101)
        at io.ably.lib.realtime.ChannelBase.setState(ChannelBase.java:85)
        at io.ably.lib.realtime.ChannelBase.detachImpl(ChannelBase.java:244)
        at io.ably.lib.realtime.ChannelBase.detachWithTimeout(ChannelBase.java:467)
        at io.ably.lib.realtime.ChannelBase.detach(ChannelBase.java:213)
        at com.ably.tracking.common.DefaultAbly$disconnect$1.onSuccess(Ably.kt:323)
        at io.ably.lib.transport.ConnectionManager$PendingMessageQueue.ack(ConnectionManager.java:1580)
        at io.ably.lib.transport.ConnectionManager.onAck(ConnectionManager.java:1177)
        at io.ably.lib.transport.ConnectionManager.onMessage(ConnectionManager.java:1066)
        at io.ably.lib.transport.WebSocketTransport$WsClient.onMessage(WebSocketTransport.java:161)
        at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:505)
        at org.java_websocket.drafts.Draft_6455.processFrameBinary(Draft_6455.java:835)
        at org.java_websocket.drafts.Draft_6455.processFrame(Draft_6455.java:794)
        at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:381)
        at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:218)
        at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:425)
        at java.lang.Thread.run(Thread.java:761)
```

It turns out that we were trying to parse the `ErrorInfo` from a `ChannelStateChange` and were assuming that it is always non-null but it's not true. Probably because the `ErrorInfo` comes from the Java world of `ably-java` the IDE and all the linting tools weren't complaining about it during compilation, which is a bit disappointing. I've added a simple null check and now it isn't throwing any errors :wink: