### PR TITLE
CI build reports

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,48 +33,56 @@ jobs:
         if: always()
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for common
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-common-build-reports
           path: common/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for integration-testing-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for publishing-example-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-publishing-example-app-build-reports
           path: publishing-example-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for publishing-java-testing
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-publishing-java-testing-build-reports
           path: publishing-java-testing/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for publishing-sdk
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
           path: publishing-sdk/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for subscribing-example-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
           path: subscribing-example-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for subscribing-java-testing
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-subscribing-java-testing-build-reports
           path: subscribing-java-testing/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for subscribing-sdk
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-subscribing-sdk-build-reports

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,11 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
+      # Reveal potential locations of test build reports
+      # (temporary: we'll remove this once we've confirmed where they all end up)
+      - run: find . -name "index.html"
+        if: always()
+
       - uses: actions/upload-artifact@v2
         with:
           name: build-profile-report

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,54 +31,54 @@ jobs:
         name: Build Reports for common
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-common-build-reports
+          name: java-version-${{ matrix.java-version }}-common-build-reports
           path: common/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for integration-testing-app
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
+          name: java-version-${{ matrix.java-version }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for publishing-example-app
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-publishing-example-app-build-reports
+          name: java-version-${{ matrix.java-version }}-publishing-example-app-build-reports
           path: publishing-example-app/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for publishing-java-testing
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-publishing-java-testing-build-reports
+          name: java-version-${{ matrix.java-version }}-publishing-java-testing-build-reports
           path: publishing-java-testing/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for publishing-sdk
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
+          name: java-version-${{ matrix.java-version }}-publishing-sdk-build-reports
           path: publishing-sdk/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for subscribing-example-app
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
+          name: java-version-${{ matrix.java-version }}-subscribing-example-app-build-reports
           path: subscribing-example-app/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for subscribing-java-testing
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-subscribing-java-testing-build-reports
+          name: java-version-${{ matrix.java-version }}-subscribing-java-testing-build-reports
           path: subscribing-java-testing/build/reports
 
       - uses: actions/upload-artifact@v2
         name: Build Reports for subscribing-sdk
         if: always()
         with:
-          name: api-level-${{ matrix.api-level }}-subscribing-sdk-build-reports
+          name: java-version-${{ matrix.java-version }}-subscribing-sdk-build-reports
           path: subscribing-sdk/build/reports

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,21 +33,49 @@ jobs:
         if: always()
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: build-profile-report
-          path: build/reports/profile/
+          name: api-level-${{ matrix.api-level }}-common-build-reports
+          path: common/build/reports
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: subscribing-sdk-coverage
-          path: subscribing-sdk/build/reports/jacoco/
+          name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
+          path: integration-testing-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: publishing-sdk-coverage
-          path: publishing-sdk/build/reports/jacoco/
+          name: api-level-${{ matrix.api-level }}-publishing-example-app-build-reports
+          path: publishing-example-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: core-sdk-coverage
-          path: core-sdk/build/reports/jacoco/
+          name: api-level-${{ matrix.api-level }}-publishing-java-testing-build-reports
+          path: publishing-java-testing/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
+          path: publishing-sdk/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
+          path: subscribing-example-app/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-subscribing-java-testing-build-reports
+          path: subscribing-java-testing/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-subscribing-sdk-build-reports
+          path: subscribing-sdk/build/reports

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,11 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
+      # Reveal potential locations of test build reports
+      # (temporary: we'll remove this once we've confirmed where they all end up)
+      - run: find . -name "index.html"
+        if: always()
+
       - uses: actions/upload-artifact@v2
         name: Build Reports for common
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,11 +27,6 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
-      # Reveal potential locations of test build reports
-      # (temporary: we'll remove this once we've confirmed where they all end up)
-      - run: find . -name "index.html"
-        if: always()
-
       - uses: actions/upload-artifact@v2
         name: Build Reports for common
         if: always()

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -47,5 +47,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: integration-testing-app-build-reports
+          name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -38,3 +38,9 @@ jobs:
           ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: integration-testing-app-build-reports
+          path: integration-testing-app/build/reports

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -49,3 +49,27 @@ jobs:
         with:
           name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-core-sdk-java-build-reports
+          path: core-sdk-java/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-common-build-reports
+          path: common/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-android-test-common-build-reports
+          path: android-test-common/build/reports
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-core-sdk-build-reports
+          path: core-sdk/build/reports

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -39,11 +39,6 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
-      # Reveal potential locations of test build reports
-      # (temporary: we'll remove this once we've confirmed where they all end up)
-      - run: find . -name "index.html"
-        if: always()
-
       - uses: actions/upload-artifact@v2
         name: Build Reports for integration-testing-app
         if: always()

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -39,6 +39,11 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
+      # Reveal potential locations of test build reports
+      # (temporary: we'll remove this once we've confirmed where they all end up)
+      - run: find . -name "index.html"
+        if: always()
+
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -39,6 +39,11 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
+      # Reveal potential locations of test build reports
+      # (temporary: we'll remove this once we've confirmed where they all end up)
+      - run: find . -name "index.html"
+        if: always()
+
       - uses: actions/upload-artifact@v2
         name: Build Reports for integration-testing-app
         if: always()

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -45,30 +45,35 @@ jobs:
         if: always()
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for integration-testing-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for core-sdk-java
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-core-sdk-java-build-reports
           path: core-sdk-java/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for common
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-common-build-reports
           path: common/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for android-test-common
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-android-test-common-build-reports
           path: android-test-common/build/reports
 
       - uses: actions/upload-artifact@v2
+        name: Build Reports for core-sdk
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-core-sdk-build-reports


### PR DESCRIPTION
Expose more information as artifacts, in particular for us to use to debug when CI runs have failed.