### PR TITLE
Add next location update intervals to the Subscriber API

### DIFF
--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -32,6 +32,7 @@ internal interface CoreSubscriber {
     val rawLocations: SharedFlow<LocationUpdate>
     val trackableStates: StateFlow<TrackableState>
     val resolutions: SharedFlow<Resolution>
+    val nextLocationUpdateIntervals: SharedFlow<Long>
 }
 
 internal fun createCoreSubscriber(
@@ -59,6 +60,7 @@ private class DefaultCoreSubscriber(
     private val _enhancedLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
     private val _rawLocations: MutableSharedFlow<LocationUpdate> = MutableSharedFlow(replay = 1)
     private val _resolutions: MutableSharedFlow<Resolution> = MutableSharedFlow(replay = 1)
+    private val _nextLocationUpdateIntervals: MutableSharedFlow<Long> = MutableSharedFlow(replay = 1)
 
     override val enhancedLocations: SharedFlow<LocationUpdate>
         get() = _enhancedLocations.asSharedFlow()
@@ -71,6 +73,9 @@ private class DefaultCoreSubscriber(
 
     override val resolutions: SharedFlow<Resolution>
         get() = _resolutions.asSharedFlow()
+
+    override val nextLocationUpdateIntervals: SharedFlow<Long>
+        get() = _nextLocationUpdateIntervals.asSharedFlow()
 
     init {
         val channel = Channel<Event>()
@@ -229,6 +234,7 @@ private class DefaultCoreSubscriber(
     private fun subscribeForResolutionEvents() {
         ably.subscribeForResolutionEvents(trackableId) {
             scope.launch { _resolutions.emit(it) }
+            scope.launch { _nextLocationUpdateIntervals.emit(it.desiredInterval) }
         }
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -29,6 +29,9 @@ internal class DefaultSubscriber(
     override val resolutions: SharedFlow<Resolution>
         get() = core.resolutions
 
+    override val nextLocationUpdateIntervals: SharedFlow<Long>
+        get() = core.nextLocationUpdateIntervals
+
     init {
         core = createCoreSubscriber(ably, resolution, trackableId)
     }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -68,6 +68,12 @@ interface Subscriber {
         @JvmSynthetic get
 
     /**
+     * The shared flow emitting the estimated next location update intervals in milliseconds when they become available.
+     */
+    val nextLocationUpdateIntervals: SharedFlow<Long>
+        @JvmSynthetic get
+
+    /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be
      * restarted.
      */


### PR DESCRIPTION
I've added a shared flow that emits the next location update intervals in milliseconds. It uses the same source of knowledge as the already available `resolutions` shared flow. This should enable us to adjust the location marker animation speed and make its movement smoother.

Resolves a part of https://github.com/ably/ably-asset-tracking-android/issues/626