### PR TITLE
Add timeout to stopping the publisher

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Wrapper for the [AblyRealtime] that's used to interact with the Ably SDK.
@@ -355,7 +356,7 @@ constructor(
      * A suspend version of the [DefaultAbly.disconnect] method. It waits until disconnection is completed.
      */
     override suspend fun disconnect(trackableId: String, presenceData: PresenceData): Result<Unit> {
-        return suspendCoroutine { continuation ->
+        return suspendCancellableCoroutine { continuation ->
             disconnect(trackableId, presenceData) {
                 try {
                     it.getOrThrow()
@@ -528,7 +529,7 @@ constructor(
      * @throws ConnectionException if the [AblyRealtime] state changes to [ConnectionState.failed].
      */
     private suspend fun closeConnection() {
-        suspendCoroutine<Unit> { continuation ->
+        suspendCancellableCoroutine<Unit> { continuation ->
             ably.connection.on {
                 if (it.current == ConnectionState.closed) {
                     continuation.resume(Unit)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -44,7 +44,7 @@ internal interface CorePublisher {
     fun addTrackable(trackable: Trackable, callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>)
     fun removeTrackable(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>)
     fun changeRoutingProfile(routingProfile: RoutingProfile)
-    fun stop(callbackFunction: ResultCallbackFunction<Unit>)
+    fun stop(timeoutInMilliseconds: Long, callbackFunction: ResultCallbackFunction<Unit>)
     val locations: SharedFlow<LocationUpdate>
     val trackables: SharedFlow<Set<Trackable>>
     val locationHistory: SharedFlow<LocationHistoryData>
@@ -254,8 +254,8 @@ constructor(
         enqueue(workerFactory.createWorker(WorkerParams.ChangeRoutingProfile(routingProfile)))
     }
 
-    override fun stop(callbackFunction: ResultCallbackFunction<Unit>) {
-        enqueue(workerFactory.createWorker(WorkerParams.Stop(callbackFunction)))
+    override fun stop(timeoutInMilliseconds: Long, callbackFunction: ResultCallbackFunction<Unit>) {
+        enqueue(workerFactory.createWorker(WorkerParams.Stop(callbackFunction, timeoutInMilliseconds)))
     }
 
     override fun retrySendingEnhancedLocation(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -92,9 +92,9 @@ constructor(
         }
     }
 
-    override suspend fun stop() {
+    override suspend fun stop(timeoutInMilliseconds: Long) {
         suspendCoroutine<Unit> { continuation ->
-            core.stop {
+            core.stop(timeoutInMilliseconds) {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -117,9 +117,11 @@ interface Publisher {
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
+     *
+     * @param timeoutInMilliseconds After this duration the stopping procedure will be canceled. Default value is 30 seconds.
      */
     @JvmSynthetic
-    suspend fun stop()
+    suspend fun stop(timeoutInMilliseconds: Long = 30_000L)
 
     /**
      * The methods implemented by builders capable of starting [Publisher] instances.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -187,6 +187,7 @@ internal class DefaultWorkerFactory(
                 params.callbackFunction,
                 ably,
                 corePublisher,
+                params.timeoutInMilliseconds,
             )
         }
     }
@@ -295,6 +296,7 @@ internal sealed class WorkerParams {
 
     data class Stop(
         val callbackFunction: ResultCallbackFunction<Unit>,
+        val timeoutInMilliseconds: Long,
     ) : WorkerParams()
 
     data class TrackableRemovalRequested(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
@@ -6,28 +6,36 @@ import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 
 internal class StopWorker(
     private val callbackFunction: ResultCallbackFunction<Unit>,
     private val ably: Ably,
-    private val corePublisher: CorePublisher
+    private val corePublisher: CorePublisher,
+    private val timeoutInMilliseconds: Long,
 ) : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
         // We're using [runBlocking] on purpose as we want to block the whole publisher when it's stopping.
         runBlocking {
-            if (properties.isTracking) {
-                corePublisher.stopLocationUpdates(properties)
-            }
             try {
-                ably.close(properties.presenceData)
-                properties.dispose()
-                properties.isStopped = true
-                callbackFunction(Result.success(Unit))
+                withTimeout(timeoutInMilliseconds) {
+                    if (properties.isTracking) {
+                        corePublisher.stopLocationUpdates(properties)
+                    }
+                    ably.close(properties.presenceData)
+                    properties.dispose()
+                    callbackFunction(Result.success(Unit))
+                }
             } catch (exception: ConnectionException) {
+                callbackFunction(Result.failure(exception))
+            } catch (exception: TimeoutCancellationException) {
                 callbackFunction(Result.failure(exception))
             }
         }
+        // We should mark the publisher as stopped no matter if the whole stopping process completed successfully.
+        properties.isStopped = true
         return SyncAsyncResult()
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -184,7 +184,7 @@ class CorePublisherLocationUpdatesPublishingTest {
 
     private suspend fun stopCorePublisher(corePublisher: CorePublisher = this.corePublisher) {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop {
+            corePublisher.stop(30_000L) {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -104,7 +104,7 @@ class CorePublisherPresenceDataTest {
 
     private suspend fun stopCorePublisher(corePublisher: CorePublisher) {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop {
+            corePublisher.stop(30_000L) {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -177,7 +177,7 @@ class CorePublisherResolutionTest(
 
     private suspend fun stopCorePublisher() {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop {
+            corePublisher.stop(30_000L) {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -158,4 +158,8 @@ fun Ably.mockCloseFailure(exception: ConnectionException = anyConnectionExceptio
     coEvery { close(any()) } throws exception
 }
 
+fun Ably.mockCloseSuccessWithDelay(delayInMilliseconds: Long) {
+    coEvery { close(any()) } coAnswers { delay(delayInMilliseconds) }
+}
+
 private fun anyConnectionException() = ConnectionException(ErrorInformation("Test"))


### PR DESCRIPTION
I've added a configurable timeout to the Publisher's `stop()` method. 
Also I've changed the behaviour of the `StopWorker`related to setting the `isStopped` flag. Previously it was only set if the stopping was successful. Now, it is set no matter if the stopping procedure was completed successfully or there was an error. This makes sense as after calling the `stop()` method we should treat the Publisher as stopped.

We agreed that all of the refactoring work should be on https://github.com/ably/ably-asset-tracking-android/pull/607 but since this is an API change I think it deserves its own PR :wink: