### PR TITLE
Add timestamps to log statements

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
+++ b/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
@@ -4,25 +4,30 @@ import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.logging.LogLevel
 
 fun LogHandler.v(message: String, throwable: Throwable? = null) {
-    logMessage(LogLevel.VERBOSE, message, throwable)
+    log(LogLevel.VERBOSE, message, throwable)
 }
 
 fun LogHandler.i(message: String, throwable: Throwable? = null) {
-    logMessage(LogLevel.INFO, message, throwable)
+    log(LogLevel.INFO, message, throwable)
 }
 
 fun LogHandler.d(message: String, throwable: Throwable? = null) {
-    logMessage(LogLevel.DEBUG, message, throwable)
+    log(LogLevel.DEBUG, message, throwable)
 }
 
 fun LogHandler.w(message: String, throwable: Throwable? = null) {
-    logMessage(LogLevel.WARN, message, throwable)
+    log(LogLevel.WARN, message, throwable)
 }
 
 fun LogHandler.e(message: String, throwable: Throwable? = null) {
-    logMessage(LogLevel.ERROR, message, throwable)
+    log(LogLevel.ERROR, message, throwable)
 }
 
 fun LogHandler.e(throwable: Throwable) {
-    logMessage(LogLevel.ERROR, "", throwable)
+    log(LogLevel.ERROR, "", throwable)
+}
+
+private fun LogHandler.log(level: LogLevel, message: String, throwable: Throwable? = null) {
+    val currentTimestamp = System.currentTimeMillis()
+    logMessage(level, "$currentTimestamp: $message", throwable)
 }

--- a/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
+++ b/common/src/main/java/com/ably/tracking/common/logging/LoggingExtensions.kt
@@ -2,6 +2,9 @@ package com.ably.tracking.common.logging
 
 import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.logging.LogLevel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 fun LogHandler.v(message: String, throwable: Throwable? = null) {
     log(LogLevel.VERBOSE, message, throwable)
@@ -27,7 +30,9 @@ fun LogHandler.e(throwable: Throwable) {
     log(LogLevel.ERROR, "", throwable)
 }
 
+private val timestampFormat = SimpleDateFormat("dd-MM-yy HH:mm:ss.SSS", Locale.ROOT)
+
 private fun LogHandler.log(level: LogLevel, message: String, throwable: Throwable? = null) {
-    val currentTimestamp = System.currentTimeMillis()
+    val currentTimestamp = timestampFormat.format(Date())
     logMessage(level, "$currentTimestamp: $message", throwable)
 }


### PR DESCRIPTION
I've added the timestamp in milliseconds since the epoch at the start of each log statement. Here's an example on how it looks:
```
25-01-22 14:22:23.843: [DefaultMapbox] Stop and close Mapbox
25-01-22 14:22:23.887: [DefaultMapbox] Destroy the MapboxNavigation instance
25-01-22 14:22:23.918: [DefaultMapbox] Change location engine resolution
25-01-22 14:22:24.034: io.ably.lib.transport.ConnectionManager: requestState(): requesting closing; id = rK0Y4LadyZ
```