### PR TITLE
Clear route when the new active trackable does not have a destination

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -218,8 +218,12 @@ constructor(
                         if (properties.active != event.trackable) {
                             properties.active = event.trackable
                             hooks.trackables?.onActiveTrackableChanged(event.trackable)
-                            event.trackable.destination?.let {
-                                setDestination(it, properties)
+                            event.trackable.destination.let {
+                                if (it != null) {
+                                    setDestination(it, properties)
+                                } else {
+                                    removeCurrentDestination(properties)
+                                }
                             }
                         }
                         event.handler(Result.success(Unit))

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -200,4 +200,21 @@ class DefaultPublisherTest {
         Assert.assertEquals(1, callsOrder[0])
         Assert.assertEquals(2, callsOrder[1])
     }
+
+    @Test()
+    fun `should clear the route if the new active trackable does not have a destination`() {
+        // given
+        val trackableWithoutDestination = Trackable(UUID.randomUUID().toString())
+        ably.mockCreateConnectionSuccess(trackableWithoutDestination.id)
+
+        // when
+        runBlocking {
+            publisher.track(trackableWithoutDestination)
+        }
+
+        // then
+        verify(exactly = 1) {
+            mapbox.clearRoute()
+        }
+    }
 }


### PR DESCRIPTION
When setting a new active trackable that does not have a destination we should clear the route so it won't navigate to the previously active trackable destination.