### PR TITLE
Add info about installing the AAT SDK from the Maven Central repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
 First, you need to declare the repository from which the Ably Asset Tracking dependency will be installed.
-We support both [Maven Central](#using-maven-central) and [GitHub Packages](#using-github-packages).
+We support both [Maven Central](#downloading-from-maven-central) and [GitHub Packages](#downloading-from-github-packages).
 
 #### Downloading from Maven Central
 
-We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/).
+We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/),
+which is the pubic repository that most users will choose to download the Ably Asset Tracking SDK from.
 
 To install the dependency you need to make sure that you have [declared the Maven Central repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) in your build script:
 
@@ -76,7 +77,8 @@ repositories {
 
 #### Downloading from GitHub Packages
 
-We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
+We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository,
+which is an alternative option for those who do not wish to download the Ably Asset Tracking SDK from [Maven Central](#downloading-from-maven-central).
 
 To [install the dependency](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package) you will first need to [authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#authenticating-to-github-packages).
 You have to get either a `GITHUB_TOKEN` or a "Personal Access Token" (with the `read:packages` permission).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We support both [Maven Central](#downloading-from-maven-central) and [GitHub Pac
 We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/),
 which is the pubic repository that most users will choose to download the Ably Asset Tracking SDK from.
 
-To install the dependency you need to make sure that you have [declared the Maven Central repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) in your build script:
+To install the dependency you need to make sure that you have [declared the Maven Central repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) in your Gradle build script:
 
 ```groovy
 repositories {
@@ -82,7 +82,7 @@ which is an alternative option for those who do not wish to download the Ably As
 
 To [install the dependency](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package) you will first need to [authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#authenticating-to-github-packages).
 You have to get either a `GITHUB_TOKEN` or a "Personal Access Token" (with the `read:packages` permission).
-Then use that token to authenticate with the Ably Asset Tracking GitHub Packages repository:
+Then use that token to authenticate with the Ably Asset Tracking GitHub Packages repository in your Gradle build script:
 
 ```gradle
 repositories {
@@ -99,7 +99,7 @@ repositories {
 
 #### Mapbox Repository
 
-Next, in order to resolve all Ably Asset Tracking dependencies you will also need to authenticate in the Mapbox repository:
+Next, in order to resolve all Ably Asset Tracking dependencies you will also need to authenticate with the Mapbox repository in your Gradle build script:
 
 ```gradle
 repositories {

--- a/README.md
+++ b/README.md
@@ -117,19 +117,23 @@ repositories {
 }
 ```
 
-#### Declaring the Ably Asset Tracking dependencies
+#### Adding Implementation Dependencies
 
-Finally, you can add the Ably Asset Tracking dependency in the Gradle build script:
+Once you have configured Gradle to know where it can download dependencies from (see above),
+you can then add the Ably Asset Tracking dependency that you require in your Gradle build script:
 
 ```groovy
 dependencies {
-    // Publishing SDK for publishers
+    // Publishers, developing in Kotlin, will need the Publishing SDK
     implementation 'com.ably.tracking:publishing-sdk:1.0.0-beta.15'
 
-    // Subscribing SDK for subscribers
+    // Subscribers, developing in Kotlin, will need the Subscribing SDK
     implementation 'com.ably.tracking:subscribing-sdk:1.0.0-beta.15'
 }
 ```
+
+It's likely that for most application use cases you will need one or the other
+(i.e. _either_ the Publishing SDK, _or_ the Subscribing SDK).
 
 ### Publishing SDK
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,23 @@ Kotlin users will want to add either `publishing-sdk` or `subscribing-sdk`, acco
 Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
-#### GitHub Packages
+#### Declaring AAT repository
+
+First, you need to declare the repository from which the AAT dependency will be installed. We support both Maven Central and GitHub Packages repositories.
+
+##### Using Maven Central
+
+We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/).
+
+To install the dependency you need to make sure that you have [declared the Maven Central repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) in your build script:
+
+```groovy
+repositories {
+    mavenCentral()
+}
+```
+
+##### Using GitHub Packages
 
 We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
 
@@ -80,7 +96,9 @@ repositories {
 }
 ```
 
-In order to resolve all AAT dependencies you will also need to authenticate in the Mapbox repository:
+#### Mapbox Repository
+
+Next, in order to resolve all AAT dependencies you will also need to authenticate in the Mapbox repository:
 
 ```gradle
 repositories {
@@ -98,7 +116,9 @@ repositories {
 }
 ```
 
-Finally, you can add the AAT dependency in the Gradle build script
+#### Declaring the AAT dependencies
+
+Finally, you can add the AAT dependency in the Gradle build script:
 
 ```gradle
 dependencies {

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ repositories {
 }
 ```
 
-#### Mapbox Repository
+#### Downloading Transitive Dependencies from the Mapbox Repository
 
-Next, in order to resolve all Ably Asset Tracking dependencies you will also need to authenticate with the Mapbox repository in your Gradle build script:
+In order to resolve all dependencies required by the Ably Asset Tracking SDK, you will also need to authenticate with the Mapbox repository in your Gradle build script:
 
 ```groovy
 repositories {

--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ Kotlin users will want to add either `publishing-sdk` or `subscribing-sdk`, acco
 Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
-#### Declaring AAT repository
+First, you need to declare the repository from which the AAT dependency will be installed.
+We support both [Maven Central](#using-maven-central) and [GitHub Packages](#using-github-packages).
 
-First, you need to declare the repository from which the AAT dependency will be installed. We support both Maven Central and GitHub Packages repositories.
-
-##### Using Maven Central
+#### Downloading from Maven Central
 
 We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/).
 
@@ -75,7 +74,7 @@ repositories {
 }
 ```
 
-##### Using GitHub Packages
+#### Downloading from GitHub Packages
 
 We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-android/packages/) for this repository.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Kotlin users will want to add either `publishing-sdk` or `subscribing-sdk`, acco
 Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
-First, you need to declare the repository from which the AAT dependency will be installed.
+First, you need to declare the repository from which the Ably Asset Tracking dependency will be installed.
 We support both [Maven Central](#using-maven-central) and [GitHub Packages](#using-github-packages).
 
 #### Downloading from Maven Central
@@ -80,7 +80,7 @@ We publish to [GitHub Packages](https://github.com/ably/ably-asset-tracking-andr
 
 To [install the dependency](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package) you will first need to [authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#authenticating-to-github-packages).
 You have to get either a `GITHUB_TOKEN` or a "Personal Access Token" (with the `read:packages` permission).
-Then use that token to authenticate with the AAT GitHub Packages repository:
+Then use that token to authenticate with the Ably Asset Tracking GitHub Packages repository:
 
 ```gradle
 repositories {
@@ -97,7 +97,7 @@ repositories {
 
 #### Mapbox Repository
 
-Next, in order to resolve all AAT dependencies you will also need to authenticate in the Mapbox repository:
+Next, in order to resolve all Ably Asset Tracking dependencies you will also need to authenticate in the Mapbox repository:
 
 ```gradle
 repositories {
@@ -115,9 +115,9 @@ repositories {
 }
 ```
 
-#### Declaring the AAT dependencies
+#### Declaring the Ably Asset Tracking dependencies
 
-Finally, you can add the AAT dependency in the Gradle build script:
+Finally, you can add the Ably Asset Tracking dependency in the Gradle build script:
 
 ```gradle
 dependencies {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We support both [Maven Central](#downloading-from-maven-central) and [GitHub Pac
 #### Downloading from Maven Central
 
 We publish to [Maven Central](https://repo1.maven.org/maven2/com/ably/tracking/),
-which is the pubic repository that most users will choose to download the Ably Asset Tracking SDK from.
+which is the public repository that most users will choose to download the Ably Asset Tracking SDK from.
 
 To install the dependency you need to make sure that you have [declared the Maven Central repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) in your Gradle build script:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Kotlin users will want to add either `publishing-sdk` or `subscribing-sdk`, acco
 Java users should add either `publishing-sdk-java` or `subscribing-sdk-java`.
 See [Android Runtime Requirements](#android-runtime-requirements) for more details.
 
-First, you need to declare the repository from which the Ably Asset Tracking dependency will be installed.
+You need to declare the repository from which the Ably Asset Tracking SDK dependency will be installed.
 We support both [Maven Central](#downloading-from-maven-central) and [GitHub Packages](#downloading-from-github-packages).
 
 #### Downloading from Maven Central


### PR DESCRIPTION
I've added the info about using the SDKs from Maven Central.