### PR TITLE
Set trackable destination in the publisher example app

### DIFF
--- a/publishing-example-app/src/main/AndroidManifest.xml
+++ b/publishing-example-app/src/main/AndroidManifest.xml
@@ -39,6 +39,10 @@
       android:name=".MapActivity"
       android:screenOrientation="portrait" />
 
+    <activity
+      android:name=".SetDestinationActivity"
+      android:screenOrientation="portrait" />
+
     <service android:name=".PublisherService" />
   </application>
 

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SetDestinationActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SetDestinationActivity.kt
@@ -1,0 +1,117 @@
+// Mapbox has deprecated the Marker class and recommends using the Annotation Plugin
+// but to keep things as simple as possible we're going to still use the Marker approach
+@file:Suppress("DEPRECATION")
+
+package com.ably.tracking.example.publisher
+
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.annotations.Marker
+import com.mapbox.mapboxsdk.annotations.MarkerOptions
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import kotlinx.android.synthetic.main.activity_map.mapView
+import kotlinx.android.synthetic.main.activity_set_destination.acceptDestinationButton
+
+class SetDestinationActivity : AppCompatActivity() {
+    companion object {
+        val EXTRA_LATITUDE = "extra_latitude"
+        val EXTRA_LONGITUDE = "extra_longitude"
+    }
+
+    private var map: MapboxMap? = null
+    private var marker: Marker? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Mapbox.getInstance(this, BuildConfig.MAPBOX_ACCESS_TOKEN)
+        setContentView(R.layout.activity_set_destination)
+        mapView.onCreate(savedInstanceState)
+        setupMap()
+        setupDestinationClickListener()
+    }
+
+    private fun setupMap() {
+        mapView.getMapAsync { mapboxMap ->
+            mapboxMap.setStyle(Style.MAPBOX_STREETS) {
+                mapboxMap.addOnMapClickListener {
+                    showDestinationMarker(it)
+                    enableAcceptDestinationButton()
+                    true
+                }
+                map = mapboxMap
+            }
+        }
+    }
+
+    private fun setupDestinationClickListener() {
+        acceptDestinationButton.setOnClickListener {
+            marker?.position?.let { destinationPosition ->
+                setResult(
+                    RESULT_OK,
+                    Intent().apply {
+                        putExtra(EXTRA_LATITUDE, destinationPosition.latitude)
+                        putExtra(EXTRA_LONGITUDE, destinationPosition.longitude)
+                    }
+                )
+            }
+            finish()
+        }
+    }
+
+    private fun enableAcceptDestinationButton() {
+        acceptDestinationButton.isEnabled = true
+        acceptDestinationButton.backgroundTintList =
+            ColorStateList.valueOf(ContextCompat.getColor(this, R.color.button_active))
+    }
+
+    private fun showDestinationMarker(location: LatLng) {
+        map?.apply {
+            if (marker == null) {
+                marker = addMarker(MarkerOptions().position(location))
+            } else {
+                marker?.position = location
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView?.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView?.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView?.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView?.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView?.onSaveInstanceState(outState)
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView?.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView?.onDestroy()
+    }
+}

--- a/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
+++ b/publishing-example-app/src/main/res/layout/activity_add_trackable.xml
@@ -141,6 +141,73 @@
         android:inputType="text"
         app:layout_constraintTop_toBottomOf="@id/trackableIdLabelTextView"
         tools:text="Here goes test ID" />
+
+      <TextView
+        android:id="@+id/destinationLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/destination"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/trackableIdEditText" />
+
+      <TextView
+        android:id="@+id/latitudeLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:text="@string/latitude_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/destinationLabelTextView" />
+
+      <TextView
+        android:id="@+id/latitudeValueTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:textColor="@color/black"
+        app:layout_constraintBottom_toBottomOf="@+id/latitudeLabelTextView"
+        app:layout_constraintStart_toEndOf="@+id/latitudeLabelTextView"
+        tools:text="10.234" />
+
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/verticalCenterGuideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+      <TextView
+        android:id="@+id/longitudeLabelTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/longitude_label"
+        app:layout_constraintStart_toStartOf="@id/verticalCenterGuideline"
+        app:layout_constraintTop_toTopOf="@+id/latitudeLabelTextView" />
+
+      <TextView
+        android:id="@+id/longitudeValueTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/medium_margin"
+        android:textColor="@color/black"
+        app:layout_constraintBottom_toBottomOf="@+id/longitudeLabelTextView"
+        app:layout_constraintStart_toEndOf="@+id/longitudeLabelTextView"
+        tools:text="51.125" />
+
+      <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/setDestinationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/medium_margin"
+        android:background="@drawable/rounded_rectangle"
+        android:backgroundTint="@color/button_active"
+        android:paddingVertical="@dimen/medium_margin"
+        android:text="Set Destination"
+        android:textColor="@color/mid_grey"
+        app:layout_constraintTop_toBottomOf="@id/longitudeValueTextView" />
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 

--- a/publishing-example-app/src/main/res/layout/activity_set_destination.xml
+++ b/publishing-example-app/src/main/res/layout/activity_set_destination.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <com.mapbox.mapboxsdk.maps.MapView
+    android:id="@+id/mapView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+
+  <androidx.appcompat.widget.AppCompatButton
+    android:id="@+id/acceptDestinationButton"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/medium_margin"
+    android:background="@drawable/rounded_rectangle"
+    android:backgroundTint="@color/button_inactive"
+    android:enabled="false"
+    android:paddingVertical="@dimen/medium_margin"
+    android:text="Accept"
+    android:textColor="@color/mid_grey"
+    app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
   <string name="minimum_displacement_label">Minimum Displacement [m]</string>
   <string name="trackable_section_label">Trackable</string>
   <string name="show_map_button">Show map</string>
+  <string name="destination">Destination:</string>
 
   <string name="preferences_general_category_title">Navigation Settings</string>
   <string name="preferences_location_source_key">location_source</string>


### PR DESCRIPTION
I've added a screen with a map on which you can select the trackable's destination. This screen can be accessed from the add trackable screen.
![Screenshot from 2021-12-09 15-12-53](https://user-images.githubusercontent.com/62378170/145412505-54a37d12-0e25-4825-b541-5adcd513e3f7.png)
![Screenshot from 2021-12-09 15-13-30](https://user-images.githubusercontent.com/62378170/145412517-dc5538a1-e0e2-43c8-947c-dbf15d15f803.png)
![Screenshot from 2021-12-09 15-13-41](https://user-images.githubusercontent.com/62378170/145412527-65a168a5-850e-4e45-be76-c7a42bb5eb57.png)

