### PR TITLE
Update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ The release process must include the following steps:
 
 1. Ensure that all work intended for this release has landed to `main`
 2. Create a release branch named like `release/1.2.3`
-3. Add a commit to bump the version number
+3. Add a commit to bump the version number - this commit should also include an update to the root `README.md`, where the latest version number is explicitly referenced
 4. Add a commit to update the change log
 5. Push the release branch to GitHub
 6. Open a PR for the release against the release branch you just pushed

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Finally, you can add the AAT dependency in the Gradle build script
 ```gradle
 dependencies {
     // Publishing SDK for publishers
-    implementation 'com.ably.tracking:publishing-sdk:1.0.0-beta.11'
+    implementation 'com.ably.tracking:publishing-sdk:1.0.0-beta.13'
 
     // Subscribing SDK for subscribers
-    implementation 'com.ably.tracking:subscribing-sdk:1.0.0-beta.11'
+    implementation 'com.ably.tracking:subscribing-sdk:1.0.0-beta.13'
 }
 ```
 


### PR DESCRIPTION
After publishing the new version I've noticed that in our README we are still using version `beta.11` in the installation guide. I've updated the number so it uses our newest release.

@QuintinWillison maybe we should also update the "Release process" instruction in the contribution guide? :wink: