### PR TITLE
Add information about removing notification when stopping the publisher

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -115,6 +115,7 @@ interface Publisher {
 
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
+     * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
      */
     @JvmSynthetic
     suspend fun stop()
@@ -190,6 +191,7 @@ interface Publisher {
 
         /**
          * Sets the notification that will be displayed for the background tracking service.
+         * Please note that this notification will be removed when you call the [stop] method.
          *
          * @param notificationProvider It will be used to create the notification.
          * @param notificationId The ID of the notification used by the Android OS to display it.


### PR DESCRIPTION
I've added a note to the docs about the issue from https://github.com/ably/ably-asset-tracking-android/issues/528