### PR TITLE
Show accuracy circles for raw and enhanced markers in the subscriber app

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/Constants.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/Constants.kt
@@ -1,0 +1,6 @@
+package com.ably.tracking.example.subscriber
+
+const val COLOR_RED = 0xff0000
+const val COLOR_RED_TRANSPARENT = 0x30ff0000
+const val COLOR_ORANGE = 0xff7700
+const val COLOR_ORANGE_TRANSPARENT = 0x30ff7700

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.view.animation.AccelerateDecelerateInterpolator
+import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import kotlin.math.roundToInt
@@ -21,8 +22,9 @@ fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
     }
 }
 
-fun animateMarkerMovement(marker: Marker, finalPosition: LatLng) {
+fun animateMarkerAndCircleMovement(marker: Marker, finalPosition: LatLng, circle: Circle, finalRadius: Double) {
     val startPosition = marker.position
+    val startRadius = circle.radius
     val interpolator = AccelerateDecelerateInterpolator()
     val startTimeInMillis = SystemClock.uptimeMillis()
     val animationDurationInMillis = 1000f // this should probably match events update rate
@@ -37,8 +39,9 @@ fun animateMarkerMovement(marker: Marker, finalPosition: LatLng) {
             timeElapsedFromStartInMillis = SystemClock.uptimeMillis() - startTimeInMillis
             timeProgressPercentage = timeElapsedFromStartInMillis / animationDurationInMillis
             distanceProgressPercentage = interpolator.getInterpolation(timeProgressPercentage)
-            marker.position =
-                interpolateLinear(distanceProgressPercentage, startPosition, finalPosition)
+            marker.position = interpolateLinear(distanceProgressPercentage, startPosition, finalPosition)
+            circle.center = interpolateLinear(distanceProgressPercentage, startPosition, finalPosition)
+            circle.radius = interpolateLinear(distanceProgressPercentage, startRadius, finalRadius)
 
             if (timeProgressPercentage < 1) {
                 handler.postDelayed(this, nextCalculationDelayInMillis)
@@ -48,7 +51,9 @@ fun animateMarkerMovement(marker: Marker, finalPosition: LatLng) {
 }
 
 private fun interpolateLinear(fraction: Float, a: LatLng, b: LatLng): LatLng {
-    val lat = (b.latitude - a.latitude) * fraction + a.latitude
-    val lng = (b.longitude - a.longitude) * fraction + a.longitude
+    val lat = interpolateLinear(fraction, a.latitude, b.latitude)
+    val lng = interpolateLinear(fraction, a.longitude, b.longitude)
     return LatLng(lat, lng)
 }
+
+private fun interpolateLinear(fraction: Float, a: Double, b: Double): Double = (b - a) * fraction + a


### PR DESCRIPTION
I've added circles around markers that show the accuracy of received locations. The circles are always visible and they are animated together with the marker. Both circle position and radius are being animated.
![Screenshot from 2021-12-13 10-51-15](https://user-images.githubusercontent.com/62378170/145792914-487035d6-1b05-4b8c-a82f-01885e798c6a.png)