### PR TITLE
Add the WorkerFactory for easier Worker creation

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/EventWorkerQueue.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/EventWorkerQueue.kt
@@ -5,9 +5,9 @@ import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.DefaultCorePublisher
 import com.ably.tracking.publisher.Request
 import com.ably.tracking.publisher.workerqueue.resulthandlers.getWorkResultHandler
-import com.ably.tracking.publisher.workerqueue.workers.Worker
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
+import com.ably.tracking.publisher.workerqueue.workers.Worker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -19,7 +19,8 @@ import kotlinx.coroutines.launch
 internal class EventWorkerQueue(
     private val corePublisher: CorePublisher,
     private val publisherProperties: DefaultCorePublisher.Properties,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val workerFactory: WorkerFactory,
 ) : WorkerQueue {
 
     /**
@@ -45,7 +46,7 @@ internal class EventWorkerQueue(
 
     private fun handleWorkResult(workResult: WorkResult) {
         val resultHandler = getWorkResultHandler(workResult)
-        val nextWorker = resultHandler.handle(workResult, corePublisher)
+        val nextWorker = resultHandler.handle(workResult, corePublisher, workerFactory)
         nextWorker?.let {
             it.event.apply {
                 when (this) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -1,0 +1,289 @@
+package com.ably.tracking.publisher.workerqueue
+
+import com.ably.tracking.EnhancedLocationUpdate
+import com.ably.tracking.Location
+import com.ably.tracking.LocationUpdate
+import com.ably.tracking.LocationUpdateType
+import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.common.TimeProvider
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.DefaultCorePublisher
+import com.ably.tracking.publisher.Mapbox
+import com.ably.tracking.publisher.ResolutionPolicy
+import com.ably.tracking.publisher.RoutingProfile
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.workers.AblyConnectionStateChangeWorker
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
+import com.ably.tracking.publisher.workerqueue.workers.AddTrackableWorker
+import com.ably.tracking.publisher.workerqueue.workers.ChangeLocationEngineResolutionWorker
+import com.ably.tracking.publisher.workerqueue.workers.ChangeRoutingProfileWorker
+import com.ably.tracking.publisher.workerqueue.workers.ChannelConnectionStateChangeWorker
+import com.ably.tracking.publisher.workerqueue.workers.ConnectionCreatedWorker
+import com.ably.tracking.publisher.workerqueue.workers.ConnectionReadyWorker
+import com.ably.tracking.publisher.workerqueue.workers.DestinationSetWorker
+import com.ably.tracking.publisher.workerqueue.workers.DisconnectSuccessWorker
+import com.ably.tracking.publisher.workerqueue.workers.EnhancedLocationChangedWorker
+import com.ably.tracking.publisher.workerqueue.workers.PresenceMessageWorker
+import com.ably.tracking.publisher.workerqueue.workers.RawLocationChangedWorker
+import com.ably.tracking.publisher.workerqueue.workers.RefreshResolutionPolicyWorker
+import com.ably.tracking.publisher.workerqueue.workers.RemoveTrackableWorker
+import com.ably.tracking.publisher.workerqueue.workers.SendEnhancedLocationFailureWorker
+import com.ably.tracking.publisher.workerqueue.workers.SendEnhancedLocationSuccessWorker
+import com.ably.tracking.publisher.workerqueue.workers.SendRawLocationFailureWorker
+import com.ably.tracking.publisher.workerqueue.workers.SendRawLocationSuccessWorker
+import com.ably.tracking.publisher.workerqueue.workers.SetActiveTrackableWorker
+import com.ably.tracking.publisher.workerqueue.workers.StopWorker
+import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Factory that creates the [Worker]s. It also serves as a simple DI for workers dependencies.
+ */
+internal interface WorkerFactory {
+    /**
+     * Creates an appropriate [Worker] from the passed [WorkerParams].
+     *
+     * @param params The parameters that indicate which [Worker] implementation should be created.
+     * @return New [Worker] instance.
+     */
+    fun createWorker(params: WorkerParams): Worker
+}
+
+internal class DefaultWorkerFactory(
+    private val ably: Ably,
+    private val hooks: DefaultCorePublisher.Hooks,
+    private val corePublisher: CorePublisher,
+    private val resolutionPolicy: ResolutionPolicy,
+    private val mapbox: Mapbox,
+    private val timeProvider: TimeProvider,
+) : WorkerFactory {
+    override fun createWorker(params: WorkerParams): Worker {
+        return when (params) {
+            is WorkerParams.AddTrackable -> AddTrackableWorker(
+                params.trackable,
+                params.callbackFunction,
+                ably,
+            )
+            is WorkerParams.AddTrackableFailed -> AddTrackableFailedWorker(
+                params.trackable,
+                params.callbackFunction,
+                params.exception,
+            )
+            is WorkerParams.ConnectionCreated -> ConnectionCreatedWorker(
+                params.trackable,
+                params.callbackFunction,
+                ably,
+                params.presenceUpdateListener,
+            )
+            is WorkerParams.ConnectionReady -> ConnectionReadyWorker(
+                params.trackable,
+                params.callbackFunction,
+                ably,
+                hooks,
+                corePublisher,
+                params.channelStateChangeListener,
+            )
+            is WorkerParams.DisconnectSuccess -> DisconnectSuccessWorker(
+                params.trackable,
+                params.callbackFunction,
+                corePublisher,
+                params.shouldRecalculateResolutionCallback,
+            )
+            is WorkerParams.TrackableRemovalRequested -> TrackableRemovalRequestedWorker(
+                params.trackable,
+                params.callbackFunction,
+                params.result,
+            )
+            is WorkerParams.AblyConnectionStateChange -> AblyConnectionStateChangeWorker(
+                params.connectionStateChange,
+                corePublisher,
+            )
+            WorkerParams.ChangeLocationEngineResolution -> ChangeLocationEngineResolutionWorker(
+                resolutionPolicy,
+                mapbox,
+            )
+            is WorkerParams.ChangeRoutingProfile -> ChangeRoutingProfileWorker(
+                params.routingProfile,
+                corePublisher,
+            )
+            is WorkerParams.ChannelConnectionStateChange -> ChannelConnectionStateChangeWorker(
+                params.connectionStateChange,
+                params.trackableId,
+                corePublisher,
+            )
+            is WorkerParams.DestinationSet -> DestinationSetWorker(
+                params.routeDurationInMilliseconds,
+                timeProvider,
+            )
+            is WorkerParams.EnhancedLocationChanged -> EnhancedLocationChangedWorker(
+                params.location,
+                params.intermediateLocations,
+                params.type,
+                corePublisher,
+            )
+            is WorkerParams.PresenceMessage -> PresenceMessageWorker(
+                params.trackable,
+                params.presenceMessage,
+                corePublisher,
+            )
+            is WorkerParams.RawLocationChanged -> RawLocationChangedWorker(
+                params.location,
+                corePublisher,
+            )
+            WorkerParams.RefreshResolutionPolicy -> RefreshResolutionPolicyWorker(
+                corePublisher,
+            )
+            is WorkerParams.RemoveTrackable -> RemoveTrackableWorker(
+                params.trackable,
+                params.callbackFunction,
+                ably,
+            )
+            is WorkerParams.SendEnhancedLocationFailure -> SendEnhancedLocationFailureWorker(
+                params.locationUpdate,
+                params.trackableId,
+                params.exception,
+                corePublisher,
+            )
+            is WorkerParams.SendEnhancedLocationSuccess -> SendEnhancedLocationSuccessWorker(
+                params.location,
+                params.trackableId,
+                corePublisher,
+            )
+            is WorkerParams.SendRawLocationFailure -> SendRawLocationFailureWorker(
+                params.locationUpdate,
+                params.trackableId,
+                params.exception,
+                corePublisher,
+            )
+            is WorkerParams.SendRawLocationSuccess -> SendRawLocationSuccessWorker(
+                params.location,
+                params.trackableId,
+                corePublisher,
+            )
+            is WorkerParams.SetActiveTrackable -> SetActiveTrackableWorker(
+                params.trackable,
+                params.callbackFunction,
+                corePublisher,
+                hooks,
+            )
+            is WorkerParams.Stop -> StopWorker(
+                params.callbackFunction,
+                ably,
+                corePublisher,
+            )
+        }
+    }
+}
+
+internal sealed class WorkerParams {
+    data class AblyConnectionStateChange(
+        val connectionStateChange: ConnectionStateChange,
+    ) : WorkerParams()
+
+    data class AddTrackable(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+    ) : WorkerParams()
+
+    data class AddTrackableFailed(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val exception: Exception,
+    ) : WorkerParams()
+
+    object ChangeLocationEngineResolution : WorkerParams()
+
+    data class ChangeRoutingProfile(
+        val routingProfile: RoutingProfile,
+    ) : WorkerParams()
+
+    data class ChannelConnectionStateChange(
+        val trackableId: String,
+        val connectionStateChange: ConnectionStateChange,
+    ) : WorkerParams()
+
+    data class ConnectionCreated(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
+    ) : WorkerParams()
+
+    data class ConnectionReady(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
+    ) : WorkerParams()
+
+    data class DestinationSet(
+        val routeDurationInMilliseconds: Long,
+    ) : WorkerParams()
+
+    data class DisconnectSuccess(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<Unit>,
+        val shouldRecalculateResolutionCallback: () -> Unit,
+    ) : WorkerParams()
+
+    data class EnhancedLocationChanged(
+        val location: Location,
+        val intermediateLocations: List<Location>,
+        val type: LocationUpdateType,
+    ) : WorkerParams()
+
+    data class PresenceMessage(
+        val trackable: Trackable,
+        val presenceMessage: com.ably.tracking.common.PresenceMessage,
+    ) : WorkerParams()
+
+    data class RawLocationChanged(
+        val location: Location,
+    ) : WorkerParams()
+
+    object RefreshResolutionPolicy : WorkerParams()
+
+    data class RemoveTrackable(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<Boolean>,
+    ) : WorkerParams()
+
+    data class SendEnhancedLocationFailure(
+        val locationUpdate: EnhancedLocationUpdate,
+        val trackableId: String,
+        val exception: Throwable?,
+    ) : WorkerParams()
+
+    data class SendEnhancedLocationSuccess(
+        val location: Location,
+        val trackableId: String,
+    ) : WorkerParams()
+
+    data class SendRawLocationFailure(
+        val locationUpdate: LocationUpdate,
+        val trackableId: String,
+        val exception: Throwable?,
+    ) : WorkerParams()
+
+    data class SendRawLocationSuccess(
+        val location: Location,
+        val trackableId: String,
+    ) : WorkerParams()
+
+    data class SetActiveTrackable(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<Unit>,
+    ) : WorkerParams()
+
+    data class Stop(
+        val callbackFunction: ResultCallbackFunction<Unit>,
+    ) : WorkerParams()
+
+    data class TrackableRemovalRequested(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val result: Result<Unit>,
+    ) : WorkerParams()
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -2,14 +2,16 @@ package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.ConnectionForTrackableCreatedEvent
 import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
-import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class AddTrackableResultHandler : WorkResultHandler<AddTrackableWorkResult> {
     override fun handle(
         workResult: AddTrackableWorkResult,
-        corePublisher: CorePublisher
+        corePublisher: CorePublisher,
+        workerFactory: WorkerFactory,
     ): Worker? {
         when (workResult) {
             is AddTrackableWorkResult.AlreadyIn -> workResult.callbackFunction(
@@ -17,8 +19,10 @@ internal class AddTrackableResultHandler : WorkResultHandler<AddTrackableWorkRes
             )
 
             is AddTrackableWorkResult.Fail ->
-                return AddTrackableFailedWorker(
-                    workResult.trackable, workResult.callbackFunction, workResult.exception as Exception
+                return workerFactory.createWorker(
+                    WorkerParams.AddTrackableFailed(
+                        workResult.trackable, workResult.callbackFunction, workResult.exception as Exception
+                    )
                 )
 
             is AddTrackableWorkResult.Success -> corePublisher.request(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -3,14 +3,16 @@ package com.ably.tracking.publisher.workerqueue.resulthandlers
 import com.ably.tracking.publisher.ConnectionForTrackableReadyEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.TrackableRemovalRequestedEvent
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
-import com.ably.tracking.publisher.workerqueue.workers.AddTrackableFailedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class ConnectionCreatedResultHandler : WorkResultHandler<ConnectionCreatedWorkResult> {
     override fun handle(
         workResult: ConnectionCreatedWorkResult,
-        corePublisher: CorePublisher
+        corePublisher: CorePublisher,
+        workerFactory: WorkerFactory,
     ): Worker? {
         when (workResult) {
             is ConnectionCreatedWorkResult.RemovalRequested ->
@@ -31,7 +33,11 @@ internal class ConnectionCreatedResultHandler : WorkResultHandler<ConnectionCrea
                 )
             }
             is ConnectionCreatedWorkResult.PresenceFail ->
-                return AddTrackableFailedWorker(workResult.trackable, workResult.callbackFunction, workResult.exception)
+                return workerFactory.createWorker(
+                    WorkerParams.AddTrackableFailed(
+                        workResult.trackable, workResult.callbackFunction, workResult.exception
+                    )
+                )
         }
         return null
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
@@ -1,18 +1,23 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
 import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
-import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class ConnectionReadyResultHandler : WorkResultHandler<ConnectionReadyWorkResult> {
-    override fun handle(workResult: ConnectionReadyWorkResult, corePublisher: CorePublisher): Worker? {
+    override fun handle(
+        workResult: ConnectionReadyWorkResult,
+        corePublisher: CorePublisher,
+        workerFactory: WorkerFactory
+    ): Worker? {
         when (workResult) {
             is ConnectionReadyWorkResult.RemovalRequested ->
-                return TrackableRemovalRequestedWorker(
-                    trackable = workResult.trackable,
-                    callbackFunction = workResult.callbackFunction,
-                    result = workResult.result
+                return workerFactory.createWorker(
+                    WorkerParams.TrackableRemovalRequested(
+                        workResult.trackable, workResult.callbackFunction, workResult.result
+                    )
                 )
         }
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RemoveTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RemoveTrackableResultHandler.kt
@@ -2,28 +2,33 @@ package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.ChangeLocationEngineResolutionEvent
 import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
-import com.ably.tracking.publisher.workerqueue.workers.DisconnectSuccessWorker
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
 internal class RemoveTrackableResultHandler : WorkResultHandler<RemoveTrackableWorkResult> {
     override fun handle(
         workResult: RemoveTrackableWorkResult,
-        corePublisher: CorePublisher
+        corePublisher: CorePublisher,
+        workerFactory: WorkerFactory,
     ): Worker? {
         when (workResult) {
             is RemoveTrackableWorkResult.Success ->
-                DisconnectSuccessWorker(
-                    trackable = workResult.trackable,
-                    callbackFunction = {
-                        if (it.isSuccess) {
-                            workResult.callbackFunction(Result.success(true))
-                        } else {
-                            workResult.callbackFunction(Result.failure(it.exceptionOrNull()!!))
+                workerFactory.createWorker(
+                    WorkerParams.DisconnectSuccess(
+                        trackable = workResult.trackable,
+                        callbackFunction = {
+                            if (it.isSuccess) {
+                                workResult.callbackFunction(Result.success(true))
+                            } else {
+                                workResult.callbackFunction(Result.failure(it.exceptionOrNull()!!))
+                            }
+                        },
+                        shouldRecalculateResolutionCallback = {
+                            corePublisher.enqueue(ChangeLocationEngineResolutionEvent)
                         }
-                    },
-                    corePublisher = corePublisher,
-                    shouldRecalculateResolutionCallback = { corePublisher.enqueue(ChangeLocationEngineResolutionEvent) }
+                    )
                 )
             is RemoveTrackableWorkResult.Fail -> workResult.callbackFunction(
                 Result.failure(workResult.exception)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandler.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
 import com.ably.tracking.publisher.workerqueue.workers.Worker
 
@@ -17,10 +18,11 @@ internal interface WorkResultHandler<in T : WorkResult> {
      * @param workResult : [WorkResult] to be handled
      * @param corePublisher: This is a temporary reference of [CorePublisher] that is kept here to maintain
      * compatibility with refactored code.
+     * @param workerFactory: A [WorkerFactory] that will create the optional [Worker].
      *
      * Implementors must delegate work to [corePublisher]  if the required [Worker]s have not been implemented yet.
      *
      * @return an optional [Worker] if implementors decide there is a need to add another worker to the queue.
      * **/
-    fun handle(workResult: T, corePublisher: CorePublisher): Worker?
+    fun handle(workResult: T, corePublisher: CorePublisher, workerFactory: WorkerFactory): Worker?
 }


### PR DESCRIPTION
I've added the `WorkerFactory` that's responsible for creating all the workers. Thanks to this we can hide the implementation details like usage of the Ably wrapper or log handler when creating a worker.
This is a groundwork for the upcoming PRs that will replace the event queue with the new worker queue.