### PR TITLE
Add sources and javadoc JARs to the published library

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'org.jetbrains.dokka'
 }
 
 dependencies {

--- a/core-sdk-java/build.gradle
+++ b/core-sdk-java/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'org.jetbrains.dokka'
 }
 
 apply from: '../jacoco.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,6 +3,22 @@ apply plugin: 'maven-publish'
 final githubActor = findProperty('GITHUB_ACTOR')
 final githubToken = findProperty('GITHUB_TOKEN')
 
+task sourcesJar(type: Jar) {
+    // Copy files from main source directories to the JAR.
+    from android.sourceSets.main.java.srcDirs
+    // Specify the JAR type (it will be appended to its filename).
+    archiveClassifier.set("sources")
+}
+
+task dokkaJavadocJar(type: Jar) {
+    // Generate the javadocs.
+    dependsOn dokkaJavadoc
+    // Copy files from the javadocs directory to the jar.
+    from dokkaJavadoc.outputDirectory
+    // Specify the JAR type (it will be appended to its filename).
+    archiveClassifier.set("javadoc")
+}
+
 afterEvaluate {
     // Based on: https://developer.android.com/studio/build/maven-publish-plugin
     // See: https://docs.gradle.org/current/dsl/org.gradle.api.publish.PublishingExtension.html
@@ -10,6 +26,11 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
+
+                // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).
+                artifact sourcesJar
+                // Add a JAR with javadocs.
+                artifact dokkaJavadocJar
             }
         }
 

--- a/publishing-sdk-java/build.gradle
+++ b/publishing-sdk-java/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'org.jetbrains.dokka'
 }
 
 apply from: '../jacoco.gradle'

--- a/subscribing-sdk-java/build.gradle
+++ b/subscribing-sdk-java/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'org.jetbrains.dokka'
 }
 
 apply from: '../jacoco.gradle'


### PR DESCRIPTION
I've added two additional JARs to the published library packages. One of them contains the javadocs and the other contains the source code. In order to do that I had to add the `dokka` plugin to all modules that are being published. 
Thanks to that, when we use the library from a maven repository we can lookup the code and view the docs.