### PR TITLE
Add trackable removal requested worker tests

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -21,6 +21,7 @@ import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.guards.DublicateTrackableGuardImpl
 import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
+import com.ably.tracking.publisher.guards.TrackableRemovalGuardImpl
 import com.ably.tracking.publisher.workerqueue.EventWorkerQueue
 import com.ably.tracking.publisher.workerqueue.WorkerQueue
 import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
@@ -859,7 +860,7 @@ constructor(
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val duplicateTrackableGuard: DuplicateTrackableGuard = DublicateTrackableGuardImpl()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
-        override val trackableRemovalGuard: TrackableRemovalGuard = TrackableRemovalGuard()
+        override val trackableRemovalGuard: TrackableRemovalGuard = TrackableRemovalGuardImpl()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
 
         override fun dispose() {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/TrackableRemovalGuard.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/TrackableRemovalGuard.kt
@@ -7,7 +7,14 @@ import com.ably.tracking.publisher.Trackable
  * This guard class will keep track of trackables that are requested for removal. The aim of this class is to
  * maintain a set of trackables and expose client functions.
  */
-internal class TrackableRemovalGuard {
+internal interface TrackableRemovalGuard {
+    fun markForRemoval(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>)
+    fun isMarkedForRemoval(trackable: Trackable): Boolean
+    fun removeMarked(trackable: Trackable, result: Result<Boolean>)
+    fun clearAll()
+}
+
+internal class TrackableRemovalGuardImpl : TrackableRemovalGuard {
 
     /**
      * A set of trackables that were marked for removal. This should be used to store / retrieve trackables
@@ -15,7 +22,7 @@ internal class TrackableRemovalGuard {
      */
     private val trackables = hashMapOf<Trackable, MutableList<ResultCallbackFunction<Boolean>>>()
 
-    fun markForRemoval(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>) {
+    override fun markForRemoval(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>) {
         trackables[trackable]?.let {
             it.add(callbackFunction)
         } ?: kotlin.run {
@@ -24,14 +31,14 @@ internal class TrackableRemovalGuard {
         }
     }
 
-    fun isMarkedForRemoval(trackable: Trackable): Boolean = trackables.contains(trackable)
+    override fun isMarkedForRemoval(trackable: Trackable): Boolean = trackables.contains(trackable)
 
-    fun removeMarked(trackable: Trackable, result: Result<Boolean>) {
+    override fun removeMarked(trackable: Trackable, result: Result<Boolean>) {
         val handlers = trackables.remove(trackable)
         handlers?.forEach {
             it(result)
         }
     }
 
-    fun clearAll() = trackables.clear()
+    override fun clearAll() = trackables.clear()
 }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/guards/TrackableRemovalGuardTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/guards/TrackableRemovalGuardTest.kt
@@ -6,7 +6,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TrackableRemovalGuardTest {
-    private val trackableRemovalGuard = TrackableRemovalGuard()
+    private val trackableRemovalGuard = TrackableRemovalGuardImpl()
 
     @Test
     fun `marking trackable for removal really marks it for removal`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
@@ -1,0 +1,175 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.AddTrackableCallbackFunction
+import com.ably.tracking.publisher.AddTrackableResult
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.RemoveTrackableRequestedException
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
+import com.ably.tracking.publisher.guards.TrackableRemovalGuard
+import io.mockk.CapturingSlot
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class TrackableRemovalRequestedWorkerTest {
+    private lateinit var worker: TrackableRemovalRequestedWorker
+    private val trackable = Trackable("test-trackable")
+    private val resultCallbackFunction = mockk<ResultCallbackFunction<StateFlow<TrackableState>>>(relaxed = true)
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val trackableRemovalGuard = TrackableRemovalGuardSpy()
+    private val duplicateTrackableGuard = DuplicateTrackableGuardSpy()
+
+    @Before
+    fun setUp() {
+        prepareWorkerWithResult(Result.success(Unit))
+        every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
+        every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+        duplicateTrackableGuard.reset()
+        trackableRemovalGuard.reset()
+    }
+
+    @Test
+    fun `should always return an empty result`() {
+        // given
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should always call the add trackable callback with a trackable removal requested exception`() {
+        // given
+        val addTrackableResultSlot = captureResultCallbackFunctionResult()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        val addTrackableResult = addTrackableResultSlot.captured
+        Assert.assertTrue(addTrackableResult.isFailure)
+        Assert.assertTrue(addTrackableResult.exceptionOrNull() is RemoveTrackableRequestedException)
+    }
+
+    @Test
+    fun `should always finish adding the trackable with a trackable removal requested exception`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        val finishAddingTrackableResult = duplicateTrackableGuard.lastFinishAddingTrackableResult!!
+        Assert.assertTrue(finishAddingTrackableResult.isFailure)
+        Assert.assertTrue(finishAddingTrackableResult.exceptionOrNull() is RemoveTrackableRequestedException)
+    }
+
+    @Test
+    fun `should mark removal success if result is successful`() {
+        // given
+        prepareWorkerWithResult(Result.success(Unit))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        val removeMarkedResult = trackableRemovalGuard.lastRemoveMarkedResult!!
+        Assert.assertTrue(removeMarkedResult.isSuccess)
+        Assert.assertTrue(removeMarkedResult.getOrNull()!!)
+    }
+
+    @Test
+    fun `should mark removal failure if result is failure`() {
+        // given
+        prepareWorkerWithResult(Result.failure(Exception()))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        val removeMarkedResult = trackableRemovalGuard.lastRemoveMarkedResult!!
+        Assert.assertTrue(removeMarkedResult.isFailure)
+        Assert.assertNotNull(removeMarkedResult.exceptionOrNull())
+    }
+
+    private fun prepareWorkerWithResult(result: Result<Unit>) {
+        worker = TrackableRemovalRequestedWorker(trackable, resultCallbackFunction, result)
+    }
+
+    private fun captureResultCallbackFunctionResult(): CapturingSlot<Result<StateFlow<TrackableState>>> {
+        val resultCallbackFunctionResult = slot<Result<StateFlow<TrackableState>>>()
+        every { resultCallbackFunction.invoke(capture(resultCallbackFunctionResult)) } just runs
+        return resultCallbackFunctionResult
+    }
+}
+
+/**
+ * This class is a test utility that we had to create because the Mockk library couldn't mock the
+ * [finishAddingTrackable] method (i.e. the result parameter). We've previously noticed that this
+ * library has troubles with the Kotlin's [Result] type and couldn't find any workaround, hence
+ * this class was created. This is the same issue that's behind [TrackableRemovalGuardSpy].
+ */
+private class DuplicateTrackableGuardSpy : DuplicateTrackableGuard {
+    var lastFinishAddingTrackableResult: Result<AddTrackableResult>? = null
+
+    override fun startAddingTrackable(trackable: Trackable) = Unit
+
+    override fun finishAddingTrackable(trackable: Trackable, result: Result<AddTrackableResult>) {
+        lastFinishAddingTrackableResult = result
+    }
+
+    override fun isCurrentlyAddingTrackable(trackable: Trackable): Boolean = false
+
+    override fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction) = Unit
+
+    override fun clear(trackable: Trackable) = Unit
+
+    override fun clearAll() = Unit
+
+    fun reset() {
+        lastFinishAddingTrackableResult = null
+    }
+}
+
+/**
+ * This class is a test utility that we had to create because the Mockk library couldn't mock the
+ * [removeMarked] method (i.e. the result parameter). We've previously noticed that this
+ * library has troubles with the Kotlin's [Result] type and couldn't find any workaround, hence
+ * this class was created. This is the same issue that's behind [DuplicateTrackableGuardSpy].
+ */
+private class TrackableRemovalGuardSpy : TrackableRemovalGuard {
+    var lastRemoveMarkedResult: Result<Boolean>? = null
+
+    override fun markForRemoval(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>) = Unit
+
+    override fun isMarkedForRemoval(trackable: Trackable): Boolean = false
+
+    override fun removeMarked(trackable: Trackable, result: Result<Boolean>) {
+        lastRemoveMarkedResult = result
+    }
+
+    override fun clearAll() = Unit
+
+    fun reset() {
+        lastRemoveMarkedResult = null
+    }
+}


### PR DESCRIPTION
I've added tests for `TrackableRemovalRequestedWorker`.

Unfortunately, the mocking library we use (`Mockk`) has some troubles with mocking methods that have Kotlin's `Result<T>` type as a parameter. We've encountered issues with `Mockk` and `Result<T>` before but this time I couldn't find a workaround for the issue. Therefore, I've added 2 spy classes (`DuplicateTrackableGuardSpy` and `TrackableRemovalGuardSpy`) that are performing the tasks that normally the mocks would do.

Additionally, I've added an interface for `TrackableRemovalGuard` to make it more testable and match the approach we've previously taken towards the other guard classes (i.e. `DuplicateTrackableGuard`).