### PR TITLE
Tweak Maven meta

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -65,7 +65,7 @@ afterEvaluate {
                     scm {
                         connection = 'scm:git:git://github.com/ably/ably-asset-tracking-android.git'
                         developerConnection = 'scm:git:ssh://github.com/ably/ably-asset-tracking-android.git'
-                        url = 'https://github.com/ably/ably-asset-tracking-android/tree/main'
+                        url = 'https://github.com/ably/ably-asset-tracking-android'
                     }
                 }
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -66,6 +66,7 @@ afterEvaluate {
                         connection = 'scm:git:git://github.com/ably/ably-asset-tracking-android.git'
                         developerConnection = 'scm:git:ssh://github.com/ably/ably-asset-tracking-android.git'
                         url = 'https://github.com/ably/ably-asset-tracking-android'
+                        tag = 'v' + PUBLISH_VERSION
                     }
                 }
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -55,10 +55,12 @@ afterEvaluate {
                             id = 'ably' // our company org in GitHub: https://github.com/ably
                             name = 'Ably' // UK based company: Ably Real-time Ltd
                             email = 'support@ably.com'
-                            organization = 'Ably' // UK based company: Ably Real-time Ltd
-                            organizationUrl = 'https://ably.com/'
                             url = 'https://ably.com/'
                         }
+                    }
+                    organization {
+                        name = 'Ably' // UK based company: Ably Real-time Ltd
+                        url = 'https://ably.com/'
                     }
                     scm {
                         connection = 'scm:git:git://github.com/ably/ably-asset-tracking-android.git'


### PR DESCRIPTION
Looking at [how we appear on Maven Central for v.1.0.0](https://search.maven.org/artifact/com.ably.tracking/publishing-sdk/1.0.0/aar):

<img width="943" alt="Screenshot 2022-02-04 at 06 20 58" src="https://user-images.githubusercontent.com/8318344/152484543-5856cdf6-81e5-454f-83b0-e311b79fb7bc.png">

I didn't like:

- Having two `Ably` entities under `Developers` (fixed in https://github.com/ably/ably-asset-tracking-android/commit/30c53a73afd3b81280573d700c6076f9eeb6ba2a)
- Having a specific branch name specified under `Source code` (fixed in https://github.com/ably/ably-asset-tracking-android/commit/9c107c232401971c062ff1e346e1d739cb437c69)

I also noticed, from looking at another publisher's POM, that there is a `tag` node in `scm` which allows us to specify accurately the tagged commit which built this release (added in https://github.com/ably/ably-asset-tracking-android/commit/16738436381c0424849d1e56b1666370df524295). Others appear to be doing this wrong, perhaps because [the docs that I could find](https://maven.apache.org/pom.html#SCM) also specify `HEAD` as the value for this node. 🙄 

The other publisher's POM, for comparison, [how it appears on Maven Central](https://search.maven.org/artifact/com.google.firebase/firebase-admin/8.1.0/jar):

<img width="949" alt="Screenshot 2022-02-04 at 06 17 13" src="https://user-images.githubusercontent.com/8318344/152485127-10eb170e-9886-4e48-b774-b7ac306d4f04.png">

Noting that they also have the same issue we had with their product/company (!?) name appearing twice under `Developers`. From inspecting other POMs, I could see that `organization` and `organizationUrl` appear to not be required for a `developer` block.