### PR TITLE
Add callback for retrieving the raw history data from Mapbox

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -50,7 +50,8 @@ class MapboxTests {
                         .build()
             },
             12345,
-            true
+            true,
+            null,
         )
 
     private fun getLocationData(context: Context): LocationHistoryData {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -161,6 +161,7 @@ internal class DefaultMapbox(
     notificationProvider: PublisherNotificationProvider,
     notificationId: Int,
     predictionsEnabled: Boolean,
+    private val rawHistoryCallback: ((String) -> Unit)?,
 ) : Mapbox {
     private val TAG = createLoggingTag(this)
 
@@ -258,6 +259,7 @@ internal class DefaultMapbox(
                             .mapNotNull { historyMapper.mapToReplayEvent(it) }
                             .toList()
                         locationHistoryListener?.invoke(LocationHistoryData(historyEvents.toGeoJsonMessages()))
+                        rawHistoryCallback?.invoke(historyDataFilepath)
                     }
                 }
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -234,6 +234,16 @@ interface Publisher {
         fun predictions(enabled: Boolean): Builder
 
         /**
+         * EXPERIMENTAL API
+         * **OPTIONAL** Specifies a callback that will be called with the filepath of raw history data from the Navigation SDK component.
+         * This will be probably removed in the future. Do not use this in the production environment.
+         *
+         * @param callback The callback that will be called with the raw history data filepath.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun rawHistoryDataCallback(callback: (String) -> Unit): Builder
+
+        /**
          * Creates a [Publisher] and starts publishing.
          *
          * The returned publisher instance does not start in a state whereby it is actively tracking anything. If

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -22,6 +22,7 @@ internal data class PublisherBuilder(
     val areRawLocationsEnabled: Boolean? = null,
     val sendResolutionEnabled: Boolean = false,
     val predictionsEnabled: Boolean = true,
+    val rawHistoryCallback: ((String) -> Unit)? = null,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -60,6 +61,9 @@ internal data class PublisherBuilder(
     override fun predictions(enabled: Boolean): Publisher.Builder =
         this.copy(predictionsEnabled = enabled)
 
+    override fun rawHistoryDataCallback(callback: (String) -> Unit): Publisher.Builder =
+        this.copy(rawHistoryCallback = callback)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -77,6 +81,7 @@ internal data class PublisherBuilder(
                 notificationProvider!!,
                 notificationId!!,
                 predictionsEnabled,
+                rawHistoryCallback,
             ),
             resolutionPolicyFactory!!,
             routingProfile,


### PR DESCRIPTION
In order to collect raw history data from the Mapbox SDK I had to add another callback to the API of the Publisher SDK. 
It is only meant for the tracking testing app and probably we will remove it in the future.