### PR TITLE
Enable setting a constant location engine resolution

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -52,6 +52,7 @@ class MapboxTests {
             12345,
             true,
             null,
+            null,
         )
 
     private fun getLocationData(context: Context): LocationHistoryData {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -5,6 +5,7 @@ import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.annotation.SuppressLint
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.logging.LogHandler
@@ -25,6 +26,7 @@ constructor(
     logHandler: LogHandler?,
     areRawLocationsEnabled: Boolean?,
     sendResolutionEnabled: Boolean,
+    constantLocationEngineResolution: Resolution?,
 ) :
     Publisher {
     private val core: CorePublisher
@@ -50,6 +52,7 @@ constructor(
             logHandler,
             areRawLocationsEnabled,
             sendResolutionEnabled,
+            constantLocationEngineResolution,
         )
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -19,6 +19,7 @@ import com.ably.tracking.publisher.locationengine.FusedAndroidLocationEngine
 import com.ably.tracking.publisher.locationengine.GoogleLocationEngine
 import com.ably.tracking.publisher.locationengine.LocationEngineUtils
 import com.ably.tracking.publisher.locationengine.ResolutionLocationEngine
+import com.ably.tracking.publisher.locationengine.toLocationEngineRequest
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.module.Mapbox_TripNotificationModuleConfiguration
@@ -162,6 +163,7 @@ internal class DefaultMapbox(
     notificationId: Int,
     predictionsEnabled: Boolean,
     private val rawHistoryCallback: ((String) -> Unit)?,
+    constantLocationEngineResolution: Resolution?,
 ) : Mapbox {
     private val TAG = createLoggingTag(this)
 
@@ -196,6 +198,10 @@ internal class DefaultMapbox(
 
         if (!predictionsEnabled) {
             mapboxBuilder.navigatorPredictionMillis(0L) // Setting this to 0 disables location predictions
+        }
+
+        if (constantLocationEngineResolution != null) {
+            mapboxBuilder.locationEngineRequest(constantLocationEngineResolution.toLocationEngineRequest())
         }
 
         runBlocking(mainDispatcher) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
@@ -242,6 +243,18 @@ interface Publisher {
          * @return A new instance of the builder with this property changed.
          */
         fun rawHistoryDataCallback(callback: (String) -> Unit): Builder
+
+        /**
+         * **OPTIONAL** Enables using a constant location engine resolution.
+         * If the [resolution] is not null then instead of using [ResolutionPolicy] to calculate a dynamic resolution for the location engine
+         * the [resolution] will be used as the location engine resolution.
+         * If the [resolution] is null then the constant resolution is disabled and the location engine resolution will be calculated by the [ResolutionPolicy].
+         * By default this is disabled.
+         *
+         * @param resolution The resolution that will be used as the location engine resolution.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun constantLocationEngineResolution(resolution: Resolution?): Builder
 
         /**
          * Creates a [Publisher] and starts publishing.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -5,6 +5,7 @@ import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
+import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
@@ -23,6 +24,7 @@ internal data class PublisherBuilder(
     val sendResolutionEnabled: Boolean = false,
     val predictionsEnabled: Boolean = true,
     val rawHistoryCallback: ((String) -> Unit)? = null,
+    val constantLocationEngineResolution: Resolution? = null,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -64,6 +66,9 @@ internal data class PublisherBuilder(
     override fun rawHistoryDataCallback(callback: (String) -> Unit): Publisher.Builder =
         this.copy(rawHistoryCallback = callback)
 
+    override fun constantLocationEngineResolution(resolution: Resolution?): Publisher.Builder =
+        this.copy(constantLocationEngineResolution = resolution)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -82,12 +87,14 @@ internal data class PublisherBuilder(
                 notificationId!!,
                 predictionsEnabled,
                 rawHistoryCallback,
+                constantLocationEngineResolution,
             ),
             resolutionPolicyFactory!!,
             routingProfile,
             logHandler,
             areRawLocationsEnabled,
             sendResolutionEnabled,
+            constantLocationEngineResolution,
         )
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -37,7 +37,7 @@ class CorePublisherLocationUpdatesPublishingTest {
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false, null)
 
     @Test
     fun `Should send a message only once if publishing it succeeds`() {
@@ -128,7 +128,7 @@ class CorePublisherLocationUpdatesPublishingTest {
     fun `Should send raw messages if they are enabled`() {
         // given
         val corePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false, null)
         val trackableId = UUID.randomUUID().toString()
         mockAllTrackablesResolution(Resolution(Accuracy.MAXIMUM, 0, 0.0))
         addTrackable(Trackable(trackableId), corePublisher)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -39,7 +39,7 @@ class CorePublisherPresenceDataTest {
     @Test
     fun `Should se rawMessages to null in the presence data if they are disabled`() {
         val corePublisher: CorePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, null, false)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, null, false, null)
         // given
         val trackableId = UUID.randomUUID().toString()
 
@@ -59,7 +59,7 @@ class CorePublisherPresenceDataTest {
     @Test
     fun `Should set rawMessages to true in the presence data if they are enabled`() {
         val corePublisher: CorePublisher =
-            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false)
+            createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, true, false, null)
         // given
         val trackableId = UUID.randomUUID().toString()
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -112,7 +112,7 @@ class CorePublisherResolutionTest(
 
     @SuppressLint("MissingPermission")
     private val corePublisher: CorePublisher =
-        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
+        createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false, null)
 
     @Test
     fun `Should send limited location updates`() {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -29,7 +29,7 @@ class DefaultPublisherTest {
 
     @SuppressLint("MissingPermission")
     private val publisher: Publisher =
-        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false)
+        DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false, null)
 
     @Test(expected = ConnectionException::class)
     fun `should return an error when adding a trackable with subscribing to presence error`() {


### PR DESCRIPTION
I've added a method to the `Publisher` builder that allows to specify whether the location engine should have a dynamic resolution calculated by the `ResolutionPolicy`or should it have a constant resolution that won't change throughout the publisher lifetime.

Resolves a part of https://github.com/ably/ably-asset-tracking-android/issues/626