### PR TITLE
Update the Ably SDK to the version 1.2.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.8'
+    ext.ably_core_version = '1.2.11'
 
     repositories {
         google()


### PR DESCRIPTION
I've updated the Ably SDK from `1.2.8` to `1.2.11`