### PR TITLE
Allow to disable the enhanced location predictions in the publisher

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -31,6 +31,7 @@ class AppPreferences private constructor(context: Context) {
         context.getString(R.string.preferences_resolution_minimum_displacement_key)
     private val SEND_RAW_LOCATIONS_KEY = context.getString(R.string.preferences_send_raw_locations_key)
     private val SEND_RESOLUTION_KEY = context.getString(R.string.preferences_send_resolution_key)
+    private val ENABLE_PREDICTIONS_KEY = context.getString(R.string.preferences_send_resolution_key)
     private val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
@@ -39,6 +40,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
     private val DEFAULT_SEND_RAW_LOCATIONS = false
     private val DEFAULT_SEND_RESOLUTION = false
+    private val DEFAULT_ENABLE_PREDICTIONS = true
 
     fun getLocationSource(): LocationSourceType =
         LocationSourceType.valueOf(preferences.getString(LOCATION_SOURCE_KEY, DEFAULT_LOCATION_SOURCE)!!)
@@ -65,4 +67,7 @@ class AppPreferences private constructor(context: Context) {
 
     fun shouldSendResolution() =
         preferences.getBoolean(SEND_RESOLUTION_KEY, DEFAULT_SEND_RESOLUTION)
+
+    fun shouldEnablePredictions() =
+        preferences.getBoolean(ENABLE_PREDICTIONS_KEY, DEFAULT_ENABLE_PREDICTIONS)
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -120,6 +120,7 @@ class PublisherService : Service() {
             )
             .rawLocations(appPreferences.shouldSendRawLocations())
             .sendResolution(appPreferences.shouldSendResolution())
+            .predictions(appPreferences.shouldEnablePredictions())
             .start()
 
     private fun createDefaultResolution(): Resolution =

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
   <string name="preferences_send_raw_locations_label">Send raw location updates</string>
   <string name="preferences_send_resolution_key">send_resolution</string>
   <string name="preferences_send_resolution_label">Send resolution</string>
+  <string name="preferences_enable_predictions_key">enable_predictions</string>
+  <string name="preferences_enable_predictions_label">Enable predictions</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>
   <string name="service_not_started_dialog_title">Publisher service not started</string>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -77,6 +77,12 @@
       android:layout="@layout/switch_preference_layout"
       android:title="@string/preferences_send_resolution_label" />
 
+    <SwitchPreferenceCompat
+      android:defaultValue="true"
+      android:key="@string/preferences_enable_predictions_key"
+      android:layout="@layout/switch_preference_layout"
+      android:title="@string/preferences_enable_predictions_label" />
+
   </PreferenceCategory>
 
 </PreferenceScreen>

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -49,7 +49,8 @@ class MapboxTests {
                         .setSmallIcon(R.drawable.aat_logo)
                         .build()
             },
-            12345
+            12345,
+            true
         )
 
     private fun getLocationData(context: Context): LocationHistoryData {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -153,7 +153,8 @@ internal class DefaultMapbox(
     locationSource: LocationSource? = null,
     private val logHandler: LogHandler?,
     notificationProvider: PublisherNotificationProvider,
-    notificationId: Int
+    notificationId: Int,
+    predictionsEnabled: Boolean,
 ) : Mapbox {
     private val TAG = createLoggingTag(this)
 
@@ -183,6 +184,10 @@ internal class DefaultMapbox(
                     useHistoryDataReplayerLocationEngine(mapboxBuilder, it)
                 }
             }
+        }
+
+        if (!predictionsEnabled) {
+            mapboxBuilder.navigatorPredictionMillis(0L) // Setting this to 0 disables location predictions
         }
 
         runBlocking(mainDispatcher) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -223,6 +223,15 @@ interface Publisher {
         fun sendResolution(enabled: Boolean): Builder
 
         /**
+         * **OPTIONAL** Enables using predictions for enhanced location updates.
+         * By default this is enabled.
+         *
+         * @param enabled Whether the predictions for enhanced locations are enabled.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun predictions(enabled: Boolean): Builder
+
+        /**
          * Creates a [Publisher] and starts publishing.
          *
          * The returned publisher instance does not start in a state whereby it is actively tracking anything. If

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -21,6 +21,7 @@ internal data class PublisherBuilder(
     val locationSource: LocationSource? = null,
     val areRawLocationsEnabled: Boolean? = null,
     val sendResolutionEnabled: Boolean = false,
+    val predictionsEnabled: Boolean = true,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -56,6 +57,9 @@ internal data class PublisherBuilder(
     override fun sendResolution(enabled: Boolean): Publisher.Builder =
         this.copy(sendResolutionEnabled = enabled)
 
+    override fun predictions(enabled: Boolean): Publisher.Builder =
+        this.copy(predictionsEnabled = enabled)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -71,7 +75,8 @@ internal data class PublisherBuilder(
                 locationSource,
                 logHandler,
                 notificationProvider!!,
-                notificationId!!
+                notificationId!!,
+                predictionsEnabled,
             ),
             resolutionPolicyFactory!!,
             routingProfile,


### PR DESCRIPTION
I've added the option to disable the predictions to the `Publisher` builder. To disable the location predictions we need to set the `navigatorPredictionMillis` to `0`.
I've also added a switch to the publisher example app that enables or disables the predictions.