### PR TITLE
Allow to specify the constant location engine resolution in the publisher example app

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.example.publisher
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
 
 class AppPreferences private constructor(context: Context) {
     companion object {
@@ -33,7 +34,15 @@ class AppPreferences private constructor(context: Context) {
     private val SEND_RAW_LOCATIONS_KEY = context.getString(R.string.preferences_send_raw_locations_key)
     private val SEND_RESOLUTION_KEY = context.getString(R.string.preferences_send_resolution_key)
     private val ENABLE_PREDICTIONS_KEY = context.getString(R.string.preferences_send_resolution_key)
-    private val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
+    private val ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION_KEY =
+        context.getString(R.string.preferences_enable_constant_resolution_key)
+    private val CONSTANT_RESOLUTION_ACCURACY_KEY =
+        context.getString(R.string.preferences_constant_resolution_accuracy_key)
+    private val CONSTANT_RESOLUTION_DESIRED_INTERVAL_KEY =
+        context.getString(R.string.preferences_constant_resolution_desired_interval_key)
+    private val CONSTANT_RESOLUTION_MINIMUM_DISPLACEMENT_KEY =
+        context.getString(R.string.preferences_constant_resolution_minimum_displacement_key)
+    val DEFAULT_LOCATION_SOURCE = LocationSourceType.PHONE.name
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
     private val DEFAULT_ROUTING_PROFILE = RoutingProfileType.DRIVING.name
@@ -43,6 +52,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_SEND_RAW_LOCATIONS = false
     private val DEFAULT_SEND_RESOLUTION = false
     private val DEFAULT_ENABLE_PREDICTIONS = true
+    private val DEFAULT_ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION = false
 
     fun getLocationSource(): LocationSourceType =
         LocationSourceType.valueOf(preferences.getString(LOCATION_SOURCE_KEY, DEFAULT_LOCATION_SOURCE)!!)
@@ -75,4 +85,20 @@ class AppPreferences private constructor(context: Context) {
 
     fun shouldEnablePredictions() =
         preferences.getBoolean(ENABLE_PREDICTIONS_KEY, DEFAULT_ENABLE_PREDICTIONS)
+
+    fun isConstantLocationEngineResolutionEnabled() = preferences.getBoolean(
+        ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION_KEY,
+        DEFAULT_ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION
+    )
+
+    fun getConstantLocationEngineResolution(): Resolution {
+        val accuracy = preferences.getString(CONSTANT_RESOLUTION_ACCURACY_KEY, DEFAULT_RESULTION_ACCURACY)!!.let {
+            Accuracy.valueOf(it)
+        }
+        val desiredInterval = preferences.getString(CONSTANT_RESOLUTION_DESIRED_INTERVAL_KEY, null)?.toLong()
+            ?: DEFAULT_RESULTION_DESIRED_INTERVAL
+        val minimumDisplacement = preferences.getString(CONSTANT_RESOLUTION_MINIMUM_DISPLACEMENT_KEY, null)?.toFloat()
+            ?: DEFAULT_RESULTION_MINIMUM_DISPLACEMENT
+        return Resolution(accuracy, desiredInterval, minimumDisplacement.toDouble())
+    }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -120,6 +120,7 @@ class PublisherService : Service() {
             .rawLocations(appPreferences.shouldSendRawLocations())
             .sendResolution(appPreferences.shouldSendResolution())
             .predictions(appPreferences.shouldEnablePredictions())
+            .constantLocationEngineResolution(createConstantLocationEngineResolution())
             .start()
 
     private fun createDefaultResolution(): Resolution =
@@ -137,4 +138,11 @@ class PublisherService : Service() {
             ) { showShortToast(R.string.error_s3_not_initialized_history_data_upload_failed) }
         }
     }
+
+    private fun createConstantLocationEngineResolution(): Resolution? =
+        if (appPreferences.isConstantLocationEngineResolutionEnabled()) {
+            appPreferences.getConstantLocationEngineResolution()
+        } else {
+            null
+        }
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -22,7 +22,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         addPreferencesFromResource(R.xml.settings_preferences)
         setupLocationSourcePreference()
         setupRoutingProfilePreference()
-        setupResolutionPreferences()
+        setupDefaultResolutionPreferences()
+        setupConstantLocationEngineResolutionPreferences()
         loadS3Preferences()
     }
 
@@ -80,7 +81,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
     }
 
-    private fun setupResolutionPreferences() {
+    private fun setupDefaultResolutionPreferences() {
         val appPreferences = AppPreferences.getInstance(requireContext())
         (findPreference(getString(R.string.preferences_resolution_accuracy_key)) as ListPreference?)?.apply {
             entries = Accuracy.values()
@@ -95,6 +96,26 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
         (findPreference(getString(R.string.preferences_resolution_minimum_displacement_key)) as EditTextPreference?)?.apply {
             text = appPreferences.getResolutionMinimumDisplacement().toString()
+            setFloatNumberInputType()
+        }
+    }
+
+    private fun setupConstantLocationEngineResolutionPreferences() {
+        val appPreferences = AppPreferences.getInstance(requireContext())
+        val constantLocationEngineResolution = appPreferences.getConstantLocationEngineResolution()
+        (findPreference(getString(R.string.preferences_constant_resolution_accuracy_key)) as ListPreference?)?.apply {
+            entries = Accuracy.values()
+                .map { accuracy -> accuracy.name.lowercase().replaceFirstChar { it.uppercase() } }
+                .toTypedArray()
+            entryValues = Accuracy.values().map { it.name }.toTypedArray()
+            value = constantLocationEngineResolution.accuracy.name
+        }
+        (findPreference(getString(R.string.preferences_constant_resolution_desired_interval_key)) as EditTextPreference?)?.apply {
+            text = constantLocationEngineResolution.desiredInterval.toString()
+            setIntNumberInputType()
+        }
+        (findPreference(getString(R.string.preferences_constant_resolution_minimum_displacement_key)) as EditTextPreference?)?.apply {
+            text = constantLocationEngineResolution.minimumDisplacement.toString()
             setFloatNumberInputType()
         }
     }

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
   <string name="preferences_s3_file_label">S3 File</string>
   <string name="preferences_routing_profile_label">Routing profile</string>
   <string name="preferences_resolution_category_title">Default resolution</string>
+  <string name="preferences_constant_resolution_category_title">Constant location engine resolution</string>
   <string name="preferences_resolution_accuracy_label">Accuracy</string>
   <string name="preferences_resolution_desired_interval_label">Desired interval</string>
   <string name="preferences_update_resolution_desired_interval_message">Desired Interval [ms]</string>
@@ -50,6 +51,7 @@
   <string name="preferences_send_raw_locations_label">Send raw location updates</string>
   <string name="preferences_send_resolution_label">Send resolution</string>
   <string name="preferences_enable_predictions_label">Enable predictions</string>
+  <string name="preferences_enable_constant_resolution_label">Use constant location engine resolution</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>
   <string name="service_not_started_dialog_title">Publisher service not started</string>

--- a/publishing-example-app/src/main/res/values/untranslatable_strings.xml
+++ b/publishing-example-app/src/main/res/values/untranslatable_strings.xml
@@ -10,5 +10,9 @@
   <string name="preferences_send_raw_locations_key" translatable="false">send_raw_locations</string>
   <string name="preferences_send_resolution_key" translatable="false">send_resolution</string>
   <string name="preferences_enable_predictions_key" translatable="false">enable_predictions</string>
+  <string name="preferences_enable_constant_resolution_key" translatable="false">enable_constant_resolution</string>
+  <string name="preferences_constant_resolution_accuracy_key" translatable="false">constant_resolution_accuracy</string>
+  <string name="preferences_constant_resolution_desired_interval_key" translatable="false">constant_resolution_desired_interval</string>
+  <string name="preferences_constant_resolution_minimum_displacement_key" translatable="false">constant_resolution_minimum_displacement</string>
 </resources>
 

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -69,6 +69,40 @@
 
   <PreferenceCategory
     android:layout="@layout/preference_category_layout"
+    android:title="@string/preferences_constant_resolution_category_title">
+
+    <SwitchPreferenceCompat
+      android:defaultValue="false"
+      android:key="@string/preferences_enable_constant_resolution_key"
+      android:layout="@layout/switch_preference_layout"
+      android:title="@string/preferences_enable_constant_resolution_label" />
+
+    <ListPreference
+      android:key="@string/preferences_constant_resolution_accuracy_key"
+      android:layout="@layout/preference_with_summary_layout"
+      android:title="@string/preferences_resolution_accuracy_label"
+      app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference
+      android:dialogMessage="@string/preferences_update_resolution_desired_interval_message"
+      android:dialogTitle="@string/preferences_update_resolution_desired_interval_title"
+      android:key="@string/preferences_constant_resolution_desired_interval_key"
+      android:layout="@layout/preference_with_summary_layout"
+      android:title="@string/preferences_resolution_desired_interval_label"
+      app:useSimpleSummaryProvider="true" />
+
+    <EditTextPreference
+      android:dialogMessage="@string/preferences_update_resolution_minimum_displacement_message"
+      android:dialogTitle="@string/preferences_update_resolution_minimum_displacement_title"
+      android:key="@string/preferences_constant_resolution_minimum_displacement_key"
+      android:layout="@layout/preference_with_summary_layout"
+      android:title="@string/preferences_resolution_minimum_displacement_label"
+      app:useSimpleSummaryProvider="true" />
+
+  </PreferenceCategory>
+
+  <PreferenceCategory
+    android:layout="@layout/preference_category_layout"
     android:title="@string/preferences_debug_category_title">
 
     <SwitchPreferenceCompat


### PR DESCRIPTION
I've added a new category to the settings screen called "Constant location engine resolution" which can be used to enable the constant resolution for the location engine.
![Screenshot from 2022-02-11 08-22-58](https://user-images.githubusercontent.com/62378170/153551932-af302426-f834-40e5-9948-de06d8a5de90.png)

