### PR TITLE
Remove unnecessary sleeps in the publisher-subscriber integration test

### DIFF
--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -45,10 +45,6 @@ class PublisherAndSubscriberTests {
             .onEach { receivedLocations.add(it) }
             .launchIn(scope)
 
-        // TODO replace this sleep with an await on an expectation that the subscriber is ready (connected and subscribed)
-        // https://github.com/ably/ably-asset-tracking-android/issues/211
-        Thread.sleep(4000)
-
         val publisher = createAndStartPublisher(
             context,
             onLocationDataEnded = {
@@ -73,10 +69,6 @@ class PublisherAndSubscriberTests {
 
         // await
         dataEndedExpectation.await()
-
-        // TODO replace this sleep with an await on an expectation
-        // https://github.com/ably/ably-asset-tracking-android/issues/212
-        Thread.sleep(6000)
 
         testLogD("COUNT published ${publishedLocations.size}") // observed 15
         testLogD("COUNT received ${receivedLocations.size}") // observed 12


### PR DESCRIPTION
After some investigation and multiple local runs of the tests it looks like both sleep calls are unnecessary with current SDK implementation. However, if it turns out that in the CI environment this test becomes flakey, we can reintroduce the sleep after the "data ended expectation" but IMO it should be much smaller than 6 seconds (I'd say 1 second should be enough).