### PR TITLE
Move log statements from the event queue to the workers

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -163,7 +163,7 @@ constructor(
         )
         val channel = Channel<Event>()
         sendEventChannel = channel
-        workerFactory = DefaultWorkerFactory(ably, hooks, this, policy, mapbox, this)
+        workerFactory = DefaultWorkerFactory(ably, hooks, this, policy, mapbox, this, logHandler)
         scope.launch {
             coroutineScope {
                 sequenceEventsQueue(channel, routingProfile, areRawLocationsEnabled)
@@ -226,11 +226,9 @@ constructor(
                         )
                     }
                     is RawLocationChangedEvent -> {
-                        logHandler?.v("$TAG Raw location changed event received ${event.location}")
                         workerQueue.execute(workerFactory.createWorker(WorkerParams.RawLocationChanged(event.location)))
                     }
                     is EnhancedLocationChangedEvent -> {
-                        logHandler?.v("$TAG Enhanced location changed event received ${event.location}")
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.EnhancedLocationChanged(
@@ -374,7 +372,6 @@ constructor(
                         workerQueue.execute(workerFactory.createWorker(WorkerParams.Stop(event.callbackFunction)))
                     }
                     is AblyConnectionStateChangeEvent -> {
-                        logHandler?.v("$TAG Ably connection state changed ${event.connectionStateChange.state}")
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.AblyConnectionStateChange(event.connectionStateChange)
@@ -382,7 +379,6 @@ constructor(
                         )
                     }
                     is ChannelConnectionStateChangeEvent -> {
-                        logHandler?.v("$TAG Trackable ${event.trackableId} connection state changed ${event.connectionStateChange.state}")
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.ChannelConnectionStateChange(
@@ -393,7 +389,6 @@ constructor(
                         )
                     }
                     is SendEnhancedLocationSuccessEvent -> {
-                        logHandler?.v("$TAG Trackable ${event.trackableId} successfully sent enhanced location ${event.location}")
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.SendEnhancedLocationSuccess(
@@ -404,10 +399,6 @@ constructor(
                         )
                     }
                     is SendEnhancedLocationFailureEvent -> {
-                        logHandler?.w(
-                            "$TAG Trackable ${event.trackableId} failed to send enhanced location ${event.locationUpdate.location}",
-                            event.exception
-                        )
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.SendEnhancedLocationFailure(
@@ -419,7 +410,6 @@ constructor(
                         )
                     }
                     is SendRawLocationSuccessEvent -> {
-                        logHandler?.v("$TAG Trackable ${event.trackableId} successfully sent raw location ${event.location}")
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.SendRawLocationSuccess(
@@ -430,10 +420,6 @@ constructor(
                         )
                     }
                     is SendRawLocationFailureEvent -> {
-                        logHandler?.w(
-                            "$TAG Trackable ${event.trackableId} failed to send raw location ${event.locationUpdate.location}",
-                            event.exception
-                        )
                         workerQueue.execute(
                             workerFactory.createWorker(
                                 WorkerParams.SendRawLocationFailure(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -9,6 +9,7 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.common.TimeProvider
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.DefaultCorePublisher
 import com.ably.tracking.publisher.Mapbox
@@ -60,6 +61,7 @@ internal class DefaultWorkerFactory(
     private val resolutionPolicy: ResolutionPolicy,
     private val mapbox: Mapbox,
     private val timeProvider: TimeProvider,
+    private val logHandler: LogHandler?,
 ) : WorkerFactory {
     override fun createWorker(params: WorkerParams): Worker {
         return when (params) {
@@ -101,6 +103,7 @@ internal class DefaultWorkerFactory(
             is WorkerParams.AblyConnectionStateChange -> AblyConnectionStateChangeWorker(
                 params.connectionStateChange,
                 corePublisher,
+                logHandler,
             )
             WorkerParams.ChangeLocationEngineResolution -> ChangeLocationEngineResolutionWorker(
                 resolutionPolicy,
@@ -114,6 +117,7 @@ internal class DefaultWorkerFactory(
                 params.connectionStateChange,
                 params.trackableId,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.DestinationSet -> DestinationSetWorker(
                 params.routeDurationInMilliseconds,
@@ -124,6 +128,7 @@ internal class DefaultWorkerFactory(
                 params.intermediateLocations,
                 params.type,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.PresenceMessage -> PresenceMessageWorker(
                 params.trackable,
@@ -133,6 +138,7 @@ internal class DefaultWorkerFactory(
             is WorkerParams.RawLocationChanged -> RawLocationChangedWorker(
                 params.location,
                 corePublisher,
+                logHandler,
             )
             WorkerParams.RefreshResolutionPolicy -> RefreshResolutionPolicyWorker(
                 corePublisher,
@@ -147,22 +153,26 @@ internal class DefaultWorkerFactory(
                 params.trackableId,
                 params.exception,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.SendEnhancedLocationSuccess -> SendEnhancedLocationSuccessWorker(
                 params.location,
                 params.trackableId,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.SendRawLocationFailure -> SendRawLocationFailureWorker(
                 params.locationUpdate,
                 params.trackableId,
                 params.exception,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.SendRawLocationSuccess -> SendRawLocationSuccessWorker(
                 params.location,
                 params.trackableId,
                 corePublisher,
+                logHandler,
             )
             is WorkerParams.SetActiveTrackable -> SetActiveTrackableWorker(
                 params.trackable,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AblyConnectionStateChangeWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AblyConnectionStateChangeWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.AblyConnectionStateChangeEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
@@ -10,11 +13,14 @@ import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 internal class AblyConnectionStateChangeWorker(
     private val connectionStateChange: ConnectionStateChange,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = AblyConnectionStateChangeEvent(connectionStateChange)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Ably connection state changed ${connectionStateChange.state}")
         properties.lastConnectionStateChange = connectionStateChange
         properties.trackables.forEach {
             corePublisher.updateTrackableState(properties, it.id)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChannelConnectionStateChangeWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChannelConnectionStateChangeWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.ChannelConnectionStateChangeEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
@@ -11,11 +14,14 @@ internal class ChannelConnectionStateChangeWorker(
     private val connectionStateChange: ConnectionStateChange,
     private val trackableId: String,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = ChannelConnectionStateChangeEvent(connectionStateChange, trackableId)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Trackable $trackableId connection state changed ${connectionStateChange.state}")
         properties.lastChannelConnectionStateChanges[trackableId] = connectionStateChange
         corePublisher.updateTrackableState(properties, trackableId)
         return SyncAsyncResult()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnhancedLocationChangedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnhancedLocationChangedWorker.kt
@@ -3,6 +3,9 @@ package com.ably.tracking.publisher.workerqueue.workers
 import com.ably.tracking.EnhancedLocationUpdate
 import com.ably.tracking.Location
 import com.ably.tracking.LocationUpdateType
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.EnhancedLocationChangedEvent
 import com.ably.tracking.publisher.Event
@@ -14,11 +17,14 @@ internal class EnhancedLocationChangedWorker(
     private val intermediateLocations: List<Location>,
     private val type: LocationUpdateType,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = EnhancedLocationChangedEvent(location, intermediateLocations, type)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Enhanced location changed event received $location")
         properties.trackables.forEach {
             corePublisher.processEnhancedLocationUpdate(event as EnhancedLocationChangedEvent, properties, it.id)
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.Location
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
 import com.ably.tracking.publisher.PublisherProperties
@@ -10,11 +13,14 @@ import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 internal class RawLocationChangedWorker(
     private val location: Location,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = RawLocationChangedEvent(location)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Raw location changed event received $location")
         properties.lastPublisherLocation = location
         if (properties.areRawLocationsEnabled) {
             properties.trackables.forEach {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationFailureWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationFailureWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.EnhancedLocationUpdate
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.w
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
 import com.ably.tracking.publisher.PublisherProperties
@@ -12,11 +15,17 @@ internal class SendEnhancedLocationFailureWorker(
     private val trackableId: String,
     private val exception: Throwable?,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = SendEnhancedLocationFailureEvent(locationUpdate, trackableId, exception)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.w(
+            "$TAG Trackable $trackableId failed to send enhanced location ${locationUpdate.location}",
+            exception
+        )
         if (properties.enhancedLocationsPublishingState.shouldRetryPublishing(trackableId)) {
             corePublisher.retrySendingEnhancedLocation(properties, trackableId, locationUpdate)
         } else {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationSuccessWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.Location
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
 import com.ably.tracking.publisher.PublisherProperties
@@ -11,11 +14,14 @@ internal class SendEnhancedLocationSuccessWorker(
     private val location: Location,
     private val trackableId: String,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = SendEnhancedLocationSuccessEvent(location, trackableId)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Trackable $trackableId successfully sent enhanced location $location")
         properties.enhancedLocationsPublishingState.unmarkMessageAsPending(trackableId)
         properties.lastSentEnhancedLocations[trackableId] = location
         properties.skippedEnhancedLocations.clear(trackableId)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationFailureWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationFailureWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.LocationUpdate
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.w
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
 import com.ably.tracking.publisher.PublisherProperties
@@ -12,11 +15,14 @@ internal class SendRawLocationFailureWorker(
     private val trackableId: String,
     private val exception: Throwable?,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = SendRawLocationFailureEvent(locationUpdate, trackableId, exception)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.w("$TAG Trackable $trackableId failed to send raw location ${locationUpdate.location}", exception)
         if (properties.rawLocationsPublishingState.shouldRetryPublishing(trackableId)) {
             corePublisher.retrySendingRawLocation(properties, trackableId, locationUpdate)
         } else {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationSuccessWorker.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.Location
+import com.ably.tracking.common.logging.createLoggingTag
+import com.ably.tracking.common.logging.v
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.Event
 import com.ably.tracking.publisher.PublisherProperties
@@ -11,11 +14,14 @@ internal class SendRawLocationSuccessWorker(
     private val location: Location,
     private val trackableId: String,
     private val corePublisher: CorePublisher,
+    private val logHandler: LogHandler?,
 ) : Worker {
+    private val TAG = createLoggingTag(this)
     override val event: Event
         get() = SendRawLocationSuccessEvent(location, trackableId)
 
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        logHandler?.v("$TAG Trackable $trackableId successfully sent raw location $location")
         properties.rawLocationsPublishingState.unmarkMessageAsPending(trackableId)
         properties.lastSentRawLocations[trackableId] = location
         properties.skippedRawLocations.clear(trackableId)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AblyConnectionStateChangeWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AblyConnectionStateChangeWorkerTest.kt
@@ -22,7 +22,7 @@ class AblyConnectionStateChangeWorkerTest {
 
     @Before
     fun setUp() {
-        worker = AblyConnectionStateChangeWorker(connectionStateChange, corePublisher)
+        worker = AblyConnectionStateChangeWorker(connectionStateChange, corePublisher, null)
     }
 
     @After

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ChannelConnectionStateChangeWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ChannelConnectionStateChangeWorkerTest.kt
@@ -23,7 +23,7 @@ class ChannelConnectionStateChangeWorkerTest {
 
     @Before
     fun setUp() {
-        worker = ChannelConnectionStateChangeWorker(connectionStateChange, trackableId, corePublisher)
+        worker = ChannelConnectionStateChangeWorker(connectionStateChange, trackableId, corePublisher, null)
         every { publisherProperties.lastChannelConnectionStateChanges } returns lastChannelConnectionStateChanges
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/EnhancedLocationChangedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/EnhancedLocationChangedWorkerTest.kt
@@ -30,7 +30,7 @@ class EnhancedLocationChangedWorkerTest {
 
     @Before
     fun setUp() {
-        worker = EnhancedLocationChangedWorker(location, intermediateLocations, type, corePublisher)
+        worker = EnhancedLocationChangedWorker(location, intermediateLocations, type, corePublisher, null)
     }
 
     @After

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorkerTest.kt
@@ -22,7 +22,7 @@ class RawLocationChangedWorkerTest {
 
     @Before
     fun setUp() {
-        worker = RawLocationChangedWorker(location, corePublisher)
+        worker = RawLocationChangedWorker(location, corePublisher, null)
     }
 
     @After

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationFailureWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationFailureWorkerTest.kt
@@ -30,7 +30,7 @@ class SendEnhancedLocationFailureWorkerTest {
 
     @Before
     fun setUp() {
-        worker = SendEnhancedLocationFailureWorker(locationUpdate, trackableId, null, corePublisher)
+        worker = SendEnhancedLocationFailureWorker(locationUpdate, trackableId, null, corePublisher, null)
         every { publisherProperties.lastSentEnhancedLocations } returns lastSentEnhancedLocations
         every { publisherProperties.enhancedLocationsPublishingState } returns enhancedLocationsPublishingState
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendEnhancedLocationSuccessWorkerTest.kt
@@ -23,7 +23,7 @@ class SendEnhancedLocationSuccessWorkerTest {
 
     @Before
     fun setUp() {
-        worker = SendEnhancedLocationSuccessWorker(location, trackableId, corePublisher)
+        worker = SendEnhancedLocationSuccessWorker(location, trackableId, corePublisher, null)
         every { publisherProperties.lastSentEnhancedLocations } returns lastSentEnhancedLocations
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationFailureWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationFailureWorkerTest.kt
@@ -27,7 +27,7 @@ class SendRawLocationFailureWorkerTest {
 
     @Before
     fun setUp() {
-        worker = SendRawLocationFailureWorker(locationUpdate, trackableId, null, corePublisher)
+        worker = SendRawLocationFailureWorker(locationUpdate, trackableId, null, corePublisher, null)
         every { publisherProperties.lastSentRawLocations } returns lastSentRawLocations
         every { publisherProperties.rawLocationsPublishingState } returns rawLocationsPublishingState
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/SendRawLocationSuccessWorkerTest.kt
@@ -23,7 +23,7 @@ class SendRawLocationSuccessWorkerTest {
 
     @Before
     fun setUp() {
-        worker = SendRawLocationSuccessWorker(location, trackableId, corePublisher)
+        worker = SendRawLocationSuccessWorker(location, trackableId, corePublisher, null)
         every { publisherProperties.lastSentRawLocations } returns lastSentRawLocations
     }
 


### PR DESCRIPTION
I've moved log statements from the `CorePublisher` to the appropriate `Worker`s in preparation for the upcoming PR that will replace the event queue with the worker queue.