### PR TITLE
Show skipped locations in the subscriber example app

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.example.subscriber
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.LinearInterpolator
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
@@ -25,7 +25,7 @@ fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
 fun animateMarkerAndCircleMovement(marker: Marker, finalPosition: LatLng, circle: Circle, finalRadius: Double) {
     val startPosition = marker.position
     val startRadius = circle.radius
-    val interpolator = AccelerateDecelerateInterpolator()
+    val interpolator = LinearInterpolator()
     val startTimeInMillis = SystemClock.uptimeMillis()
     val animationDurationInMillis = 1000f // this should probably match events update rate
     val nextCalculationDelayInMillis = 16L

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
@@ -7,6 +7,8 @@ import android.view.animation.LinearInterpolator
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 import kotlin.math.roundToInt
 
 fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
@@ -22,12 +24,32 @@ fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
     }
 }
 
-fun animateMarkerAndCircleMovement(marker: Marker, finalPosition: LatLng, circle: Circle, finalRadius: Double) {
+suspend fun animateMarkerAndCircleMovement(
+    marker: Marker,
+    finalPosition: LatLng,
+    circle: Circle,
+    finalRadius: Double,
+    animationDurationInMillis: Float = 1000f,
+) {
+    suspendCoroutine<Unit> {
+        animateMarkerAndCircleMovement(marker, finalPosition, circle, finalRadius, animationDurationInMillis) {
+            it.resume(Unit)
+        }
+    }
+}
+
+fun animateMarkerAndCircleMovement(
+    marker: Marker,
+    finalPosition: LatLng,
+    circle: Circle,
+    finalRadius: Double,
+    animationDurationInMillis: Float = 1000f,
+    animationFinishedCallback: () -> Unit = {}
+) {
     val startPosition = marker.position
     val startRadius = circle.radius
     val interpolator = LinearInterpolator()
     val startTimeInMillis = SystemClock.uptimeMillis()
-    val animationDurationInMillis = 1000f // this should probably match events update rate
     val nextCalculationDelayInMillis = 16L
     val handler = Handler(Looper.getMainLooper())
 
@@ -45,6 +67,8 @@ fun animateMarkerAndCircleMovement(marker: Marker, finalPosition: LatLng, circle
 
             if (timeProgressPercentage < 1) {
                 handler.postDelayed(this, nextCalculationDelayInMillis)
+            } else {
+                animationFinishedCallback()
             }
         }
     })


### PR DESCRIPTION
I'm using skipped locations to create a smoother route for driver marker. If a location update with skipped locations is received I'm dividing the animation time to give even time for each of the updates. 
The animation time is equal to the current resolution that the publisher is sending. If no resolution from publisher is received (for example because the publisher is not publishing it) we are using 1 second animation times.
To avoid huge delays between the newest received position and the one that's currently being shown, when a new location is received the previous movement is cancelled and the marker moves to the newest location.