### PR TITLE
Connect add trackable process workers

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -244,15 +244,18 @@ constructor(
                             workerFactory.createWorker(
                                 WorkerParams.AddTrackable(
                                     event.trackable,
-                                ) { result ->
-                                    if (result.isSuccess) {
-                                        request(
-                                            SetActiveTrackableEvent(event.trackable) { event.callbackFunction(result) }
-                                        )
-                                    } else {
-                                        event.callbackFunction(result)
-                                    }
-                                }
+                                    callbackFunction = { result ->
+                                        if (result.isSuccess) {
+                                            request(
+                                                SetActiveTrackableEvent(event.trackable) { event.callbackFunction(result) }
+                                            )
+                                        } else {
+                                            event.callbackFunction(result)
+                                        }
+                                    },
+                                    presenceUpdateListener = {}, // temporary placeholder
+                                    channelStateChangeListener = {}, // temporary placeholder
+                                )
                             )
                         )
                     }
@@ -271,7 +274,9 @@ constructor(
                             workerFactory.createWorker(
                                 WorkerParams.AddTrackable(
                                     event.trackable,
-                                    event.callbackFunction
+                                    event.callbackFunction,
+                                    presenceUpdateListener = {}, // temporary placeholder
+                                    channelStateChangeListener = {}, // temporary placeholder
                                 )
                             )
                         )
@@ -316,9 +321,11 @@ constructor(
                                 WorkerParams.ConnectionCreated(
                                     event.trackable,
                                     event.callbackFunction,
-                                ) { presenceMessage ->
-                                    enqueue(PresenceMessageEvent(event.trackable, presenceMessage))
-                                }
+                                    presenceUpdateListener = { presenceMessage ->
+                                        enqueue(PresenceMessageEvent(event.trackable, presenceMessage))
+                                    },
+                                    channelStateChangeListener = {}, // temporary placeholder
+                                )
                             )
                         )
                     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -68,6 +68,8 @@ internal class DefaultWorkerFactory(
             is WorkerParams.AddTrackable -> AddTrackableWorker(
                 params.trackable,
                 params.callbackFunction,
+                params.presenceUpdateListener,
+                params.channelStateChangeListener,
                 ably,
             )
             is WorkerParams.AddTrackableFailed -> AddTrackableFailedWorker(
@@ -80,6 +82,7 @@ internal class DefaultWorkerFactory(
                 params.callbackFunction,
                 ably,
                 params.presenceUpdateListener,
+                params.channelStateChangeListener,
             )
             is WorkerParams.ConnectionReady -> ConnectionReadyWorker(
                 params.trackable,
@@ -197,6 +200,8 @@ internal sealed class WorkerParams {
     data class AddTrackable(
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     ) : WorkerParams()
 
     data class AddTrackableFailed(
@@ -220,6 +225,7 @@ internal sealed class WorkerParams {
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
         val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     ) : WorkerParams()
 
     data class ConnectionReady(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
-import com.ably.tracking.publisher.ConnectionForTrackableCreatedEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.workerqueue.WorkerFactory
 import com.ably.tracking.publisher.workerqueue.WorkerParams
@@ -25,12 +24,15 @@ internal class AddTrackableResultHandler : WorkResultHandler<AddTrackableWorkRes
                     )
                 )
 
-            is AddTrackableWorkResult.Success -> corePublisher.request(
-                ConnectionForTrackableCreatedEvent(
-                    workResult.trackable,
-                    workResult.callbackFunction
+            is AddTrackableWorkResult.Success ->
+                return workerFactory.createWorker(
+                    WorkerParams.ConnectionCreated(
+                        workResult.trackable,
+                        workResult.callbackFunction,
+                        workResult.presenceUpdateListener,
+                        workResult.channelStateChangeListener
+                    )
                 )
-            )
         }
         return null
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
-import com.ably.tracking.publisher.ConnectionForTrackableReadyEvent
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.TrackableRemovalRequestedEvent
 import com.ably.tracking.publisher.workerqueue.WorkerFactory
@@ -25,10 +24,9 @@ internal class ConnectionCreatedResultHandler : WorkResultHandler<ConnectionCrea
                 )
 
             is ConnectionCreatedWorkResult.PresenceSuccess -> {
-                corePublisher.request(
-                    ConnectionForTrackableReadyEvent(
-                        workResult.trackable,
-                        workResult.callbackFunction
+                return workerFactory.createWorker(
+                    WorkerParams.ConnectionReady(
+                        workResult.trackable, workResult.callbackFunction, workResult.channelStateChangeListener
                     )
                 )
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.publisher.workerqueue.results
 
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.Trackable
@@ -40,7 +41,9 @@ internal sealed class AddTrackableWorkResult : WorkResult() {
 
     internal data class Success(
         val trackable: Trackable,
-        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     ) : AddTrackableWorkResult()
 
     internal data class Fail(
@@ -60,7 +63,8 @@ internal sealed class ConnectionCreatedWorkResult : WorkResult() {
     internal data class PresenceSuccess(
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
-        val presenceUpdateListener: (presenceMessage: PresenceMessage) -> Unit
+        val presenceUpdateListener: (presenceMessage: PresenceMessage) -> Unit,
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     ) : ConnectionCreatedWorkResult()
 
     internal data class PresenceFail(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -2,6 +2,8 @@ package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.AddTrackableEvent
 import com.ably.tracking.publisher.PublisherProperties
@@ -14,6 +16,8 @@ import kotlinx.coroutines.flow.StateFlow
 internal class AddTrackableWorker(
     private val trackable: Trackable,
     private val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+    private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+    private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     private val ably: Ably
 ) : Worker {
     override val event: Request<*>
@@ -44,7 +48,7 @@ internal class AddTrackableWorker(
                             willSubscribe = false,
                         )
                         if (connectResult.isSuccess) {
-                            AddTrackableWorkResult.Success(trackable, callbackFunction)
+                            AddTrackableWorkResult.Success(trackable, callbackFunction, presenceUpdateListener, channelStateChangeListener)
                         } else {
                             AddTrackableWorkResult.Fail(trackable, connectResult.exceptionOrNull(), callbackFunction)
                         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.publisher.workerqueue.workers
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.ResultCallbackFunction
@@ -12,15 +13,16 @@ import com.ably.tracking.publisher.Request
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
-import kotlinx.coroutines.flow.StateFlow
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.flow.StateFlow
 
 internal class ConnectionCreatedWorker(
     private val trackable: Trackable,
     private val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
     private val ably: Ably,
     private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+    private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
 ) : Worker {
     override val event: Request<*>
         get() = ConnectionForTrackableCreatedEvent(trackable, callbackFunction)
@@ -56,7 +58,8 @@ internal class ConnectionCreatedWorker(
                             ConnectionCreatedWorkResult.PresenceSuccess(
                                 trackable,
                                 callbackFunction,
-                                presenceUpdateListener
+                                presenceUpdateListener,
+                                channelStateChangeListener,
                             )
                         )
                     } catch (exception: ConnectionException) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -17,12 +17,12 @@ import org.junit.Test
 class WorkResultHandlersTest {
     private val addTrackableWorkResults = listOf(
         AddTrackableWorkResult.AlreadyIn(MutableStateFlow(TrackableState.Online), {}),
-        AddTrackableWorkResult.Success(Trackable(""), {}),
+        AddTrackableWorkResult.Success(Trackable(""), {}, {}, {}),
         AddTrackableWorkResult.Fail(Trackable(""), null, {}),
     )
     private val connectionCreatedWorkResults = listOf(
         ConnectionCreatedWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),
-        ConnectionCreatedWorkResult.PresenceSuccess(Trackable(""), {}, {}),
+        ConnectionCreatedWorkResult.PresenceSuccess(Trackable(""), {}, {}, {}),
         ConnectionCreatedWorkResult.PresenceFail(Trackable(""), {}, ConnectionException(ErrorInformation(""))),
     )
     private val connectionReadyWorkResults = listOf(

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
@@ -34,7 +34,7 @@ class AddTrackableWorkerTest {
 
     @Before
     fun setUp() {
-        worker = AddTrackableWorker(trackable, resultCallbackFunction, ably)
+        worker = AddTrackableWorker(trackable, resultCallbackFunction, {}, {}, ably)
         every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -38,7 +38,7 @@ class ConnectionCreatedWorkerTest {
 
     @Before
     fun setUp() {
-        worker = ConnectionCreatedWorker(trackable, resultCallbackFunction, ably, presenceUpdateListener)
+        worker = ConnectionCreatedWorker(trackable, resultCallbackFunction, ably, presenceUpdateListener, {})
         every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
     }
 


### PR DESCRIPTION
The add trackable process was previously represented by 3 events and now is represented by 3 workers. In order to correctly chain them together I had to add some callbacks that are used in the latter workers to the prior ones. This is a groundwork for the upcoming work that will replace the event queue with the worker queue.