### PR TITLE
Send resolution data from publisher

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -745,10 +745,12 @@ constructor(
     private fun resolveResolution(trackable: Trackable, properties: Properties) {
         val resolutionRequests: Set<Resolution> = properties.requests[trackable.id]?.values?.toSet() ?: emptySet()
         policy.resolve(TrackableResolutionRequest(trackable, resolutionRequests)).let { resolution ->
-            properties.resolutions[trackable.id] = resolution
-            enqueue(ChangeLocationEngineResolutionEvent())
-            if (sendResolutionEnabled) {
-                ably.sendResolution(trackable.id, resolution) {} // we ignore the result of this operation
+            if (properties.resolutions[trackable.id] != resolution) {
+                properties.resolutions[trackable.id] = resolution
+                enqueue(ChangeLocationEngineResolutionEvent())
+                if (sendResolutionEnabled) {
+                    ably.sendResolution(trackable.id, resolution) {} // we ignore the result of this operation
+                }
             }
         }
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -215,10 +215,8 @@ interface Publisher {
         fun rawLocations(enabled: Boolean): Builder
 
         /**
-         * EXPERIMENTAL API
-         * **OPTIONAL** Enables sending of calculated resolutions. This should only be enabled for diagnostics.
-         * In the production environment this should be always disabled.
-         * By default this is disabled.
+         * **OPTIONAL** Enables sending of calculated resolutions.
+         * By default this is enabled.
          *
          * @param enabled Whether the sending of calculated resolutions is enabled.
          * @return A new instance of the builder with this property changed.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -21,7 +21,7 @@ internal data class PublisherBuilder(
     val notificationId: Int? = null,
     val locationSource: LocationSource? = null,
     val areRawLocationsEnabled: Boolean? = null,
-    val sendResolutionEnabled: Boolean = false,
+    val sendResolutionEnabled: Boolean = true,
     val predictionsEnabled: Boolean = true,
     val rawHistoryCallback: ((String) -> Unit)? = null,
     val constantLocationEngineResolution: Resolution? = null,

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -63,7 +63,6 @@ interface Subscriber {
 
     /**
      * The shared flow emitting resolution values when they become available.
-     * Resolutions are disabled by default. You need to enable them in the Publishing SDK.
      */
     val resolutions: SharedFlow<Resolution>
         @JvmSynthetic get


### PR DESCRIPTION
I've used the already implemented debug capability of sending resolutions. I've made it enabled by default and added a check that will only perform resolution related actions if the new resolution is different than the current one.

Resolves a part of https://github.com/ably/ably-asset-tracking-android/issues/626