### PR TITLE
Add disconnect success worker

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -660,7 +660,7 @@ constructor(
         val resolutionRequests: Set<Resolution> = properties.requests[trackable.id]?.values?.toSet() ?: emptySet()
         policy.resolve(TrackableResolutionRequest(trackable, resolutionRequests)).let { resolution ->
             properties.resolutions[trackable.id] = resolution
-            enqueue(ChangeLocationEngineResolutionEvent())
+            enqueue(ChangeLocationEngineResolutionEvent)
             if (sendResolutionEnabled) {
                 ably.sendResolution(trackable.id, resolution) {} // we ignore the result of this operation
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherEvents.kt
@@ -199,7 +199,7 @@ internal data class PresenceMessageEvent(
  * Change the location engine resolution.
  * Should be created only from within the [CorePublisher].
  */
-internal class ChangeLocationEngineResolutionEvent : AdhocEvent()
+internal object ChangeLocationEngineResolutionEvent : AdhocEvent()
 
 /**
  * Change the navigation routing profile.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RemoveTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RemoveTrackableResultHandler.kt
@@ -1,8 +1,8 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.CorePublisher
-import com.ably.tracking.publisher.DisconnectSuccessEvent
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.DisconnectSuccessWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class RemoveTrackableResultHandler : WorkResultHandler<RemoveTrackableWorkResult> {
@@ -11,15 +11,18 @@ internal class RemoveTrackableResultHandler : WorkResultHandler<RemoveTrackableW
         corePublisher: CorePublisher
     ): Worker? {
         when (workResult) {
-            is RemoveTrackableWorkResult.Success -> corePublisher.request(
-                DisconnectSuccessEvent(workResult.trackable) {
-                    if (it.isSuccess) {
-                        workResult.callbackFunction(Result.success(true))
-                    } else {
-                        workResult.callbackFunction(Result.failure(it.exceptionOrNull()!!))
-                    }
-                }
-            )
+            is RemoveTrackableWorkResult.Success ->
+                DisconnectSuccessWorker(
+                    trackable = workResult.trackable,
+                    callbackFunction = {
+                        if (it.isSuccess) {
+                            workResult.callbackFunction(Result.success(true))
+                        } else {
+                            workResult.callbackFunction(Result.failure(it.exceptionOrNull()!!))
+                        }
+                    },
+                    corePublisher = corePublisher,
+                )
             is RemoveTrackableWorkResult.Fail -> workResult.callbackFunction(
                 Result.failure(workResult.exception)
             )

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorker.kt
@@ -12,7 +12,7 @@ internal class ChangeLocationEngineResolutionWorker(
     private val mapbox: Mapbox,
 ) : Worker {
     override val event: Event
-        get() = ChangeLocationEngineResolutionEvent()
+        get() = ChangeLocationEngineResolutionEvent
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
         val newResolution = policy.resolve(properties.resolutions.values.toSet())

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -1,0 +1,63 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.ChangeLocationEngineResolutionEvent
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.DisconnectSuccessEvent
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Request
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+
+internal class DisconnectSuccessWorker(
+    private val trackable: Trackable,
+    private val callbackFunction: ResultCallbackFunction<Unit>,
+    private val corePublisher: CorePublisher,
+) : Worker {
+    override val event: Request<*>
+        get() = DisconnectSuccessEvent(trackable, callbackFunction)
+
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        properties.trackables.remove(trackable)
+
+        corePublisher.updateTrackables(properties)
+        properties.trackableStateFlows.remove(trackable.id) // there is no way to stop the StateFlow so we just remove it
+        corePublisher.updateTrackableStateFlows(properties)
+        properties.trackableStates.remove(trackable.id)
+
+        corePublisher.notifyResolutionPolicyThatTrackableWasRemoved(trackable)
+        corePublisher.removeAllSubscribers(trackable, properties)
+
+        properties.resolutions.remove(trackable.id)
+            ?.let { corePublisher.enqueue(ChangeLocationEngineResolutionEvent()) }
+        properties.requests.remove(trackable.id)
+
+        properties.lastSentEnhancedLocations.remove(trackable.id)
+        properties.lastSentRawLocations.remove(trackable.id)
+        properties.skippedEnhancedLocations.clear(trackable.id)
+        properties.skippedRawLocations.clear(trackable.id)
+
+        properties.enhancedLocationsPublishingState.clear(trackable.id)
+        properties.rawLocationsPublishingState.clear(trackable.id)
+
+        properties.duplicateTrackableGuard.clear(trackable)
+
+        // If this was the active Trackable then clear that state and remove destination.
+        if (properties.active == trackable) {
+            corePublisher.removeCurrentDestination(properties)
+            properties.active = null
+            corePublisher.notifyResolutionPolicyThatActiveTrackableHasChanged(null)
+        }
+
+        // When we remove the last trackable then we should stop location updates
+        if (properties.trackables.isEmpty() && properties.isTracking) {
+            corePublisher.stopLocationUpdates(properties)
+        }
+
+        properties.lastChannelConnectionStateChanges.remove(trackable.id)
+
+        callbackFunction(Result.success(Unit))
+
+        return SyncAsyncResult()
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -29,7 +29,7 @@ internal class DisconnectSuccessWorker(
         corePublisher.removeAllSubscribers(trackable, properties)
 
         properties.resolutions.remove(trackable.id)
-            ?.let { corePublisher.enqueue(ChangeLocationEngineResolutionEvent()) }
+            ?.let { corePublisher.enqueue(ChangeLocationEngineResolutionEvent) }
         properties.requests.remove(trackable.id)
 
         properties.lastSentEnhancedLocations.remove(trackable.id)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -1,0 +1,464 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.ChangeLocationEngineResolutionEvent
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.test.common.anyLocation
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class DisconnectSuccessWorkerTest {
+    private lateinit var worker: DisconnectSuccessWorker
+
+    private val trackable = Trackable("testtrackable")
+    private val resultCallbackFunction = mockk<ResultCallbackFunction<Unit>>(relaxed = true)
+    private val corePublisher = mockk<CorePublisher>(relaxed = true)
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        worker = DisconnectSuccessWorker(trackable, resultCallbackFunction, corePublisher)
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should always return an empty result`() {
+        // given
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should remove the trackable from the tracked trackables`() {
+        // given
+        every { publisherProperties.trackables } returns mutableSetOf(trackable)
+        Assert.assertTrue(publisherProperties.trackables.contains(trackable))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.trackables.contains(trackable))
+    }
+
+    @Test
+    fun `should remove the trackable state flow`() {
+        // given
+        every { publisherProperties.trackableStateFlows } returns mutableMapOf(
+            trackable.id to MutableStateFlow(TrackableState.Offline())
+        )
+        Assert.assertTrue(publisherProperties.trackableStateFlows.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.trackableStateFlows.contains(trackable.id))
+    }
+
+    @Test
+    fun `should remove the trackable state`() {
+        // given
+        every { publisherProperties.trackableStates } returns mutableMapOf(
+            trackable.id to TrackableState.Offline()
+        )
+        Assert.assertTrue(publisherProperties.trackableStates.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.trackableStates.contains(trackable.id))
+    }
+
+    @Test
+    fun `should remove the trackable resolution`() {
+        // given
+        every { publisherProperties.resolutions } returns mutableMapOf(
+            trackable.id to Resolution(Accuracy.BALANCED, 1L, 1.0)
+        )
+        Assert.assertTrue(publisherProperties.resolutions.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.resolutions.contains(trackable.id))
+    }
+
+    @Test
+    fun `should request location engine resolution recalculation if this trackable had a resolution`() {
+        // given
+        every { publisherProperties.resolutions } returns mutableMapOf(
+            trackable.id to Resolution(Accuracy.BALANCED, 1L, 1.0)
+        )
+        Assert.assertTrue(publisherProperties.resolutions.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.enqueue(ChangeLocationEngineResolutionEvent)
+        }
+    }
+
+    @Test
+    fun `should not request location engine resolution recalculation if this trackable didn't have a resolution`() {
+        // given
+        every { publisherProperties.resolutions } returns mutableMapOf()
+        Assert.assertFalse(publisherProperties.resolutions.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.enqueue(ChangeLocationEngineResolutionEvent)
+        }
+    }
+
+    @Test
+    fun `should remove the trackable resolution requests`() {
+        // given
+        every { publisherProperties.requests } returns mutableMapOf(
+            trackable.id to mutableMapOf()
+        )
+        Assert.assertTrue(publisherProperties.requests.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.requests.contains(trackable.id))
+    }
+
+    @Test
+    fun `should remove the trackable last sent enhanced location`() {
+        // given
+        every { publisherProperties.lastSentEnhancedLocations } returns mutableMapOf(
+            trackable.id to anyLocation()
+        )
+        Assert.assertTrue(publisherProperties.lastSentEnhancedLocations.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.lastSentEnhancedLocations.contains(trackable.id))
+    }
+
+    @Test
+    fun `should remove the trackable last sent raw location`() {
+        // given
+        every { publisherProperties.lastSentRawLocations } returns mutableMapOf(
+            trackable.id to anyLocation()
+        )
+        Assert.assertTrue(publisherProperties.lastSentRawLocations.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.lastSentRawLocations.contains(trackable.id))
+    }
+
+    @Test
+    fun `should remove the trackable last channel connection state change`() {
+        // given
+        every { publisherProperties.lastChannelConnectionStateChanges } returns mutableMapOf(
+            trackable.id to ConnectionStateChange(ConnectionState.OFFLINE, null)
+        )
+        Assert.assertTrue(publisherProperties.lastChannelConnectionStateChanges.contains(trackable.id))
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertFalse(publisherProperties.lastChannelConnectionStateChanges.contains(trackable.id))
+    }
+
+    @Test
+    fun `should update the trackables in the publisher`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.updateTrackables(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should update the trackable state flows in the publisher`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.updateTrackableStateFlows(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should notify the resolution policy that a trackable was removed`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.notifyResolutionPolicyThatTrackableWasRemoved(trackable)
+        }
+    }
+
+    @Test
+    fun `should remove all saved subscribers for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.removeAllSubscribers(trackable, publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should clear all skipped enhanced locations for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.skippedEnhancedLocations.clear(trackable.id)
+        }
+    }
+
+    @Test
+    fun `should clear all skipped raw locations for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.skippedRawLocations.clear(trackable.id)
+        }
+    }
+
+    @Test
+    fun `should clear the enhanced locations publishing state for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.enhancedLocationsPublishingState.clear(trackable.id)
+        }
+    }
+
+    @Test
+    fun `should clear the raw locations publishing state for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.rawLocationsPublishingState.clear(trackable.id)
+        }
+    }
+
+    @Test
+    fun `should clear the duplicate trackable guard for the removed trackable`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.duplicateTrackableGuard.clear(trackable)
+        }
+    }
+
+    @Test
+    fun `should always call the result callback with a success`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            resultCallbackFunction(Result.success(Unit))
+        }
+    }
+
+    @Test
+    fun `should clear the active trackable if the removed trackable was the active one`() {
+        // given
+        every { publisherProperties.active } returns trackable
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            publisherProperties.active = null
+        }
+    }
+
+    @Test
+    fun `should remove the current destination if the removed trackable was the active one`() {
+        // given
+        every { publisherProperties.active } returns trackable
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.removeCurrentDestination(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should notify the Resolution Policy that there is no active trackable the removed trackable was the active one`() {
+        // given
+        every { publisherProperties.active } returns trackable
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.notifyResolutionPolicyThatActiveTrackableHasChanged(null)
+        }
+    }
+
+    @Test
+    fun `should not clear the active trackable if the removed trackable was not the active one`() {
+        // given
+        every { publisherProperties.active } returns anyOtherTrackable()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            publisherProperties.active = null
+        }
+    }
+
+    @Test
+    fun `should not remove the current destination if the removed trackable was not the active one`() {
+        // given
+        every { publisherProperties.active } returns anyOtherTrackable()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.removeCurrentDestination(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should not notify the Resolution Policy that there is no active trackable the removed trackable was not the active one`() {
+        // given
+        every { publisherProperties.active } returns anyOtherTrackable()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.notifyResolutionPolicyThatActiveTrackableHasChanged(null)
+        }
+    }
+
+    @Test
+    fun `should stop location updates if the removed trackable was the last one and the publisher is currently tracking`() {
+        // given
+        every { publisherProperties.trackables } returns mutableSetOf(trackable)
+        every { publisherProperties.isTracking } returns true
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.stopLocationUpdates(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should not stop location updates if the removed trackable was not the last one`() {
+        // given
+        every { publisherProperties.trackables } returns mutableSetOf(trackable, anyOtherTrackable())
+        every { publisherProperties.isTracking } returns true
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.stopLocationUpdates(publisherProperties)
+        }
+    }
+
+    @Test
+    fun `should not stop location updates if the publisher is not currently tracking`() {
+        // given
+        every { publisherProperties.trackables } returns mutableSetOf(trackable)
+        every { publisherProperties.isTracking } returns false
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            corePublisher.stopLocationUpdates(publisherProperties)
+        }
+    }
+
+    private fun anyOtherTrackable() = Trackable("some-other-trackable")
+}


### PR DESCRIPTION
I've added the `DisconnectSuccessWorker` which finalizes the trackable removal process.