### PR TITLE
Maven Central release process

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -17,10 +17,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-#      Temporarily disable tag checkout to test this workflow. According to checkout docs, if we don't specify any ref then:
-#      "When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch."
-#      with:
-#        ref: v${{ github.event.inputs.version }}
+      with:
+        ref: v${{ github.event.inputs.version }}
 
     # Gradle 7 requires Java 11 to run
     - uses: actions/setup-java@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,11 @@ The release process must include the following steps:
 7. Gain approval(s) for the release PR from maintainer(s)
 8. Land the release PR to `main`
 9. Create a tag named like `v1.2.3` and push it to GitHub
-10. Run the [publish workflow](https://github.com/ably/ably-asset-tracking-android/actions/workflows/publish.yml) from the `main` branch (manually triggered, where you supply the version number so the script publishes only up to that tag)
+10. Run the publish workflows:
+    - These are manually triggered, where you supply the version number so the script publishes only up to that tag
+    - They must be run from the `main` branch
+    - First workflow: [Maven Central](https://github.com/ably/ably-asset-tracking-android/blob/main/.github/workflows/publish-maven-central.yml)
+    - Second workflow: [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/actions/workflows/publish-github-packages.yml)
 
 We tend to use [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator) to collate the information required for a change log update.
 Your mileage may vary, but it seems the most reliable method to invoke the generator is something like:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To [install the dependency](https://docs.github.com/en/packages/working-with-a-g
 You have to get either a `GITHUB_TOKEN` or a "Personal Access Token" (with the `read:packages` permission).
 Then use that token to authenticate with the AAT GitHub Packages repository:
 
-```gradle
+```groovy
 repositories {
     maven {
         name = "Ably Asset Tracking"
@@ -82,7 +82,7 @@ repositories {
 
 In order to resolve all AAT dependencies you will also need to authenticate in the Mapbox repository:
 
-```gradle
+```groovy
 repositories {
     maven {
         name = "Mapbox"
@@ -100,7 +100,7 @@ repositories {
 
 Finally, you can add the AAT dependency in the Gradle build script
 
-```gradle
+```groovy
 dependencies {
     // Publishing SDK for publishers
     implementation 'com.ably.tracking:publishing-sdk:1.0.0-beta.15'


### PR DESCRIPTION
[Documented](https://github.com/ably/ably-asset-tracking-android/commit/4ac141e3744887f8bd069dd962c79d6582df2665) and [finished implementation](https://github.com/ably/ably-asset-tracking-android/commit/5a9e165d34c45525a174b282d1155c6856b35f98).

@KacperKluka, we'll document procedure from the app developer's perspective under a separate pull request.