### PR TITLE
Change ResolutionConstraints to an interface

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -331,7 +331,7 @@ internal fun DefaultResolutionSet.getResolution(isNear: Boolean, hasSubscriber: 
 /**
  * Specifies factors which contribute towards deciding the tracking [Resolution] for a [Trackable].
  */
-sealed class ResolutionConstraints
+interface ResolutionConstraints
 
 /**
  * Specifies the thresholds and corresponding logical mappings for a [Trackable] that can be used
@@ -360,7 +360,7 @@ data class DefaultResolutionConstraints(
      * [batteryLevelThreshold].
      */
     val lowBatteryMultiplier: Float
-) : ResolutionConstraints()
+) : ResolutionConstraints
 
 /**
  * Represents the means of transport that's being used.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultResolutionPolicyFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultResolutionPolicyFactory.kt
@@ -49,6 +49,7 @@ internal class DefaultResolutionPolicy(
                         if (allResolutions.isEmpty()) defaultResolution else createFinalResolution(allResolutions)
                     return adjustResolutionToBatteryLevel(finalResolution, constraints)
                 }
+                else -> throw WrongResolutionConstraintsException()
             }
         }
 
@@ -130,7 +131,8 @@ internal class DefaultResolutionPolicy(
             } else {
                 activeTrackable = trackable
                 trackable.constraints?.let {
-                    val constraints = it as DefaultResolutionConstraints
+                    val constraints = it as? DefaultResolutionConstraints
+                        ?: throw WrongResolutionConstraintsException()
                     methods.setProximityThreshold(constraints.proximityThreshold, proximityHandler)
                 }
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherExceptions.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherExceptions.kt
@@ -7,3 +7,5 @@ class PublisherPropertiesDisposedException : Exception("Cannot access the publis
 class MapException(throwable: Throwable) : Exception(throwable)
 
 class RemoveTrackableRequestedException : Exception("This trackable is marked for removal.")
+
+class WrongResolutionConstraintsException : Exception("In the default resolution policy you need to use the DefaultResolutionConstraints.")

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultResolutionPolicyTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultResolutionPolicyTest.kt
@@ -339,6 +339,33 @@ class DefaultResolutionPolicyTest {
         Assert.assertEquals(defaultResolution, resolvedResolution)
     }
 
+    @Test(expected = WrongResolutionConstraintsException::class)
+    fun `should throw an error when using any other ResolutionConstraint than DefaultResolutionConstraints when resolving a resolution`() {
+        // given
+        val customResolutionConstraints = object : ResolutionConstraints {}
+        val trackable = Trackable("test_id", constraints = customResolutionConstraints)
+        val resolutionRequest = TrackableResolutionRequest(trackable, emptySet())
+
+        // when
+        policy.resolve(resolutionRequest)
+
+        // then
+        // exception is thrown
+    }
+
+    @Test(expected = WrongResolutionConstraintsException::class)
+    fun `should throw an error when using any other ResolutionConstraint than DefaultResolutionConstraints when signaling active trackable change`() {
+        // given
+        val customResolutionConstraints = object : ResolutionConstraints {}
+        val trackable = Trackable("test_id", constraints = customResolutionConstraints)
+
+        // when
+        hooks.trackableSetListener!!.onActiveTrackableChanged(trackable)
+
+        // then
+        // exception is thrown
+    }
+
     /**
      * [level] should be between [DefaultBatteryDataProvider.MINIMUM_BATTERY_PERCENTAGE] and [DefaultBatteryDataProvider.MAXIMUM_BATTERY_PERCENTAGE]
      */


### PR DESCRIPTION
I've changed the `ResolutionConstraints` from a sealed class to an interface. Because of that I had to add a few checks in the `DefaultResolutionPolicy` to make sure we are using the expected resolution constraints type.