### PR TITLE
Make map marker animations smoother

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/LocationAnimator.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/LocationAnimator.kt
@@ -1,0 +1,64 @@
+package com.ably.tracking.example.subscriber
+
+import com.ably.tracking.LocationUpdate
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Extension for the [com.ably.tracking.subscriber.Subscriber] that enables smooth location updates animation.
+ */
+interface LocationAnimator {
+    /**
+     * The flow of subsequent map marker positions that create the animation.
+     * The position of the map marker should be changed each time a new value arrives in this flow.
+     */
+    val positionsFlow: SharedFlow<Position>
+
+    /**
+     * The flow of subsequent camera positions that helps to follow the animation progress from [positionsFlow].
+     * The position of the camera can be changed each time a new value arrives in this flow.
+     */
+    val cameraPositionsFlow: SharedFlow<Position>
+
+    /**
+     * Queues the location update for the animation.
+     * This should be called each time a new location update is received from the [com.ably.tracking.subscriber.Subscriber].
+     *
+     * @param locationUpdate The newest location update received from the Subscriber SDK.
+     * @param expectedIntervalBetweenLocationUpdatesInMilliseconds The expected interval of location updates in milliseconds.
+     */
+    fun animateLocationUpdate(
+        locationUpdate: LocationUpdate,
+        expectedIntervalBetweenLocationUpdatesInMilliseconds: Long,
+    )
+
+    /**
+     * Stops and cancels any ongoing animations.
+     * After stopping the [LocationAnimator] instance should not be used anymore.
+     */
+    fun stop()
+}
+
+/**
+ * Represents a position on the map with additional properties required for a map marker animation.
+ */
+data class Position(
+    /**
+     * The latitude of the location in degrees.
+     */
+    val latitude: Double,
+
+    /**
+     * The longitude of the location in degrees.
+     */
+    val longitude: Double,
+
+    /**
+     * The bearing of the location in degrees.
+     */
+    val bearing: Float,
+
+    /**
+     * The accuracy of the location in meters.
+     */
+    val accuracy: Float
+)

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/LocationAnimator.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/LocationAnimator.kt
@@ -1,7 +1,17 @@
 package com.ably.tracking.example.subscriber
 
+import android.os.SystemClock
+import android.view.animation.LinearInterpolator
+import com.ably.tracking.Location
 import com.ably.tracking.LocationUpdate
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 
 /**
  * Extension for the [com.ably.tracking.subscriber.Subscriber] that enables smooth location updates animation.
@@ -62,3 +72,140 @@ data class Position(
      */
     val accuracy: Float
 )
+
+// This delay helps to smooth out movement when we receive a location update later than we've expected.
+private const val INTENTIONAL_ANIMATION_DELAY_IN_MILLISECONDS: Long = 2_000L
+private const val IDLE_ANIMATION_LOOP_DELAY_IN_MILLISECONDS: Long = 50L
+private const val SINGLE_ANIMATION_FRAME_INTERVAL_IN_MILLISECONDS: Long = (1000 / 60.0).toLong() // 60 FPS
+private const val ANIMATION_REQUESTS_BUFFER_SIZE = 20
+private const val POSITIONS_BUFFER_SIZE = 10
+private const val CAMERA_POSITIONS_BUFFER_SIZE = 10
+private const val UNKNOWN_DURATION: Long = -1L
+
+class CoreLocationAnimator : LocationAnimator {
+    override val positionsFlow: SharedFlow<Position>
+        get() = _positionsFlow
+    override val cameraPositionsFlow: SharedFlow<Position>
+        get() = _cameraPositionsFlow
+
+    private val _positionsFlow = MutableSharedFlow<Position>(replay = 1, extraBufferCapacity = POSITIONS_BUFFER_SIZE)
+    private val _cameraPositionsFlow =
+        MutableSharedFlow<Position>(replay = 1, extraBufferCapacity = CAMERA_POSITIONS_BUFFER_SIZE)
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private var animationRequestsChannel: Channel<AnimationRequest> = Channel(ANIMATION_REQUESTS_BUFFER_SIZE)
+    private val animationSteps: MutableList<AnimationStep> = mutableListOf()
+    private var previousFinalPosition: Position? = null
+
+    init {
+        scope.launch {
+            for (request in animationRequestsChannel) {
+                processAnimationRequest(request)
+            }
+        }
+        scope.launch {
+            animationLoop()
+        }
+    }
+
+    override fun animateLocationUpdate(
+        locationUpdate: LocationUpdate,
+        expectedIntervalBetweenLocationUpdatesInMilliseconds: Long,
+    ) {
+        scope.launch {
+            animationRequestsChannel.send(
+                AnimationRequest(locationUpdate, expectedIntervalBetweenLocationUpdatesInMilliseconds)
+            )
+        }
+    }
+
+    override fun stop() {
+        scope.cancel()
+    }
+
+    private fun processAnimationRequest(request: AnimationRequest) {
+        val steps = createAnimationStepsFromRequest(request)
+        val expectedAnimationDurationInMilliseconds =
+            INTENTIONAL_ANIMATION_DELAY_IN_MILLISECONDS + request.expectedIntervalBetweenLocationUpdatesInMilliseconds
+        synchronized(animationSteps) {
+            animationSteps.addAll(steps)
+            val animationStepDurationInMilliseconds = expectedAnimationDurationInMilliseconds / animationSteps.size
+            animationSteps.forEach { it.durationInMilliseconds = animationStepDurationInMilliseconds }
+            previousFinalPosition = animationSteps.last().endPosition
+        }
+    }
+
+    private fun createAnimationStepsFromRequest(request: AnimationRequest): List<AnimationStep> {
+        val requestPositions = (request.locationUpdate.skippedLocations + request.locationUpdate.location)
+            .map { it.toPosition() }
+        return requestPositions.foldIndexed(mutableListOf()) { index, steps, position ->
+            val startPosition =
+                if (index == 0) getNewAnimationStartingPosition(request.locationUpdate)
+                else requestPositions[index - 1]
+            steps.add(AnimationStep(startPosition, position, UNKNOWN_DURATION))
+            steps
+        }
+    }
+
+    private fun getNewAnimationStartingPosition(locationUpdate: LocationUpdate): Position =
+        previousFinalPosition
+            ?: locationUpdate.skippedLocations.firstOrNull()?.toPosition()
+            ?: locationUpdate.location.toPosition()
+
+    private suspend fun animationLoop() {
+        while (true) {
+            if (animationSteps.isNotEmpty()) {
+                val currentStep = synchronized(animationSteps) { animationSteps.removeFirst() }
+                animateStep(currentStep)
+            } else {
+                delay(IDLE_ANIMATION_LOOP_DELAY_IN_MILLISECONDS)
+            }
+        }
+    }
+
+    private suspend fun animateStep(animationStep: AnimationStep) {
+        val interpolator = LinearInterpolator()
+        val startTimeInMillis = SystemClock.uptimeMillis()
+
+        var timeElapsedFromStartInMilliseconds: Long
+        var timeProgressPercentage = 0f
+        var distanceProgressPercentage: Float
+
+        _cameraPositionsFlow.emit(
+            animationStep.endPosition
+        )
+
+        while (timeProgressPercentage < 1) {
+            timeElapsedFromStartInMilliseconds = SystemClock.uptimeMillis() - startTimeInMillis
+            timeProgressPercentage = timeElapsedFromStartInMilliseconds / animationStep.durationInMilliseconds.toFloat()
+            distanceProgressPercentage = interpolator.getInterpolation(timeProgressPercentage)
+            _positionsFlow.emit(
+                interpolateLinear(distanceProgressPercentage, animationStep.startPosition, animationStep.endPosition)
+            )
+            delay(SINGLE_ANIMATION_FRAME_INTERVAL_IN_MILLISECONDS)
+        }
+    }
+
+    private fun interpolateLinear(fraction: Float, first: Position, second: Position): Position {
+        val latitude = interpolateLinear(fraction, first.latitude, second.latitude)
+        val longitude = interpolateLinear(fraction, first.longitude, second.longitude)
+        val accuracy = interpolateLinear(fraction, first.accuracy, second.accuracy)
+        return Position(latitude, longitude, second.bearing, accuracy)
+    }
+
+    private fun interpolateLinear(fraction: Float, a: Double, b: Double): Double = (b - a) * fraction + a
+
+    private fun interpolateLinear(fraction: Float, a: Float, b: Float): Float = (b - a) * fraction + a
+
+    private fun Location.toPosition() = Position(latitude, longitude, bearing, accuracy)
+
+    private data class AnimationRequest(
+        val locationUpdate: LocationUpdate,
+        val expectedIntervalBetweenLocationUpdatesInMilliseconds: Long,
+    )
+
+    private data class AnimationStep(
+        val startPosition: Position,
+        val endPosition: Position,
+        var durationInMilliseconds: Long,
+    )
+}

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -12,8 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.transition.TransitionManager
 import com.ably.tracking.Accuracy
-import com.ably.tracking.Location
-import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.Authentication
@@ -47,13 +45,10 @@ import kotlinx.android.synthetic.main.trackable_input_controls_view.startButton
 import kotlinx.android.synthetic.main.trackable_input_controls_view.trackableIdEditText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 import timber.log.Timber
 
 // The client ID for the Ably SDK instance.
@@ -67,8 +62,6 @@ private const val ZOOM_LEVEL_STREETS = 15F
 private const val ZOOM_LEVEL_CITY = 10F
 private const val ZOOM_LEVEL_CONTINENT = 5F
 
-private const val INITIAL_LOCATION_UPDATE_INTERVAL_IN_MILLISECONDS = 1000L
-
 class MainActivity : AppCompatActivity() {
     private var subscriber: Subscriber? = null
     private var googleMap: GoogleMap? = null
@@ -78,7 +71,9 @@ class MainActivity : AppCompatActivity() {
     private var rawAccuracyCircle: Circle? = null
     private var resolution: Resolution =
         Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
-    private var locationUpdateIntervalInMilliseconds = INITIAL_LOCATION_UPDATE_INTERVAL_IN_MILLISECONDS
+    private var locationUpdateIntervalInMilliseconds = resolution.desiredInterval
+    private val enhancedLocationAnimator: LocationAnimator = CoreLocationAnimator()
+    private val rawLocationAnimator: LocationAnimator = CoreLocationAnimator()
 
     // SupervisorJob() is used to keep the scope working after any of its children fail
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -90,6 +85,7 @@ class MainActivity : AppCompatActivity() {
         prepareMap()
         setTrackableIdEditTextListener()
         setupTrackableInputAction()
+        setupLocationMarkerAnimations()
 
         startButton.setOnClickListener {
             if (subscriber == null) {
@@ -98,6 +94,20 @@ class MainActivity : AppCompatActivity() {
                 stopSubscribing()
             }
         }
+    }
+
+    private fun setupLocationMarkerAnimations() {
+        enhancedLocationAnimator.positionsFlow
+            .onEach { showMarkerOnMap(it, isRaw = false) }
+            .launchIn(scope)
+
+        enhancedLocationAnimator.cameraPositionsFlow
+            .onEach { moveCamera(it) }
+            .launchIn(scope)
+
+        rawLocationAnimator.positionsFlow
+            .onEach { showMarkerOnMap(it, isRaw = true) }
+            .launchIn(scope)
     }
 
     private fun setTrackableIdEditTextListener() {
@@ -165,28 +175,22 @@ class MainActivity : AppCompatActivity() {
             })
             .start()
             .apply {
-                var processEnhancedLocationJob: Job? = null
-                var processRawLocationJob: Job? = null
                 locations
-                    .onEach {
-                        processEnhancedLocationJob?.cancel()
-                        processEnhancedLocationJob = scope.launch { processLocationUpdate(it, isRaw = false) }
-                    }
+                    .onEach { enhancedLocationAnimator.animateLocationUpdate(it, locationUpdateIntervalInMilliseconds) }
                     .launchIn(scope)
                 rawLocations
-                    .onEach {
-                        processRawLocationJob?.cancel()
-                        processRawLocationJob = scope.launch { processLocationUpdate(it, isRaw = true) }
-                    }
+                    .onEach { rawLocationAnimator.animateLocationUpdate(it, locationUpdateIntervalInMilliseconds) }
                     .launchIn(scope)
                 trackableStates
                     .onEach { updateAssetState(it) }
                     .launchIn(scope)
                 resolutions
                     .onEach {
-                        locationUpdateIntervalInMilliseconds = resolution.desiredInterval
                         updatePublisherResolutionInfo(it)
                     }
+                    .launchIn(scope)
+                nextLocationUpdateIntervals
+                    .onEach { locationUpdateIntervalInMilliseconds = it }
                     .launchIn(scope)
             }
     }
@@ -297,72 +301,65 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private suspend fun processLocationUpdate(locationUpdate: LocationUpdate, isRaw: Boolean) {
-        if (locationUpdate.skippedLocations.isNotEmpty()) {
-            val allLocations = locationUpdate.skippedLocations + locationUpdate.location
-            val singleLocationUpdateDuration: Float = locationUpdateIntervalInMilliseconds.toFloat() / allLocations.size
-            allLocations.forEach { location ->
-                yield() // this will break the coroutine if it was cancelled
-                showMarkerOnMap(location, isRaw, singleLocationUpdateDuration)
+    private fun showMarkerOnMap(newPosition: Position, isRaw: Boolean) {
+        val currentMarker = if (isRaw) rawMarker else enhancedMarker
+        val currentAccuracyCircle = if (isRaw) rawAccuracyCircle else enhancedAccuracyCircle
+        if (currentMarker == null || currentAccuracyCircle == null) {
+            createMarker(newPosition, isRaw)
+            if (!isRaw) {
+                moveCamera(newPosition, ZOOM_LEVEL_STREETS)
             }
         } else {
-            yield() // this will break the coroutine if it was cancelled
-            showMarkerOnMap(locationUpdate.location, isRaw, locationUpdateIntervalInMilliseconds.toFloat())
+            updateMarker(newPosition, currentMarker, currentAccuracyCircle, isRaw)
         }
     }
 
-    private suspend fun showMarkerOnMap(location: Location, isRaw: Boolean, animationDuration: Float) {
+    private fun createMarker(newPosition: Position, isRaw: Boolean) {
         googleMap?.apply {
-            val position = LatLng(location.latitude, location.longitude)
-            val currentMarker = if (isRaw) rawMarker else enhancedMarker
-            val currentAccuracyCircle = if (isRaw) rawAccuracyCircle else enhancedAccuracyCircle
-            if (currentMarker == null || currentAccuracyCircle == null) {
-                val marker = addMarker(
-                    MarkerOptions()
-                        .position(position)
-                        .icon(getMarkerIcon(location.bearing, isRaw))
-                        .alpha(if (isRaw) 0.5f else 1f)
-                )
-                val accuracyCircle = addCircle(
-                    CircleOptions()
-                        .center(position)
-                        .radius(location.accuracy.toDouble())
-                        .strokeColor(if (isRaw) COLOR_RED else COLOR_ORANGE)
-                        .fillColor(if (isRaw) COLOR_RED_TRANSPARENT else COLOR_ORANGE_TRANSPARENT)
-                        .strokeWidth(2f)
-                )
-                if (isRaw) {
-                    rawMarker = marker
-                    rawAccuracyCircle = accuracyCircle
-                } else {
-                    enhancedMarker = marker
-                    enhancedAccuracyCircle = accuracyCircle
-                    moveCamera(CameraUpdateFactory.newLatLngZoom(position, ZOOM_LEVEL_STREETS))
-                }
+            val position = LatLng(newPosition.latitude, newPosition.longitude)
+            val marker = addMarker(
+                MarkerOptions()
+                    .position(position)
+                    .icon(getMarkerIcon(newPosition.bearing, isRaw))
+                    .alpha(if (isRaw) 0.5f else 1f)
+            )
+            val accuracyCircle = addCircle(
+                CircleOptions()
+                    .center(position)
+                    .radius(newPosition.accuracy.toDouble())
+                    .strokeColor(if (isRaw) COLOR_RED else COLOR_ORANGE)
+                    .fillColor(if (isRaw) COLOR_RED_TRANSPARENT else COLOR_ORANGE_TRANSPARENT)
+                    .strokeWidth(2f)
+            )
+            if (isRaw) {
+                rawMarker = marker
+                rawAccuracyCircle = accuracyCircle
             } else {
-                val cameraPosition = CameraUpdateFactory.newLatLng(position)
-                currentMarker.setIcon(getMarkerIcon(location.bearing, isRaw))
-                if (animationSwitch.isChecked) {
-                    if (!isRaw) {
-                        animateCamera(cameraPosition)
-                    }
-                    animateMarkerAndCircleMovement(
-                        currentMarker,
-                        position,
-                        currentAccuracyCircle,
-                        location.accuracy.toDouble(),
-                        animationDuration,
-                    )
-                } else {
-                    if (!isRaw) {
-                        moveCamera(cameraPosition)
-                    }
-                    currentMarker.position = position
-                    currentAccuracyCircle.center = position
-                    currentAccuracyCircle.radius = location.accuracy.toDouble()
-                    delay(animationDuration.toLong())
-                }
+                enhancedMarker = marker
+                enhancedAccuracyCircle = accuracyCircle
             }
+        }
+    }
+
+    private fun updateMarker(newPosition: Position, marker: Marker, accuracyCircle: Circle, isRaw: Boolean) {
+        val position = LatLng(newPosition.latitude, newPosition.longitude)
+        marker.setIcon(getMarkerIcon(newPosition.bearing, isRaw))
+        marker.position = position
+        accuracyCircle.center = position
+        accuracyCircle.radius = newPosition.accuracy.toDouble()
+    }
+
+    private fun moveCamera(newPosition: Position, zoomLevel: Float? = null) {
+        val position = LatLng(newPosition.latitude, newPosition.longitude)
+        val cameraPosition = if (zoomLevel == null) {
+            CameraUpdateFactory.newLatLng(position)
+        } else {
+            CameraUpdateFactory.newLatLngZoom(position, zoomLevel)
+        }
+        if (animationSwitch.isChecked && zoomLevel == null) {
+            googleMap?.animateCamera(cameraPosition)
+        } else {
+            googleMap?.moveCamera(cameraPosition)
         }
     }
 

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MapIconHelper.kt
@@ -1,14 +1,5 @@
 package com.ably.tracking.example.subscriber
 
-import android.os.Handler
-import android.os.Looper
-import android.os.SystemClock
-import android.view.animation.LinearInterpolator
-import com.google.android.gms.maps.model.Circle
-import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.Marker
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import kotlin.math.roundToInt
 
 fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
@@ -23,61 +14,3 @@ fun getMarkerResourceIdByBearing(bearing: Float, isRaw: Boolean): Int {
         else -> if (isRaw) R.drawable.driver_raw_n else R.drawable.driver_n
     }
 }
-
-suspend fun animateMarkerAndCircleMovement(
-    marker: Marker,
-    finalPosition: LatLng,
-    circle: Circle,
-    finalRadius: Double,
-    animationDurationInMillis: Float = 1000f,
-) {
-    suspendCoroutine<Unit> {
-        animateMarkerAndCircleMovement(marker, finalPosition, circle, finalRadius, animationDurationInMillis) {
-            it.resume(Unit)
-        }
-    }
-}
-
-fun animateMarkerAndCircleMovement(
-    marker: Marker,
-    finalPosition: LatLng,
-    circle: Circle,
-    finalRadius: Double,
-    animationDurationInMillis: Float = 1000f,
-    animationFinishedCallback: () -> Unit = {}
-) {
-    val startPosition = marker.position
-    val startRadius = circle.radius
-    val interpolator = LinearInterpolator()
-    val startTimeInMillis = SystemClock.uptimeMillis()
-    val nextCalculationDelayInMillis = 16L
-    val handler = Handler(Looper.getMainLooper())
-
-    handler.post(object : Runnable {
-        var timeElapsedFromStartInMillis = 0L
-        var timeProgressPercentage = 0f
-        var distanceProgressPercentage = 0f
-        override fun run() {
-            timeElapsedFromStartInMillis = SystemClock.uptimeMillis() - startTimeInMillis
-            timeProgressPercentage = timeElapsedFromStartInMillis / animationDurationInMillis
-            distanceProgressPercentage = interpolator.getInterpolation(timeProgressPercentage)
-            marker.position = interpolateLinear(distanceProgressPercentage, startPosition, finalPosition)
-            circle.center = interpolateLinear(distanceProgressPercentage, startPosition, finalPosition)
-            circle.radius = interpolateLinear(distanceProgressPercentage, startRadius, finalRadius)
-
-            if (timeProgressPercentage < 1) {
-                handler.postDelayed(this, nextCalculationDelayInMillis)
-            } else {
-                animationFinishedCallback()
-            }
-        }
-    })
-}
-
-private fun interpolateLinear(fraction: Float, a: LatLng, b: LatLng): LatLng {
-    val lat = interpolateLinear(fraction, a.latitude, b.latitude)
-    val lng = interpolateLinear(fraction, a.longitude, b.longitude)
-    return LatLng(lat, lng)
-}
-
-private fun interpolateLinear(fraction: Float, a: Double, b: Double): Double = (b - a) * fraction + a


### PR DESCRIPTION
I've added a `LocationAnimator` which takes care of animating the location updates received from the `Subscriber` SDK. It takes the location updates and returns a flow of subsequent animation steps. All the user has to do is to move the marker when a animation step appears in the flow.
We mainly rely on the `desiredInterval` value from the calculated resolution to calculate the time of the animation. However, to avoid marker stop when a new location update is coming a bit late, we've introduced an intentional delay of 2 seconds. Additionally, we also are prepared to speed up the marker movement if a new location update arrives sooner than we've anticipated. Overall, the animation should be as long as the sum of the `desiredInterval` and the intentional 2 seconds delay.
Because of the way of the new location animator is working the "toggle animation" switch no longer stops the animation of the map marker but only controls the animation of the camera movement.