### PR TITLE
Add connection ready worker

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
@@ -1,0 +1,19 @@
+package com.ably.tracking.publisher.workerqueue.resulthandlers
+
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+
+internal class ConnectionReadyResultHandler : WorkResultHandler<ConnectionReadyWorkResult> {
+    override fun handle(workResult: ConnectionReadyWorkResult, corePublisher: CorePublisher): Worker? {
+        when (workResult) {
+            is ConnectionReadyWorkResult.RemovalRequested ->
+                return TrackableRemovalRequestedWorker(
+                    trackable = workResult.trackable,
+                    callbackFunction = workResult.callbackFunction,
+                    result = workResult.result
+                )
+        }
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
+import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
 
 @Suppress("UNCHECKED_CAST")
@@ -9,5 +10,6 @@ internal fun getWorkResultHandler(workResult: WorkResult): WorkResultHandler<Wor
     when (workResult) {
         is AddTrackableWorkResult -> AddTrackableResultHandler() as WorkResultHandler<WorkResult>
         is ConnectionCreatedWorkResult -> ConnectionCreatedResultHandler() as WorkResultHandler<WorkResult>
+        is ConnectionReadyWorkResult -> ConnectionReadyResultHandler() as WorkResultHandler<WorkResult>
         else -> throw IllegalArgumentException("Invalid workResult provided")
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -69,3 +69,11 @@ internal sealed class ConnectionCreatedWorkResult : WorkResult() {
         val exception: ConnectionException
     ) : ConnectionCreatedWorkResult()
 }
+
+internal sealed class ConnectionReadyWorkResult : WorkResult() {
+    internal data class RemovalRequested(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val result: Result<Unit>
+    ) : ConnectionReadyWorkResult()
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
@@ -1,0 +1,66 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.ConnectionForTrackableReadyEvent
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.DefaultCorePublisher
+import com.ably.tracking.publisher.Event
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class ConnectionReadyWorker(
+    private val trackable: Trackable,
+    private val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+    private val ably: Ably,
+    private val hooks: DefaultCorePublisher.Hooks,
+    private val corePublisher: CorePublisher,
+    private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
+) : Worker {
+    override val event: Event
+        get() = ConnectionForTrackableReadyEvent(trackable, callbackFunction)
+
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        if (properties.trackableRemovalGuard.isMarkedForRemoval(trackable)) {
+            val presenceData = properties.presenceData.copy()
+            return SyncAsyncResult(
+                asyncWork = {
+                    val result = ably.disconnect(trackable.id, presenceData)
+                    ConnectionReadyWorkResult.RemovalRequested(trackable, callbackFunction, result)
+                }
+            )
+        }
+
+        ably.subscribeForChannelStateChange(trackable.id) {
+            channelStateChangeListener(it)
+        }
+
+        if (!properties.isTracking) {
+            corePublisher.startLocationUpdates(properties)
+        }
+
+        properties.trackables.add(trackable)
+        corePublisher.updateTrackables(properties)
+        corePublisher.resolveResolution(trackable, properties)
+        hooks.trackables?.onTrackableAdded(trackable)
+
+        val trackableState = properties.trackableStates[trackable.id] ?: TrackableState.Offline()
+        val trackableStateFlow = properties.trackableStateFlows[trackable.id] ?: MutableStateFlow(trackableState)
+        properties.trackableStateFlows[trackable.id] = trackableStateFlow
+        corePublisher.updateTrackableStateFlows(properties)
+        properties.trackableStates[trackable.id] = trackableState
+
+        val successResult = Result.success(trackableStateFlow.asStateFlow())
+        callbackFunction(successResult)
+        properties.duplicateTrackableGuard.finishAddingTrackable(trackable, successResult)
+
+        return SyncAsyncResult()
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -6,6 +6,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
+import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert
 import org.junit.Test
@@ -22,6 +23,9 @@ class WorkResultHandlersTest {
         ConnectionCreatedWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),
         ConnectionCreatedWorkResult.PresenceSuccess(Trackable(""), {}, {}),
         ConnectionCreatedWorkResult.PresenceFail(Trackable(""), {}, ConnectionException(ErrorInformation(""))),
+    )
+    private val connectionReadyWorkResults = listOf(
+        ConnectionReadyWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),
     )
 
     @Test
@@ -54,6 +58,23 @@ class WorkResultHandlersTest {
             Assert.assertTrue(
                 "Work result ${it::class.simpleName} should return ConnectionCreatedResultHandler",
                 handler is ConnectionCreatedResultHandler
+            )
+        }
+    }
+
+    @Test
+    fun `should return ConnectionReadyResultHandler for each ConnectionReadyWorkResult`() {
+        connectionReadyWorkResults.forEach {
+            // given
+            val workResult = it
+
+            // when
+            val handler = getWorkResultHandler(workResult)
+
+            // then
+            Assert.assertTrue(
+                "Work result ${it::class.simpleName} should return ConnectionReadyResultHandler",
+                handler is ConnectionReadyResultHandler
             )
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -1,0 +1,327 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.DefaultCorePublisher
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
+import com.ably.tracking.publisher.guards.TrackableRemovalGuard
+import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
+import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
+import com.ably.tracking.test.common.mockSuspendingDisconnect
+import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
+import io.mockk.clearAllMocks
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ConnectionReadyWorkerTest {
+    private lateinit var worker: ConnectionReadyWorker
+    private val trackable = Trackable("test-trackable")
+    private val trackables = mockk<MutableSet<Trackable>>(relaxed = true)
+    private val trackableStates = mockk<MutableMap<String, TrackableState>>(relaxed = true)
+    private val trackableStateFlows = mockk<MutableMap<String, MutableStateFlow<TrackableState>>>(relaxed = true)
+    private val resultCallbackFunction = mockk<ResultCallbackFunction<StateFlow<TrackableState>>>(relaxed = true)
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val trackableRemovalGuard = mockk<TrackableRemovalGuard>(relaxed = true)
+    private val duplicateTrackableGuard = mockk<DuplicateTrackableGuard>(relaxed = true)
+    private val ably = mockk<Ably>(relaxed = true)
+    private val hooks = mockk<DefaultCorePublisher.Hooks>(relaxed = true)
+    private val corePublisher = mockk<CorePublisher>(relaxed = true)
+    private val connectionStateChangeListener: (ConnectionStateChange) -> Unit = {}
+
+    @Before
+    fun setUp() {
+        worker = ConnectionReadyWorker(
+            trackable,
+            resultCallbackFunction,
+            ably,
+            hooks,
+            corePublisher,
+            connectionStateChangeListener
+        )
+        every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
+        every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
+        every { publisherProperties.trackables } returns trackables
+        every { publisherProperties.trackableStateFlows } returns trackableStateFlows
+        every { trackableStateFlows[trackable.id] } returns null
+        every { publisherProperties.trackableStates } returns trackableStates
+        every { trackableStates[trackable.id] } returns null
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should return empty result when executing normally`() {
+        // given
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should subscribe to Ably channel state updates when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            ably.subscribeForChannelStateChange(trackable.id, any())
+        }
+    }
+
+    @Test
+    fun `should start location updates if is not already tracking when executing normally`() {
+        // given
+        every { publisherProperties.isTracking } returns false
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.startLocationUpdates(any())
+        }
+    }
+
+    @Test
+    fun `should not start location updates if is already tracking when executing normally`() {
+        // given
+        every { publisherProperties.isTracking } returns true
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.startLocationUpdates(any())
+        }
+    }
+
+    @Test
+    fun `should add the trackable to the tracked trackables when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            trackables.add(trackable)
+        }
+    }
+
+    @Test
+    fun `should update the tracked trackables when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.updateTrackables(any())
+        }
+    }
+
+    @Test
+    fun `should calculate a resolution for the added trackable when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.resolveResolution(trackable, any())
+        }
+    }
+
+    @Test
+    fun `should set a state flow for the trackable when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            trackableStateFlows[trackable.id] = any()
+        }
+    }
+
+    @Test
+    fun `should update state flows when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.updateTrackableStateFlows(any())
+        }
+    }
+
+    @Test
+    fun `should set the initial trackable state to offline when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            trackableStates[trackable.id] = TrackableState.Offline()
+        }
+    }
+
+    @Test
+    fun `should call the adding trackable callback with a success when executing normally`() {
+        // given
+        val callbackResultSlot = slot<Result<StateFlow<TrackableState>>>()
+        every { resultCallbackFunction.invoke(capture(callbackResultSlot)) } just runs
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertTrue(callbackResultSlot.captured.isSuccess)
+    }
+
+    @Test
+    fun `should finish adding the trackable with a success when executing normally`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            duplicateTrackableGuard.finishAddingTrackable(trackable, Result.success(any()))
+        }
+    }
+
+    @Test
+    fun `should return only async result when trackable removal was requested`() {
+        // given
+        mockTrackableRemovalRequested()
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNotNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should return trackable removal work result when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+            val disconnectResult = Result.success(Unit)
+            ably.mockSuspendingDisconnect(trackable.id, disconnectResult)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is ConnectionReadyWorkResult.RemovalRequested)
+            // verify result content
+            val removalRequestedResult = asyncResult as ConnectionReadyWorkResult.RemovalRequested
+            Assert.assertEquals(trackable, removalRequestedResult.trackable)
+            Assert.assertEquals(resultCallbackFunction, removalRequestedResult.callbackFunction)
+            Assert.assertEquals(disconnectResult, removalRequestedResult.result)
+        }
+    }
+
+    @Test
+    fun `should use a copy of presence data when disconnecting from Ably when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+            val originalPresenceData = PresenceData("test")
+            every { publisherProperties.presenceData } returns originalPresenceData
+            val presenceDataSlot = ably.mockSuspendingDisconnectSuccessAndCapturePresenceData(trackable.id)
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            val usedPresenceData = presenceDataSlot.captured
+            Assert.assertEquals(originalPresenceData, usedPresenceData)
+            Assert.assertNotSame(originalPresenceData, usedPresenceData)
+        }
+    }
+
+    @Test
+    fun `should disconnect from Ably when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            coVerify(exactly = 1) {
+                ably.disconnect(trackable.id, any())
+            }
+        }
+    }
+
+    @Test
+    fun `should not perform any of the normal operations when trackable removal was requested`() {
+        runBlocking {
+            // given
+            mockTrackableRemovalRequested()
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            verify(exactly = 0) {
+                ably.subscribeForChannelStateChange(trackable.id, any())
+                corePublisher.startLocationUpdates(any())
+                trackables.add(trackable)
+                corePublisher.updateTrackables(any())
+                corePublisher.resolveResolution(trackable, any())
+                trackableStateFlows[trackable.id] = any()
+                corePublisher.updateTrackableStateFlows(any())
+                trackableStates[trackable.id] = any()
+                resultCallbackFunction.invoke(any())
+                duplicateTrackableGuard.finishAddingTrackable(trackable, Result.success(any()))
+            }
+        }
+    }
+
+    private fun mockTrackableRemovalRequested() {
+        every { trackableRemovalGuard.isMarkedForRemoval(trackable) } returns true
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -24,7 +24,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import io.mockk.verifyAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -17,7 +17,6 @@ import com.ably.tracking.test.common.mockSuspendingDisconnect
 import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
 import io.mockk.clearAllMocks
 import io.mockk.coVerify
-import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk


### PR DESCRIPTION
I've added the `ConnectionReadyWorker` with tests. During the refactor I've noticed that we may simplify this worker but it seems to be out of scope of this PR, so I'll create an issue for it https://github.com/ably/ably-asset-tracking-android/issues/604 :wink: