### PR TITLE
Enable sending resolution from publisher example app by default

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -50,7 +50,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
     private val DEFAULT_SEND_RAW_LOCATIONS = false
-    private val DEFAULT_SEND_RESOLUTION = false
+    private val DEFAULT_SEND_RESOLUTION = true
     private val DEFAULT_ENABLE_PREDICTIONS = true
     private val DEFAULT_ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION = false
 

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -112,7 +112,7 @@
       android:title="@string/preferences_send_raw_locations_label" />
 
     <SwitchPreferenceCompat
-      android:defaultValue="false"
+      android:defaultValue="true"
       android:key="@string/preferences_send_resolution_key"
       android:layout="@layout/switch_preference_layout"
       android:title="@string/preferences_send_resolution_label" />


### PR DESCRIPTION
I think that since now in the animation logic we rely on the publisher resolution being sent, we should enable sending resolution in the publisher example app by default.