### PR TITLE
Publish to the MavenCentral

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -16,8 +16,9 @@ jobs:
 
     steps:
 
-#    Temporarily disable git branch checkout to test this on other branches than the main branch
-#    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+#      Temporarily disable tag checkout to test this workflow. According to checkout docs, if we don't specify any ref then:
+#      "When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch."
 #      with:
 #        ref: v${{ github.event.inputs.version }}
 

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -16,9 +16,10 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
-      with:
-        ref: v${{ github.event.inputs.version }}
+#    Temporarily disable git branch checkout to test this on other branches than the main branch
+#    - uses: actions/checkout@v2
+#      with:
+#        ref: v${{ github.event.inputs.version }}
 
     # Gradle 7 requires Java 11 to run
     - uses: actions/setup-java@v2
@@ -32,8 +33,11 @@ jobs:
         ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
         ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
         ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-        ORG_GRADLE_PROJECT_GITHUB_ACTOR: ${{ github.actor }}
-        ORG_GRADLE_PROJECT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORG_GRADLE_PROJECT_OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        ORG_GRADLE_PROJECT_OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
-        echo "Publishing to GitHub Packages version ${{ github.event.inputs.version }}..."
-        ./gradlew publish -PpublishTarget=GitHubPackages
+        echo "Publishing to MavenCentral version ${{ github.event.inputs.version }}..."
+        ./gradlew publishToSonatype -PpublishTarget=MavenCentral closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -38,7 +38,7 @@ jobs:
         ORG_GRADLE_PROJECT_OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
         ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
         echo "Publishing version ${{ github.event.inputs.version }} to MavenCentral..."
         ./gradlew publishToSonatype -PpublishTarget=MavenCentral closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -39,5 +39,5 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
-        echo "Publishing to MavenCentral version ${{ github.event.inputs.version }}..."
+        echo "Publishing version ${{ github.event.inputs.version }} to MavenCentral..."
         ./gradlew publishToSonatype -PpublishTarget=MavenCentral closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,9 @@ jobs:
         ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         ORG_GRADLE_PROJECT_GITHUB_ACTOR: ${{ github.actor }}
         ORG_GRADLE_PROJECT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
         echo "Publishing version ${{ github.event.inputs.version }} to GitHub Packages..."
         ./gradlew publish -PpublishTarget=GitHubPackages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         ORG_GRADLE_PROJECT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
         ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
         echo "Publishing version ${{ github.event.inputs.version }} to GitHub Packages..."
         ./gradlew publish -PpublishTarget=GitHubPackages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,5 @@ jobs:
         ORG_GRADLE_PROJECT_GITHUB_ACTOR: ${{ github.actor }}
         ORG_GRADLE_PROJECT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "Publishing to GitHub Packages version ${{ github.event.inputs.version }}..."
+        echo "Publishing version ${{ github.event.inputs.version }} to GitHub Packages..."
         ./gradlew publish -PpublishTarget=GitHubPackages

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 plugins {
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0'
     id 'org.jetbrains.dokka' version '1.4.32'
+    id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
 }
 
 // https://github.com/Kotlin/dokka/issues/2202#issuecomment-950666269
@@ -44,6 +45,14 @@ allprojects {
     // version MUST conform to the Semantic Versioning Specification (https://semver.org/) version 2.0.0
     // on incrementing this value, ensure to also increment versionCode in android defaultConfig (also in this file)
     version = '1.0.0-beta.15'
+
+    // Values used to publish the SDK to maven repositories.
+    ext {
+        PUBLISH_GROUP_ID = group
+        PUBLISH_ARTIFACT_ID = project.name // This returns the module/project name, like "publishing-sdk".
+        PUBLISH_VERSION = version
+        PUBLISH_POM_NAME = "${PUBLISH_GROUP_ID}:${PUBLISH_ARTIFACT_ID}"
+    }
 
     repositories {
         google()
@@ -259,3 +268,5 @@ subprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: "setup-mavencentral-publishing.gradle"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,4 +20,8 @@ android {
     }
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking shared code that should not be visible in the API."
+}
+
 apply from: '../publish.gradle'

--- a/core-sdk-java/build.gradle
+++ b/core-sdk-java/build.gradle
@@ -11,4 +11,8 @@ dependencies {
     api project(':core-sdk')
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking shared code that is visible in the Java API."
+}
+
 apply from: '../publish.gradle'

--- a/core-sdk/build.gradle
+++ b/core-sdk/build.gradle
@@ -11,5 +11,9 @@ android {
     }
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking shared code that is visible in the API."
+}
+
 apply from: '../jacoco.gradle'
 apply from: '../publish.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,6 @@ apply plugin: 'signing'
 
 final githubActor = findProperty('GITHUB_ACTOR')
 final githubToken = findProperty('GITHUB_TOKEN')
-final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
 final isPublishingToGitHubPackages = findProperty('publishTarget') == 'GitHubPackages'
 
 task sourcesJar(type: Jar) {
@@ -74,14 +73,12 @@ afterEvaluate {
     }
 }
 
-if (isPublishingToMavenCentral) {
-    // Sign the artifacts
-    signing {
-        useInMemoryPgpKeys(
-            findProperty("SIGNING_KEY_ID"),
-            findProperty("SIGNING_KEY"),
-            findProperty("SIGNING_PASSWORD"),
-        )
-        sign publishing.publications
-    }
+// Sign the artifacts
+signing {
+    useInMemoryPgpKeys(
+        findProperty("SIGNING_KEY_ID"),
+        findProperty("SIGNING_KEY"),
+        findProperty("SIGNING_PASSWORD"),
+    )
+    sign publishing.publications
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -51,7 +51,7 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection = 'scm:git:github.com/ably/ably-asset-tracking-android.git'
+                        connection = 'scm:git:git://github.com/ably/ably-asset-tracking-android.git'
                         developerConnection = 'scm:git:ssh://github.com/ably/ably-asset-tracking-android.git'
                         url = 'https://github.com/ably/ably-asset-tracking-android/tree/main'
                     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,6 +3,8 @@ apply plugin: 'signing'
 
 final githubActor = findProperty('GITHUB_ACTOR')
 final githubToken = findProperty('GITHUB_TOKEN')
+final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
+final isPublishingToGitHubPackages = findProperty('publishTarget') == 'GitHubPackages'
 
 task sourcesJar(type: Jar) {
     // Copy files from main source directories to the JAR.
@@ -58,7 +60,7 @@ afterEvaluate {
         }
 
         repositories {
-            if (githubActor != null && githubToken != null) {
+            if (isPublishingToGitHubPackages && githubActor != null && githubToken != null) {
                 // per: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry
                 maven {
                     url = uri("https://maven.pkg.github.com/ably/ably-asset-tracking-android")
@@ -72,12 +74,14 @@ afterEvaluate {
     }
 }
 
-// Sign the artifacts
-signing {
-    useInMemoryPgpKeys(
-        findProperty("SIGNING_KEY_ID"),
-        findProperty("SIGNING_KEY"),
-        findProperty("SIGNING_PASSWORD"),
-    )
-    sign publishing.publications
+if (isPublishingToMavenCentral) {
+    // Sign the artifacts
+    signing {
+        useInMemoryPgpKeys(
+            findProperty("SIGNING_KEY_ID"),
+            findProperty("SIGNING_KEY"),
+            findProperty("SIGNING_PASSWORD"),
+        )
+        sign publishing.publications
+    }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 final githubActor = findProperty('GITHUB_ACTOR')
 final githubToken = findProperty('GITHUB_TOKEN')
@@ -27,10 +28,32 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
 
+                groupId PUBLISH_GROUP_ID
+                artifactId PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
                 // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).
                 artifact sourcesJar
                 // Add a JAR with javadocs.
                 artifact dokkaJavadocJar
+
+                // Add POM metadata
+                pom {
+                    name = PUBLISH_POM_NAME
+                    description = PUBLISH_POM_DESCRIPTION
+                    url = 'https://github.com/ably/ably-asset-tracking-android'
+                    licenses {
+                        license {
+                            name = 'Apache License 2.0'
+                            url = 'https://github.com/ably/ably-asset-tracking-android/blob/main/LICENSE'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:github.com/ably/ably-asset-tracking-android.git'
+                        developerConnection = 'scm:git:ssh://github.com/ably/ably-asset-tracking-android.git'
+                        url = 'https://github.com/ably/ably-asset-tracking-android/tree/main'
+                    }
+                }
             }
         }
 
@@ -47,4 +70,14 @@ afterEvaluate {
             }
         }
     }
+}
+
+// Sign the artifacts
+signing {
+    useInMemoryPgpKeys(
+        findProperty("SIGNING_KEY_ID"),
+        findProperty("SIGNING_KEY"),
+        findProperty("SIGNING_PASSWORD"),
+    )
+    sign publishing.publications
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -75,9 +75,12 @@ afterEvaluate {
 
 // Sign the artifacts
 signing {
+    // According to signing plugin docs we should be providing the secret key in the ascii-armored format.
+    // This means that the bytes of the key should be converted to a Base64 encoded string.
+    // https://docs.gradle.org/current/userguide/signing_plugin.html#using_in_memory_ascii_armored_openpgp_subkeys
     useInMemoryPgpKeys(
         findProperty("SIGNING_KEY_ID"),
-        findProperty("SIGNING_KEY"),
+        findProperty("SIGNING_KEY_BASE64"),
         findProperty("SIGNING_PASSWORD"),
     )
     sign publishing.publications

--- a/publishing-sdk-java/build.gradle
+++ b/publishing-sdk-java/build.gradle
@@ -13,4 +13,8 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2'
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Publisher SDK for Java."
+}
+
 apply from: '../publish.gradle'

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -47,4 +47,8 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:17.1.0'
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Publisher SDK for Kotlin."
+}
+
 apply from: '../publish.gradle'

--- a/setup-mavencentral-publishing.gradle
+++ b/setup-mavencentral-publishing.gradle
@@ -1,15 +1,18 @@
 // MavenCentral publishing Sonatype configuration
+final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            username = findProperty('OSSRH_USERNAME') ?: ""
-            password = findProperty('OSSRH_PASSWORD') ?: ""
+if (isPublishingToMavenCentral) {
+    nexusPublishing {
+        repositories {
+            sonatype {
+                username = findProperty('OSSRH_USERNAME') ?: ""
+                password = findProperty('OSSRH_PASSWORD') ?: ""
 
-            // According to the plugin docs the "nexusUrl" and "snapshotRepositoryUrl" have to be added as we've registered after February 2021.
-            // https://github.com/gradle-nexus/publish-plugin/#publishing-to-maven-central-via-sonatype-ossrh
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+                // According to the plugin docs the "nexusUrl" and "snapshotRepositoryUrl" have to be added as we've registered after February 2021.
+                // https://github.com/gradle-nexus/publish-plugin/#publishing-to-maven-central-via-sonatype-ossrh
+                nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            }
         }
     }
 }

--- a/setup-mavencentral-publishing.gradle
+++ b/setup-mavencentral-publishing.gradle
@@ -1,0 +1,15 @@
+// MavenCentral publishing Sonatype configuration
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = findProperty('OSSRH_USERNAME') ?: ""
+            password = findProperty('OSSRH_PASSWORD') ?: ""
+
+            // According to the plugin docs the "nexusUrl" and "snapshotRepositoryUrl" have to be added as we've registered after February 2021.
+            // https://github.com/gradle-nexus/publish-plugin/#publishing-to-maven-central-via-sonatype-ossrh
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}

--- a/subscribing-sdk-java/build.gradle
+++ b/subscribing-sdk-java/build.gradle
@@ -13,4 +13,8 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2'
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Subscriber SDK for Java."
+}
+
 apply from: '../publish.gradle'

--- a/subscribing-sdk/build.gradle
+++ b/subscribing-sdk/build.gradle
@@ -18,4 +18,8 @@ dependencies {
     implementation project(':common')
 }
 
+ext {
+    PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Subscriber SDK for Kotlin."
+}
+
 apply from: '../publish.gradle'


### PR DESCRIPTION
Added configuration and workflow for publishing the SDKs to the MavenCentral.
The new workflow has temporarily disabled the version tag checkout in order to test it without merging the whole work to the `main` branch.

I've based this configuration on:
- https://github.com/gradle-nexus/publish-plugin
- https://proandroiddev.com/publishing-android-libraries-to-mavencentral-in-2021-8ac9975c3e52
- https://medium.com/mobile-app-development-publication/upload-to-mavencentral-made-easy-for-android-library-30d2b83af0c7
- https://github.com/ably/ably-asset-tracking-android/pull/499
- https://central.sonatype.org/publish/publish-gradle/