### PR TITLE
Add trackable failed worker

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -24,6 +24,7 @@ import com.ably.tracking.publisher.guards.DublicateTrackableGuardImpl
 import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
 import com.ably.tracking.publisher.workerqueue.EventWorkerQueue
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.AddTrackableWorker
 import com.ably.tracking.publisher.workerqueue.workers.ConnectionCreatedWorker
 import kotlinx.coroutines.CoroutineScope
@@ -233,10 +234,13 @@ constructor(
                         )
                     }
                     is AddTrackableFailedEvent -> {
-                        val failureResult = Result.failure<AddTrackableResult>(event.exception)
-                        event.callbackFunction(failureResult)
-                        properties.duplicateTrackableGuard.finishAddingTrackable(event.trackable, failureResult)
-                        properties.trackableRemovalGuard.removeMarked(event.trackable, Result.success(true))
+                        workerQueue.execute(
+                            AddTrackableFailedWorker(
+                                event.trackable,
+                                event.callbackFunction,
+                                event.exception
+                            )
+                        )
                     }
                     is PresenceMessageEvent -> {
                         when (event.presenceMessage.action) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -11,7 +11,7 @@ import com.ably.tracking.common.ResultCallbackFunction
 import kotlinx.coroutines.flow.StateFlow
 
 internal typealias AddTrackableResult = StateFlow<TrackableState>
-internal typealias AddTrackableHandler = ResultCallbackFunction<AddTrackableResult>
+internal typealias AddTrackableCallbackFunction = ResultCallbackFunction<AddTrackableResult>
 
 internal sealed class Event
 
@@ -37,8 +37,8 @@ internal class StopEvent(
  */
 internal class AddTrackableEvent(
     val trackable: Trackable,
-    handler: AddTrackableHandler
-) : Request<StateFlow<TrackableState>>(handler)
+    callbackFunction: AddTrackableCallbackFunction
+) : Request<StateFlow<TrackableState>>(callbackFunction)
 
 /**
  * Failed to add a [Trackable].
@@ -46,9 +46,9 @@ internal class AddTrackableEvent(
  */
 internal class AddTrackableFailedEvent(
     val trackable: Trackable,
-    handler: AddTrackableHandler,
+    callbackFunction: AddTrackableCallbackFunction,
     val exception: Exception,
-) : Request<StateFlow<TrackableState>>(handler)
+) : Request<StateFlow<TrackableState>>(callbackFunction)
 
 /**
  * Track a [Trackable].

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/DublicateTrackableGuard.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/DublicateTrackableGuard.kt
@@ -1,6 +1,6 @@
 package com.ably.tracking.publisher.guards
 
-import com.ably.tracking.publisher.AddTrackableHandler
+import com.ably.tracking.publisher.AddTrackableCallbackFunction
 import com.ably.tracking.publisher.AddTrackableResult
 import com.ably.tracking.publisher.Trackable
 
@@ -11,7 +11,7 @@ internal interface DuplicateTrackableGuard {
     fun startAddingTrackable(trackable: Trackable)
     fun finishAddingTrackable(trackable: Trackable, result: Result<AddTrackableResult>)
     fun isCurrentlyAddingTrackable(trackable: Trackable): Boolean
-    fun saveDuplicateAddHandler(trackable: Trackable, handler: AddTrackableHandler)
+    fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction)
     fun clear(trackable: Trackable)
     fun clearAll()
 }
@@ -29,7 +29,7 @@ internal class DublicateTrackableGuardImpl : DuplicateTrackableGuard {
     /**
      * Stores handlers from trackables that are duplicates of the trackables from [trackablesCurrentlyBeingAdded].
      */
-    private val duplicateAddCallsHandlers: MutableMap<Trackable, MutableList<AddTrackableHandler>> = mutableMapOf()
+    private val duplicateAddCallsHandlers: MutableMap<Trackable, MutableList<AddTrackableCallbackFunction>> = mutableMapOf()
 
     /**
      * Marks that the specified trackable adding process has started.
@@ -68,11 +68,11 @@ internal class DublicateTrackableGuardImpl : DuplicateTrackableGuard {
      * This handler will be called when the original trackable adding process will finish in [finishAddingTrackable].
      *
      * @param trackable The duplicate trackable.
-     * @param handler The handler of the duplicate trackable adding process.
+     * @param callbackFunction The handler of the duplicate trackable adding process.
      */
-    override fun saveDuplicateAddHandler(trackable: Trackable, handler: AddTrackableHandler) {
+    override fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction) {
         val handlers = duplicateAddCallsHandlers[trackable] ?: mutableListOf()
-        handlers.add(handler)
+        handlers.add(callbackFunction)
         duplicateAddCallsHandlers[trackable] = handlers
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.publisher.ConnectionForTrackableCreatedEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class AddTrackableResultHandler : WorkResultHandler {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -1,11 +1,11 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
-import com.ably.tracking.publisher.AddTrackableFailedEvent
 import com.ably.tracking.publisher.ConnectionForTrackableCreatedEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.workerqueue.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.WorkResult
 import com.ably.tracking.publisher.workerqueue.WorkResultHandler
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class AddTrackableResultHandler : WorkResultHandler {
@@ -18,12 +18,11 @@ internal class AddTrackableResultHandler : WorkResultHandler {
                 Result.success(workResult.trackableStateFlow)
             )
 
-            is AddTrackableWorkResult.Fail -> corePublisher.request(
-                AddTrackableFailedEvent(
-                    workResult.trackable,
-                    workResult.callbackFunction, workResult.exception as Exception
+            is AddTrackableWorkResult.Fail ->
+                return AddTrackableFailedWorker(
+                    workResult.trackable, workResult.callbackFunction, workResult.exception as Exception
                 )
-            )
+
             is AddTrackableWorkResult.Success -> corePublisher.request(
                 ConnectionForTrackableCreatedEvent(
                     workResult.trackable,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
-import com.ably.tracking.publisher.AddTrackableFailedEvent
 import com.ably.tracking.publisher.ConnectionForTrackableReadyEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.TrackableRemovalRequestedEvent

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -6,9 +6,6 @@ import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.TrackableRemovalRequestedEvent
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
-import com.ably.tracking.publisher.workerqueue.ConnectionCreatedWorkResult
-import com.ably.tracking.publisher.workerqueue.WorkResult
-import com.ably.tracking.publisher.workerqueue.WorkResultHandler
 import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -1,13 +1,13 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.ConnectionException
-import com.ably.tracking.publisher.AddTrackableFailedEvent
 import com.ably.tracking.publisher.ConnectionForTrackableReadyEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.TrackableRemovalRequestedEvent
 import com.ably.tracking.publisher.workerqueue.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.WorkResult
 import com.ably.tracking.publisher.workerqueue.WorkResultHandler
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class ConnectionCreatedResultHandler : WorkResultHandler {
@@ -29,15 +29,15 @@ internal class ConnectionCreatedResultHandler : WorkResultHandler {
                 )
 
             is ConnectionCreatedWorkResult.PresenceSuccess -> {
-                corePublisher.request(ConnectionForTrackableReadyEvent(workResult.trackable, workResult.callbackFunction))
-            }
-            is ConnectionCreatedWorkResult.PresenceFail -> corePublisher.request(
-                AddTrackableFailedEvent(
-                    workResult.trackable,
-                    workResult.callbackFunction,
-                    workResult.exception
+                corePublisher.request(
+                    ConnectionForTrackableReadyEvent(
+                        workResult.trackable,
+                        workResult.callbackFunction
+                    )
                 )
-            )
+            }
+            is ConnectionCreatedWorkResult.PresenceFail ->
+                return AddTrackableFailedWorker(workResult.trackable, workResult.callbackFunction, workResult.exception)
         }
         return null
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
@@ -1,0 +1,27 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.publisher.AddTrackableCallbackFunction
+import com.ably.tracking.publisher.AddTrackableFailedEvent
+import com.ably.tracking.publisher.AddTrackableResult
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Request
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.SyncAsyncResult
+
+internal class AddTrackableFailedWorker(
+    private val trackable: Trackable,
+    private val callbackFunction: AddTrackableCallbackFunction,
+    val exception: Exception
+) : Worker {
+    override val event: Request<*>
+        get() = AddTrackableFailedEvent(trackable, callbackFunction, exception)
+
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        val failureResult = Result.failure<AddTrackableResult>(exception)
+        callbackFunction(failureResult)
+        properties.duplicateTrackableGuard.finishAddingTrackable(trackable, failureResult)
+        properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
+
+        return SyncAsyncResult()
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
@@ -6,7 +6,7 @@ import com.ably.tracking.publisher.AddTrackableResult
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Request
 import com.ably.tracking.publisher.Trackable
-import com.ably.tracking.publisher.workerqueue.SyncAsyncResult
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 
 internal class AddTrackableFailedWorker(
     private val trackable: Trackable,

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/FakeProperties.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/FakeProperties.kt
@@ -2,7 +2,7 @@ package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.PresenceData
-import com.ably.tracking.publisher.AddTrackableHandler
+import com.ably.tracking.publisher.AddTrackableCallbackFunction
 import com.ably.tracking.publisher.AddTrackableResult
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
@@ -34,7 +34,7 @@ internal class FakeDuplicateGuard(private val currentlyAdding: Boolean) : Duplic
         return currentlyAdding
     }
 
-    override fun saveDuplicateAddHandler(trackable: Trackable, handler: AddTrackableHandler) {
+    override fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction) {
         // does not need implementing
     }
 


### PR DESCRIPTION
This PR contains AddTrackableFailedEvent refactoring 

Please review https://github.com/ably/ably-asset-tracking-android/pull/538 before this one

Note for this particular worker:
In the current implementation, the callback is in the middle of execution, so I didn't find it safe to change the order of operations here to return a result. This implementation will have to change a little so that we provide a work result and work result handler. I have created an issue for this. https://github.com/ably/ably-asset-tracking-android/issues/546