### PR TITLE
Use the new asset tracking Mapbox profile snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,17 @@ allprojects {
                 password = property('MAPBOX_DOWNLOADS_TOKEN')
             }
         }
+        // Mapbox Snapshot repository required to get the new asset tracking navigation profile.
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                username = 'mapbox'
+                password = property('MAPBOX_DOWNLOADS_TOKEN')
+            }
+        }
     }
 }
 

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -27,6 +27,10 @@ dependencies {
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"
     }
+    // The special asset tracking profile for the Mapbox Navigation.
+    implementation("com.mapbox.navigator:mapbox-navigation-native:ak-2.1-tracking-profile-13-SNAPSHOT") {
+        force = true
+    }
 
     // Dependencies needed for replacing Mapbox modules.
     // https://docs.mapbox.com/android/navigation/guides/modularization/#replacing-a-module


### PR DESCRIPTION
I've added the new Mapbox navigation profile prepared for AAT. This is still provided as a snapshot so it also requires to add the Mapbox Snapshot maven repository.