### PR TITLE
Set routing profile in the publisher example app

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -24,6 +24,7 @@ class AppPreferences private constructor(context: Context) {
     private val SIMULATION_CHANNEL_KEY =
         context.getString(R.string.preferences_simulation_channel_name_key)
     private val S3_FILE_KEY = context.getString(R.string.preferences_s3_file_key)
+    private val ROUTING_PROFILE_KEY = context.getString(R.string.preferences_routing_profile_key)
     private val RESOLUTION_ACCURACY_KEY = context.getString(R.string.preferences_resolution_accuracy_key)
     private val RESOLUTION_DESIRED_INTERVAL_KEY =
         context.getString(R.string.preferences_resolution_desired_interval_key)
@@ -34,6 +35,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
+    private val DEFAULT_ROUTING_PROFILE = RoutingProfileType.DRIVING.name
     private val DEFAULT_RESULTION_ACCURACY = Accuracy.BALANCED.name
     private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
@@ -48,6 +50,9 @@ class AppPreferences private constructor(context: Context) {
 
     fun getS3File() =
         preferences.getString(S3_FILE_KEY, DEFAULT_S3_FILE)!!
+
+    fun getRoutingProfile(): RoutingProfileType =
+        RoutingProfileType.valueOf(preferences.getString(ROUTING_PROFILE_KEY, DEFAULT_ROUTING_PROFILE)!!)
 
     fun getResolutionAccuracy(): Accuracy =
         preferences.getString(RESOLUTION_ACCURACY_KEY, DEFAULT_RESULTION_ACCURACY)!!.let { Accuracy.valueOf(it) }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -18,7 +18,6 @@ import com.ably.tracking.publisher.LocationSource
 import com.ably.tracking.publisher.MapConfiguration
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.PublisherNotificationProvider
-import com.ably.tracking.publisher.RoutingProfile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -100,7 +99,7 @@ class PublisherService : Service() {
             .locationSource(locationSource)
             .resolutionPolicy(DefaultResolutionPolicyFactory(createDefaultResolution(), this))
             .androidContext(this)
-            .profile(RoutingProfile.DRIVING)
+            .profile(appPreferences.getRoutingProfile().toAssetTracking())
             .logHandler(object : LogHandler {
                 override fun logMessage(level: LogLevel, message: String, throwable: Throwable?) {
                     when (level) {

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/RoutingProfileType.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/RoutingProfileType.kt
@@ -1,0 +1,10 @@
+package com.ably.tracking.example.publisher
+
+import androidx.annotation.StringRes
+
+enum class RoutingProfileType(@StringRes val displayNameResourceId: Int) {
+    DRIVING(R.string.routing_profile_driving),
+    CYCLING(R.string.routing_profile_cycling),
+    WALKING(R.string.routing_profile_walking),
+    DRIVING_TRAFFIC(R.string.routing_profile_driving_traffic),
+}

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/RoutingProfileType.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/RoutingProfileType.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.example.publisher
 
 import androidx.annotation.StringRes
+import com.ably.tracking.publisher.RoutingProfile
 
 enum class RoutingProfileType(@StringRes val displayNameResourceId: Int) {
     DRIVING(R.string.routing_profile_driving),
@@ -8,3 +9,11 @@ enum class RoutingProfileType(@StringRes val displayNameResourceId: Int) {
     WALKING(R.string.routing_profile_walking),
     DRIVING_TRAFFIC(R.string.routing_profile_driving_traffic),
 }
+
+fun RoutingProfileType.toAssetTracking(): RoutingProfile =
+    when (this) {
+        RoutingProfileType.DRIVING -> RoutingProfile.DRIVING
+        RoutingProfileType.CYCLING -> RoutingProfile.CYCLING
+        RoutingProfileType.WALKING -> RoutingProfile.WALKING
+        RoutingProfileType.DRIVING_TRAFFIC -> RoutingProfile.DRIVING_TRAFFIC
+    }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -21,6 +21,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.settings_preferences)
         setupLocationSourcePreference()
+        setupRoutingProfilePreference()
         setupResolutionPreferences()
         loadS3Preferences()
     }
@@ -65,6 +66,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 .toTypedArray()
             entryValues = LocationSourceType.values().map { it.name }.toTypedArray()
             value = appPreferences.getLocationSource().name
+        }
+    }
+
+    private fun setupRoutingProfilePreference() {
+        val appPreferences = AppPreferences.getInstance(requireContext())
+        (findPreference(getString(R.string.preferences_routing_profile_key)) as ListPreference?)?.apply {
+            entries = RoutingProfileType.values()
+                .map { getString(it.displayNameResourceId) }
+                .toTypedArray()
+            entryValues = RoutingProfileType.values().map { it.name }.toTypedArray()
+            value = appPreferences.getRoutingProfile().name
         }
     }
 

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
   <string name="default_simulation_channel">simulation_test</string>
   <string name="preferences_s3_file_key">s3_file</string>
   <string name="preferences_s3_file_label">S3 File</string>
+  <string name="preferences_routing_profile_key">routing_profile</string>
+  <string name="preferences_routing_profile_label">Routing profile</string>
   <string name="preferences_resolution_category_title">Default resolution</string>
   <string name="preferences_resolution_accuracy_key">default_resolution_accuracy</string>
   <string name="preferences_resolution_accuracy_label">Accuracy</string>
@@ -75,4 +77,9 @@
   <string name="location_source_phone">Phone</string>
   <string name="location_source_ably_channel">Ably Channel</string>
   <string name="location_source_s3_file">S3 File</string>
+
+  <string name="routing_profile_driving">Driving</string>
+  <string name="routing_profile_cycling">Cycling</string>
+  <string name="routing_profile_walking">Walking</string>
+  <string name="routing_profile_driving_traffic">Driving with traffic data</string>
 </resources>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -31,6 +31,12 @@
       android:title="@string/preferences_s3_file_label"
       app:useSimpleSummaryProvider="true" />
 
+    <ListPreference
+      android:key="@string/preferences_routing_profile_key"
+      android:layout="@layout/preference_with_summary_layout"
+      android:title="@string/preferences_routing_profile_label"
+      app:useSimpleSummaryProvider="true" />
+
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
I've added another list preference under the "Navigation Settings" section which enables to set a routing profile. I've added all 4 routing profiles that we support in AAT.
![Screenshot from 2021-12-09 15-32-39](https://user-images.githubusercontent.com/62378170/145416651-aa21be89-d3c1-4f1c-b61a-db0c1ec33415.png)
![Screenshot from 2021-12-09 15-32-50](https://user-images.githubusercontent.com/62378170/145416662-9f9cb800-34fa-4abb-a8c9-6c77ef08b065.png)
