### PR TITLE
Migrate to Mapbox v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Firebase Crashlytics

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -16,6 +16,8 @@ android {
         vectorDrawables.useSupportLibrary = true
         applicationId 'com.ably.tracking.example.publisher'
         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        // Required to initialize Mapbox and use MapView in the layout XML files.
+        resValue "string", "mapbox_access_token", property('MAPBOX_ACCESS_TOKEN')
     }
 }
 
@@ -26,7 +28,8 @@ dependencies {
     implementation 'com.amplifyframework:aws-storage-s3:1.4.1'
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
     implementation 'pub.devrel:easypermissions:3.0.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.6.6'
+    // This version needs to be compatible with the "com.mapbox.navigation:core" dependency version from publishing-sdk.
+    implementation 'com.mapbox.maps:android:10.1.0'
 
     if (useCrashlytics) {
         // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/Extensions.kt
@@ -1,11 +1,15 @@
 package com.ably.tracking.example.publisher
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.Toast
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 
 private const val NO_FLAGS = 0
 
@@ -39,3 +43,13 @@ fun Button.hideText() {
 fun Button.showText() {
     textScaleX = 1f
 }
+
+fun Context.createBitmapFromVectorDrawable(@DrawableRes id: Int): Bitmap? =
+    ContextCompat.getDrawable(this, id)?.let { drawable ->
+        val bitmap = Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+        Canvas(bitmap).let {
+            drawable.setBounds(0, 0, it.width, it.height)
+            drawable.draw(it)
+        }
+        bitmap
+    }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MapActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/MapActivity.kt
@@ -1,19 +1,17 @@
-// Mapbox has deprecated the Marker class and recommends using the Annotation Plugin
-// but to keep things as simple as possible we're going to still use the Marker approach
-@file:Suppress("DEPRECATION")
-
 package com.ably.tracking.example.publisher
 
 import android.location.Location
 import android.os.Bundle
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.annotations.Marker
-import com.mapbox.mapboxsdk.annotations.MarkerOptions
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Style
-import kotlinx.android.synthetic.main.activity_map.*
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.annotation.annotations
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
+import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
+import kotlinx.android.synthetic.main.activity_map.mapView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -24,19 +22,18 @@ class MapActivity : PublisherServiceActivity() {
     // SupervisorJob() is used to keep the scope working after any of its children fail
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var map: MapboxMap? = null
-    private var marker: Marker? = null
+    lateinit var pointAnnotationManager: PointAnnotationManager
+    private var annotation: PointAnnotation? = null
     private val INITIAL_ZOOM_LEVEL = 15.0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Mapbox.getInstance(this, BuildConfig.MAPBOX_ACCESS_TOKEN)
         setContentView(R.layout.activity_map)
-        mapView.onCreate(savedInstanceState)
-        mapView.getMapAsync { mapboxMap ->
-            mapboxMap.setStyle(Style.MAPBOX_STREETS) {
-                map = mapboxMap
-            }
+        mapView.getMapboxMap().let { mapboxMap ->
+            mapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+            map = mapboxMap
         }
+        pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     }
 
     override fun onPublisherServiceConnected(publisherService: PublisherService) {
@@ -48,50 +45,20 @@ class MapActivity : PublisherServiceActivity() {
     }
 
     private fun updateMap(location: Location) {
-        map?.apply {
-            val newPosition = LatLng(location)
-            if (marker == null) {
-                marker = addMarker(MarkerOptions().position(newPosition))
-                moveCamera(CameraUpdateFactory.newLatLngZoom(newPosition, INITIAL_ZOOM_LEVEL))
-            } else {
-                marker?.position = newPosition
-                moveCamera(CameraUpdateFactory.newLatLng(newPosition))
+        val newPosition = Point.fromLngLat(location.longitude, location.latitude)
+        if (annotation == null) {
+            createBitmapFromVectorDrawable(R.drawable.ic_red_map_marker)?.let { iconBitmap ->
+                annotation = pointAnnotationManager.create(
+                    PointAnnotationOptions()
+                        .withPoint(newPosition)
+                        .withIconImage(iconBitmap)
+                )
+                map?.setCamera(CameraOptions.Builder().center(newPosition).zoom(INITIAL_ZOOM_LEVEL).build())
             }
+        } else {
+            annotation!!.point = newPosition
+            pointAnnotationManager.update(annotation!!)
+            map?.setCamera(CameraOptions.Builder().center(newPosition).build())
         }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        mapView?.onStart()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        mapView?.onResume()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        mapView?.onPause()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        mapView?.onStop()
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        mapView?.onSaveInstanceState(outState)
-    }
-
-    override fun onLowMemory() {
-        super.onLowMemory()
-        mapView?.onLowMemory()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        mapView?.onDestroy()
     }
 }

--- a/publishing-example-app/src/main/res/drawable/ic_red_map_marker.xml
+++ b/publishing-example-app/src/main/res/drawable/ic_red_map_marker.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:tint="#DC0C0C"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+</vector>

--- a/publishing-example-app/src/main/res/layout/activity_map.xml
+++ b/publishing-example-app/src/main/res/layout/activity_map.xml
@@ -3,7 +3,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <com.mapbox.mapboxsdk.maps.MapView
+  <com.mapbox.maps.MapView
     android:id="@+id/mapView"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/publishing-example-app/src/main/res/layout/activity_set_destination.xml
+++ b/publishing-example-app/src/main/res/layout/activity_set_destination.xml
@@ -4,7 +4,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <com.mapbox.mapboxsdk.maps.MapView
+  <com.mapbox.maps.MapView
     android:id="@+id/mapView"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation('com.mapbox.navigation:core:1.6.1') {
+    implementation('com.mapbox.navigation:core:2.1.1') {
         // We provide a custom trip notification so we exclude the default one.
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"
@@ -30,17 +30,17 @@ dependencies {
 
     // Dependencies needed for replacing Mapbox modules.
     // https://docs.mapbox.com/android/navigation/guides/modularization/#replacing-a-module
-    compileOnly("com.mapbox.base:annotations:0.4.0")
+    compileOnly("com.mapbox.base:annotations:0.5.0")
     kapt("com.mapbox.base:annotations-processor:0.4.0")
 
     // Only the Core SDK portion of the MapBox Maps SDK for Android.
     // https://docs.mapbox.com/android/maps/overview/
     // https://docs.mapbox.com/android/core/overview/
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:3.1.1'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:5.0.0'
 
     // Advanced geospatial analysis - used i.e. for calculating distance between points.
     // https://docs.mapbox.com/android/java/guides/turf/
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:5.7.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:6.1.0'
 
     // Required for FusedLocationProviderClient that's used in Google location engine implementation
     // https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/MapboxTripNotification.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/MapboxTripNotification.kt
@@ -4,7 +4,7 @@ import android.app.Notification
 import androidx.annotation.Keep
 import com.mapbox.annotation.module.MapboxModule
 import com.mapbox.annotation.module.MapboxModuleType
-import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.base.trip.notification.TripNotification
 
 @MapboxModule(MapboxModuleType.NavigationTripNotification, enableConfiguration = true)
@@ -17,5 +17,5 @@ internal class MapboxTripNotification(
     override fun getNotificationId(): Int = notificationId
     override fun onTripSessionStarted() = Unit
     override fun onTripSessionStopped() = Unit
-    override fun updateNotification(routeProgress: RouteProgress?) = Unit
+    override fun updateNotification(state: TripNotificationState) = Unit
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherExceptions.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherExceptions.kt
@@ -9,3 +9,5 @@ class MapException(throwable: Throwable) : Exception(throwable)
 class RemoveTrackableRequestedException : Exception("This trackable is marked for removal.")
 
 class WrongResolutionConstraintsException : Exception("In the default resolution policy you need to use the DefaultResolutionConstraints.")
+
+class UnknownSetRouteException() : Exception("Setting route failed with an unknown exception.")


### PR DESCRIPTION
I've migrated Mapbox dependencies that we use to the newest possible versions. The major changes in the Publisher SDK were the way of retrieving the history data and the way of setting the destination. The major change in the publisher example app was switching from map markers to map annotations.
I couldn't use the newest `com.mapbox.maps:android` in version `10.2.0` as it didn't work with the newest stable Mapbox navigation SDK. Therefore, I've used the newest version that worked which is `10.1.0`.

While doing this I also had to do a few things not directly related to Mapbox:
- upgrade the gradle version as without it the `resValue` function required to setup Mapbox in the example app wouldn't properly work
- change the way of calling the `SetDestinationActivity` from the deprecated `startActivityForResult` to a result handler approach as the ktlint was failing on this