### PR TITLE
Create connection created worker tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,7 @@ subprojects {
                 // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
 
-                testImplementation 'io.mockk:mockk:1.10.2'
+                testImplementation 'io.mockk:mockk:1.12.2'
             } else {
                 testImplementation 'org.mockito:mockito-core:3.6.28'
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -37,7 +37,11 @@ internal class AddTrackableWorker(
                         val connectResult = ably.connect(
                             trackableId = trackable.id,
                             presenceData = presenceData,
-                            willPublish = true
+                            willPublish = true,
+                            // Below arguments are default ones but due to a Mockk issue we have to specify them.
+                            // We should remove those lines when https://github.com/mockk/mockk/issues/777 is resolved.
+                            useRewind = false,
+                            willSubscribe = false,
                         )
                         if (connectResult.isSuccess) {
                             AddTrackableWorkResult.Success(trackable, callbackFunction)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/TestUtils.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/TestUtils.kt
@@ -1,0 +1,10 @@
+package com.ably.tracking.publisher.workerqueue
+
+import com.ably.tracking.publisher.workerqueue.results.AsyncWork
+import com.ably.tracking.publisher.workerqueue.results.WorkResult
+import org.junit.Assert
+
+internal suspend fun AsyncWork?.assertNotNullAndExecute(): WorkResult {
+    Assert.assertNotNull(this)
+    return this!!.invoke()
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
@@ -6,6 +6,7 @@ import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
+import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.test.common.mockSuspendingConnectFailure
 import com.ably.tracking.test.common.mockSuspendingConnectSuccess
@@ -126,16 +127,12 @@ class AddTrackableWorkerTest {
             val result = worker.doWork(publisherProperties)
 
             // then
-            // first make sure there is an asyncWork
-            Assert.assertNotNull(result.asyncWork)
-            result.asyncWork?.let { asyncWork ->
-                val asyncWorkResult = asyncWork()
-                Assert.assertTrue(asyncWorkResult is AddTrackableWorkResult.Success)
-                // also check content
-                val success = asyncWorkResult as AddTrackableWorkResult.Success
-                Assert.assertEquals(trackable, success.trackable)
-                Assert.assertEquals(resultCallbackFunction, success.callbackFunction)
-            }
+            val asyncWorkResult = result.asyncWork.assertNotNullAndExecute()
+            Assert.assertTrue(asyncWorkResult is AddTrackableWorkResult.Success)
+            // also check content
+            val success = asyncWorkResult as AddTrackableWorkResult.Success
+            Assert.assertEquals(trackable, success.trackable)
+            Assert.assertEquals(resultCallbackFunction, success.callbackFunction)
         }
     }
 
@@ -150,16 +147,12 @@ class AddTrackableWorkerTest {
             val result = worker.doWork(publisherProperties)
 
             // then
-            // first make sure there is an asyncWork
-            Assert.assertNotNull(result.asyncWork)
-            result.asyncWork?.let { asyncWork ->
-                val asyncWorkResult = asyncWork()
-                Assert.assertTrue(asyncWorkResult is AddTrackableWorkResult.Fail)
-                // also check content
-                val fail = asyncWorkResult as AddTrackableWorkResult.Fail
-                Assert.assertEquals(trackable, fail.trackable)
-                Assert.assertEquals(resultCallbackFunction, fail.callbackFunction)
-            }
+            val asyncWorkResult = result.asyncWork.assertNotNullAndExecute()
+            Assert.assertTrue(asyncWorkResult is AddTrackableWorkResult.Fail)
+            // also check content
+            val fail = asyncWorkResult as AddTrackableWorkResult.Fail
+            Assert.assertEquals(trackable, fail.trackable)
+            Assert.assertEquals(resultCallbackFunction, fail.callbackFunction)
         }
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -1,0 +1,213 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.guards.TrackableRemovalGuard
+import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
+import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
+import com.ably.tracking.test.common.mockDisconnectSuccess
+import com.ably.tracking.test.common.mockDisconnectSuccessAndCapturePresenceData
+import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
+import com.ably.tracking.test.common.mockSuspendingDisconnect
+import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
+import io.mockk.clearAllMocks
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ConnectionCreatedWorkerTest {
+    private lateinit var worker: ConnectionCreatedWorker
+    private val trackable = Trackable("test-trackable")
+    private val resultCallbackFunction = mockk<ResultCallbackFunction<StateFlow<TrackableState>>>(relaxed = true)
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val trackableRemovalGuard = mockk<TrackableRemovalGuard>(relaxed = true)
+    private val ably = mockk<Ably>(relaxed = true)
+    private val presenceUpdateListener: (PresenceMessage) -> Unit = {}
+
+    @Before
+    fun setUp() {
+        worker = ConnectionCreatedWorker(trackable, resultCallbackFunction, ably, presenceUpdateListener)
+        every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should return only async result when executing normally`() {
+        // given
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNotNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should return presence success result when executing normally and presence enter was successful`() {
+        runBlocking {
+            // given
+            ably.mockSubscribeToPresenceSuccess(trackable.id)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is ConnectionCreatedWorkResult.PresenceSuccess)
+            // verify result content
+            val presenceSuccessResult = asyncResult as ConnectionCreatedWorkResult.PresenceSuccess
+            Assert.assertEquals(trackable, presenceSuccessResult.trackable)
+            Assert.assertEquals(resultCallbackFunction, presenceSuccessResult.callbackFunction)
+            Assert.assertEquals(presenceUpdateListener, presenceSuccessResult.presenceUpdateListener)
+        }
+    }
+
+    @Test
+    fun `should return presence failure result when executing normally and presence enter failed`() {
+        runBlocking {
+            // given
+            ably.mockSubscribeToPresenceError(trackable.id)
+            ably.mockDisconnectSuccess(trackable.id)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is ConnectionCreatedWorkResult.PresenceFail)
+            // verify result content
+            val presenceFailResult = asyncResult as ConnectionCreatedWorkResult.PresenceFail
+            Assert.assertEquals(trackable, presenceFailResult.trackable)
+            Assert.assertEquals(resultCallbackFunction, presenceFailResult.callbackFunction)
+            Assert.assertNotNull(presenceFailResult.exception)
+        }
+    }
+
+    @Test
+    fun `should disconnect from Ably when executing normally and presence enter failed`() {
+        runBlocking {
+            // given
+            ably.mockSubscribeToPresenceError(trackable.id)
+            ably.mockDisconnectSuccess(trackable.id)
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            coVerify(exactly = 1) {
+                ably.disconnect(trackable.id, any(), any())
+            }
+        }
+    }
+
+    @Test
+    fun `should use a copy of presence data when disconnecting when executing normally and presence enter failed`() {
+        runBlocking {
+            // given
+            val originalPresenceData = PresenceData("test-type")
+            mockPresenceData(originalPresenceData)
+            val presenceDataSlot = ably.mockDisconnectSuccessAndCapturePresenceData(trackable.id)
+            ably.mockSubscribeToPresenceError(trackable.id)
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            val disconnectPresenceData = presenceDataSlot.captured
+            Assert.assertNotSame("A copy of presence data should be used", originalPresenceData, disconnectPresenceData)
+            Assert.assertEquals("Presence data should be an exact copy", originalPresenceData, disconnectPresenceData)
+        }
+    }
+
+    @Test
+    fun `should return only async result when trackable removal was requested`() {
+        // given
+        mockTrackableRemovalRequested()
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNotNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should return removal request result when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+            val disconnectResult = Result.success(Unit)
+            ably.mockSuspendingDisconnect(trackable.id, disconnectResult)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is ConnectionCreatedWorkResult.RemovalRequested)
+            // verify result content
+            val removalRequestedResult = asyncResult as ConnectionCreatedWorkResult.RemovalRequested
+            Assert.assertEquals(trackable, removalRequestedResult.trackable)
+            Assert.assertEquals(resultCallbackFunction, removalRequestedResult.callbackFunction)
+            Assert.assertEquals(disconnectResult, removalRequestedResult.result)
+        }
+    }
+
+    @Test
+    fun `should disconnect from Ably when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            coVerify(exactly = 1) {
+                ably.disconnect(trackable.id, any())
+            }
+        }
+    }
+
+    @Test
+    fun `should use a copy of presence data when disconnecting when trackable removal was requested`() {
+        runBlocking {
+            // given
+            val originalPresenceData = PresenceData("test-type")
+            mockPresenceData(originalPresenceData)
+            val presenceDataSlot = ably.mockSuspendingDisconnectSuccessAndCapturePresenceData(trackable.id)
+            mockTrackableRemovalRequested()
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            val disconnectPresenceData = presenceDataSlot.captured
+            Assert.assertNotSame("A copy of presence data should be used", originalPresenceData, disconnectPresenceData)
+            Assert.assertEquals("Presence data should be an exact copy", originalPresenceData, disconnectPresenceData)
+        }
+    }
+
+    private fun mockTrackableRemovalRequested() {
+        every { trackableRemovalGuard.isMarkedForRemoval(trackable) } returns true
+    }
+
+    private fun mockPresenceData(presenceData: PresenceData) {
+        every { publisherProperties.presenceData } returns presenceData
+    }
+}


### PR DESCRIPTION
I've added tests for `ConnectionCreatedWorker`. To do that I had to update the mocking library, which introduced a bug for which I've luckily found a workaround.