### PR TITLE
Use the AddTrackableWorker when handling TrackTrackableEvent

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -261,14 +261,18 @@ constructor(
                         )
                     }
                     is TrackTrackableEvent -> {
-                        request(
-                            AddTrackableEvent(event.trackable) { result ->
-                                if (result.isSuccess) {
-                                    request(SetActiveTrackableEvent(event.trackable) { event.callbackFunction(result) })
-                                } else {
-                                    event.callbackFunction(result)
-                                }
-                            }
+                        workerQueue.execute(
+                            AddTrackableWorker(
+                                event.trackable,
+                                { result ->
+                                    if (result.isSuccess) {
+                                        request(SetActiveTrackableEvent(event.trackable) { event.callbackFunction(result) })
+                                    } else {
+                                        event.callbackFunction(result)
+                                    }
+                                },
+                                ably
+                            )
                         )
                     }
                     is SetActiveTrackableEvent -> {


### PR DESCRIPTION
I was wondering if we should create a `TrackTrackableWorker` but it would have an empty body. Therefore, I've refactored the event handling so it uses the new worker queue instead of using only events.