### PR TITLE
Improve add trackable process

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -11,14 +11,15 @@ sealed class TrackableState {
     object Online : TrackableState()
 
     /**
-     * Trackable state is [Publishing] when it's being actively tracked but is neither able to detect nor receive data from subscribers.
+     * Trackable state is [Publishing] when its locations are being published but it is not able to detect subscribers or receive data from them.
+     * This state allows the trackable to be actively tracked, however, its features are limited compared to the [Online] state.
      * This state can change to either [Online] or [Offline] or [Failed].
      */
     object Publishing : TrackableState()
 
     /**
-     * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online].
-     * This state can change to either [Online] or [Failed].
+     * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online] or [Publishing].
+     * This state can change to either [Online] or [Publishing] or [Failed].
      */
     data class Offline(val errorInformation: ErrorInformation? = null) : TrackableState()
 

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -11,10 +11,10 @@ sealed class TrackableState {
     object Online : TrackableState()
 
     /**
-     * Trackable state is [OnlineNonOptimal] when it's being actively tracked but is neither able to detect nor receive data from subscribers.
+     * Trackable state is [Publishing] when it's being actively tracked but is neither able to detect nor receive data from subscribers.
      * This state can change to either [Online] or [Offline] or [Failed].
      */
-    object OnlineNonOptimal : TrackableState()
+    object Publishing : TrackableState()
 
     /**
      * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online].

--- a/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/ConfigurationModels.kt
@@ -5,17 +5,26 @@ package com.ably.tracking
  */
 sealed class TrackableState {
     /**
-     * Trackable state is [Online] when it's being actively tracked. This state can change to either [Offline] or [Failed].
+     * Trackable state is [Online] when it's being actively tracked.
+     * This state can change to either [Offline] or [Failed].
      */
     object Online : TrackableState()
 
     /**
-     * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online]. This state can change to either [Online] or [Failed].
+     * Trackable state is [OnlineNonOptimal] when it's being actively tracked but is neither able to detect nor receive data from subscribers.
+     * This state can change to either [Online] or [Offline] or [Failed].
+     */
+    object OnlineNonOptimal : TrackableState()
+
+    /**
+     * Trackable state is [Offline] when it's connecting or recovering from an error and hopefully will soon be back in the [Online].
+     * This state can change to either [Online] or [Failed].
      */
     data class Offline(val errorInformation: ErrorInformation? = null) : TrackableState()
 
     /**
-     * Trackable state is [Failed] when there was an error from which we cannot recover. This is a final state.
+     * Trackable state is [Failed] when there was an error from which we cannot recover.
+     * This is a final state.
      */
     data class Failed(val errorInformation: ErrorInformation) : TrackableState()
 }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -117,7 +117,8 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
         val textColor: Int
         val colorId: Int
         when (state) {
-            is TrackableState.Online -> {
+            is TrackableState.Online,
+            is TrackableState.OnlineNonOptimal -> {
                 textId = R.string.online
                 colorId = R.color.asset_status_online
                 textColor = R.color.black

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/TrackableDetailsActivity.kt
@@ -118,7 +118,7 @@ class TrackableDetailsActivity : PublisherServiceActivity() {
         val colorId: Int
         when (state) {
             is TrackableState.Online,
-            is TrackableState.OnlineNonOptimal -> {
+            is TrackableState.Publishing -> {
                 textId = R.string.online
                 colorId = R.color.asset_status_online
                 textColor = R.color.black

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -679,6 +679,8 @@ constructor(
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val trackableStates: MutableMap<String, TrackableState> = mutableMapOf()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
+        override val trackableSubscribedToPresenceFlags: MutableMap<String, Boolean> = mutableMapOf()
+            get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val trackableStateFlows: MutableMap<String, MutableStateFlow<TrackableState>> = mutableMapOf()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val lastChannelConnectionStateChanges: MutableMap<String, ConnectionStateChange> = mutableMapOf()
@@ -740,6 +742,7 @@ constructor(
             trackables.clear()
             trackableStates.clear()
             trackableStateFlows.clear()
+            trackableSubscribedToPresenceFlags.clear()
             lastChannelConnectionStateChanges.clear()
             resolutions.clear()
             lastSentEnhancedLocations.clear()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -451,7 +451,7 @@ constructor(
                     ConnectionState.ONLINE ->
                         when {
                             hasSentAtLeastOneLocation && isSubscribedToPresence -> TrackableState.Online
-                            hasSentAtLeastOneLocation && !isSubscribedToPresence -> TrackableState.OnlineNonOptimal
+                            hasSentAtLeastOneLocation && !isSubscribedToPresence -> TrackableState.Publishing
                             else -> TrackableState.Offline()
                         }
                     ConnectionState.OFFLINE -> TrackableState.Offline()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -29,6 +29,7 @@ internal interface PublisherProperties {
     val isLocationEngineResolutionConstant: Boolean
     var isTracking: Boolean
     val trackableStates: MutableMap<String, TrackableState>
+    val trackableSubscribedToPresenceFlags: MutableMap<String, Boolean>
     val lastChannelConnectionStateChanges: MutableMap<String, ConnectionStateChange>
     var lastConnectionStateChange: ConnectionStateChange
     val lastSentEnhancedLocations: MutableMap<String, Location>

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -91,6 +91,8 @@ internal class DefaultWorkerFactory(
                 hooks,
                 corePublisher,
                 params.channelStateChangeListener,
+                params.isSubscribedToPresence,
+                params.presenceUpdateListener,
             )
             is WorkerParams.DisconnectSuccess -> DisconnectSuccessWorker(
                 params.trackable,
@@ -233,6 +235,8 @@ internal sealed class WorkerParams {
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
         val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
+        val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
+        val isSubscribedToPresence: Boolean,
     ) : WorkerParams()
 
     data class DestinationSet(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -31,6 +31,8 @@ import com.ably.tracking.publisher.workerqueue.workers.PresenceMessageWorker
 import com.ably.tracking.publisher.workerqueue.workers.RawLocationChangedWorker
 import com.ably.tracking.publisher.workerqueue.workers.RefreshResolutionPolicyWorker
 import com.ably.tracking.publisher.workerqueue.workers.RemoveTrackableWorker
+import com.ably.tracking.publisher.workerqueue.workers.RetrySubscribeToPresenceSuccessWorker
+import com.ably.tracking.publisher.workerqueue.workers.RetrySubscribeToPresenceWorker
 import com.ably.tracking.publisher.workerqueue.workers.SendEnhancedLocationFailureWorker
 import com.ably.tracking.publisher.workerqueue.workers.SendEnhancedLocationSuccessWorker
 import com.ably.tracking.publisher.workerqueue.workers.SendRawLocationFailureWorker
@@ -93,6 +95,15 @@ internal class DefaultWorkerFactory(
                 params.channelStateChangeListener,
                 params.isSubscribedToPresence,
                 params.presenceUpdateListener,
+            )
+            is WorkerParams.RetrySubscribeToPresence -> RetrySubscribeToPresenceWorker(
+                params.trackable,
+                ably,
+                params.presenceUpdateListener,
+            )
+            is WorkerParams.RetrySubscribeToPresenceSuccess -> RetrySubscribeToPresenceSuccessWorker(
+                params.trackable,
+                corePublisher,
             )
             is WorkerParams.DisconnectSuccess -> DisconnectSuccessWorker(
                 params.trackable,
@@ -237,6 +248,15 @@ internal sealed class WorkerParams {
         val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
         val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
         val isSubscribedToPresence: Boolean,
+    ) : WorkerParams()
+
+    data class RetrySubscribeToPresence(
+        val trackable: Trackable,
+        val presenceUpdateListener: ((presenceMessage: com.ably.tracking.common.PresenceMessage) -> Unit),
+    ) : WorkerParams()
+
+    data class RetrySubscribeToPresenceSuccess(
+        val trackable: Trackable,
     ) : WorkerParams()
 
     data class DestinationSet(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -83,6 +83,7 @@ internal class DefaultWorkerFactory(
                 params.trackable,
                 params.callbackFunction,
                 ably,
+                logHandler,
                 params.presenceUpdateListener,
                 params.channelStateChangeListener,
             )
@@ -99,6 +100,7 @@ internal class DefaultWorkerFactory(
             is WorkerParams.RetrySubscribeToPresence -> RetrySubscribeToPresenceWorker(
                 params.trackable,
                 ably,
+                logHandler,
                 params.presenceUpdateListener,
             )
             is WorkerParams.RetrySubscribeToPresenceSuccess -> RetrySubscribeToPresenceSuccessWorker(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionCreatedResultHandler.kt
@@ -20,14 +20,22 @@ internal class ConnectionCreatedResultHandler(
             is ConnectionCreatedWorkResult.PresenceSuccess -> {
                 return workerFactory.createWorker(
                     WorkerParams.ConnectionReady(
-                        workResult.trackable, workResult.callbackFunction, workResult.channelStateChangeListener
+                        workResult.trackable,
+                        workResult.callbackFunction,
+                        workResult.channelStateChangeListener,
+                        workResult.presenceUpdateListener,
+                        isSubscribedToPresence = true,
                     )
                 )
             }
             is ConnectionCreatedWorkResult.PresenceFail ->
                 return workerFactory.createWorker(
-                    WorkerParams.AddTrackableFailed(
-                        workResult.trackable, workResult.callbackFunction, workResult.exception
+                    WorkerParams.ConnectionReady(
+                        workResult.trackable,
+                        workResult.callbackFunction,
+                        workResult.channelStateChangeListener,
+                        workResult.presenceUpdateListener,
+                        isSubscribedToPresence = false,
                     )
                 )
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/ConnectionReadyResultHandler.kt
@@ -16,6 +16,15 @@ internal class ConnectionReadyResultHandler(
                         workResult.trackable, workResult.callbackFunction, workResult.result
                     )
                 )
+            is ConnectionReadyWorkResult.NonOptimalConnectionReady ->
+                return workerFactory.createWorker(
+                    WorkerParams.RetrySubscribeToPresence(
+                        workResult.trackable,
+                        workResult.presenceUpdateListener
+                    )
+                )
+            is ConnectionReadyWorkResult.OptimalConnectionReady ->
+                return null
         }
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RetrySubscribeToPresenceResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/RetrySubscribeToPresenceResultHandler.kt
@@ -1,0 +1,30 @@
+package com.ably.tracking.publisher.workerqueue.resulthandlers
+
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
+import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+
+internal class RetrySubscribeToPresenceResultHandler(
+    private val workerFactory: WorkerFactory
+) : WorkResultHandler<RetrySubscribeToPresenceWorkResult> {
+    override fun handle(workResult: RetrySubscribeToPresenceWorkResult): Worker? {
+        return when (workResult) {
+            is RetrySubscribeToPresenceWorkResult.Failure ->
+                workerFactory.createWorker(
+                    WorkerParams.RetrySubscribeToPresence(
+                        workResult.trackable,
+                        workResult.presenceUpdateListener,
+                    )
+                )
+            is RetrySubscribeToPresenceWorkResult.Success ->
+                workerFactory.createWorker(
+                    WorkerParams.RetrySubscribeToPresenceSuccess(
+                        workResult.trackable,
+                    )
+                )
+            RetrySubscribeToPresenceWorkResult.ChannelFailed -> null
+            RetrySubscribeToPresenceWorkResult.TrackableRemoved -> null
+        }
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
@@ -6,6 +6,7 @@ import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
+import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
 
 @Suppress("UNCHECKED_CAST")
@@ -19,5 +20,6 @@ internal fun getWorkResultHandler(
         is ConnectionCreatedWorkResult -> ConnectionCreatedResultHandler(workerFactory) as WorkResultHandler<WorkResult>
         is ConnectionReadyWorkResult -> ConnectionReadyResultHandler(workerFactory) as WorkResultHandler<WorkResult>
         is RemoveTrackableWorkResult -> RemoveTrackableResultHandler(workerFactory, workerQueue) as WorkResultHandler<WorkResult>
+        is RetrySubscribeToPresenceWorkResult -> RetrySubscribeToPresenceResultHandler(workerFactory) as WorkResultHandler<WorkResult>
         else -> throw IllegalArgumentException("Invalid workResult provided")
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -82,6 +82,21 @@ internal sealed class ConnectionReadyWorkResult : WorkResult() {
     ) : ConnectionReadyWorkResult()
 }
 
+internal sealed class RetrySubscribeToPresenceWorkResult : WorkResult() {
+    internal object TrackableRemoved : RetrySubscribeToPresenceWorkResult()
+
+    internal object ChannelFailed : RetrySubscribeToPresenceWorkResult()
+
+    internal data class Success(
+        val trackable: Trackable,
+    ) : RetrySubscribeToPresenceWorkResult()
+
+    internal data class Failure(
+        val trackable: Trackable,
+        val presenceUpdateListener: (presenceMessage: PresenceMessage) -> Unit,
+    ) : RetrySubscribeToPresenceWorkResult()
+}
+
 internal sealed class RemoveTrackableWorkResult : WorkResult() {
     internal data class Success(
         val callbackFunction: ResultCallbackFunction<Boolean>,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -80,6 +80,13 @@ internal sealed class ConnectionReadyWorkResult : WorkResult() {
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
         val result: Result<Unit>
     ) : ConnectionReadyWorkResult()
+
+    internal object OptimalConnectionReady : ConnectionReadyWorkResult()
+
+    internal data class NonOptimalConnectionReady(
+        val trackable: Trackable,
+        val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+    ) : ConnectionReadyWorkResult()
 }
 
 internal sealed class RetrySubscribeToPresenceWorkResult : WorkResult() {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.results
 
-import com.ably.tracking.ConnectionException
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceMessage
@@ -70,7 +69,8 @@ internal sealed class ConnectionCreatedWorkResult : WorkResult() {
     internal data class PresenceFail(
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
-        val exception: ConnectionException
+        val presenceUpdateListener: (presenceMessage: PresenceMessage) -> Unit,
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
     ) : ConnectionCreatedWorkResult()
 }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -29,7 +29,6 @@ internal class ConnectionCreatedWorker(
                 }
             )
         }
-        val presenceData = properties.presenceData.copy()
         return SyncAsyncResult(
             asyncWork = {
                 val subscribeToPresenceResult = subscribeToPresenceMessages()
@@ -42,8 +41,12 @@ internal class ConnectionCreatedWorker(
                         channelStateChangeListener
                     )
                 } catch (exception: ConnectionException) {
-                    ably.disconnect(trackable.id, presenceData)
-                    ConnectionCreatedWorkResult.PresenceFail(trackable, callbackFunction, exception)
+                    ConnectionCreatedWorkResult.PresenceFail(
+                        trackable,
+                        callbackFunction,
+                        presenceUpdateListener,
+                        channelStateChangeListener,
+                    )
                 }
             }
         )

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -4,6 +4,8 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.logging.w
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
@@ -15,6 +17,7 @@ internal class ConnectionCreatedWorker(
     private val trackable: Trackable,
     private val callbackFunction: AddTrackableCallbackFunction,
     private val ably: Ably,
+    private val logHandler: LogHandler?,
     private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
     private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
 ) : Worker {
@@ -41,6 +44,7 @@ internal class ConnectionCreatedWorker(
                         channelStateChangeListener
                     )
                 } catch (exception: ConnectionException) {
+                    logHandler?.w("Failed to subscribe to presence for trackable ${trackable.id}", exception)
                     ConnectionCreatedWorkResult.PresenceFail(
                         trackable,
                         callbackFunction,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
@@ -38,7 +38,10 @@ internal class ConnectionReadyWorker(
         updateTrackableState(properties, trackableState, trackableStateFlow, isSubscribedToPresence)
         notifyAddOperationFinished(properties, trackableStateFlow)
 
-        return SyncAsyncResult()
+        return SyncAsyncResult(
+            if (isSubscribedToPresence) ConnectionReadyWorkResult.OptimalConnectionReady
+            else ConnectionReadyWorkResult.NonOptimalConnectionReady(trackable, presenceUpdateListener)
+        )
     }
 
     override fun doWhenStopped(exception: Exception) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -44,6 +44,7 @@ internal class DisconnectSuccessWorker(
         corePublisher.updateTrackableStateFlows(properties)
         properties.trackableStates.remove(trackable.id)
         properties.lastChannelConnectionStateChanges.remove(trackable.id)
+        properties.trackableSubscribedToPresenceFlags.remove(trackable.id)
     }
 
     private fun updateResolutions(properties: PublisherProperties) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceSuccessWorker.kt
@@ -1,0 +1,22 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+
+internal class RetrySubscribeToPresenceSuccessWorker(
+    private val trackable: Trackable,
+    private val publisher: CorePublisher,
+) : Worker {
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        if (!properties.trackables.contains(trackable)) {
+            return SyncAsyncResult()
+        }
+        properties.trackableSubscribedToPresenceFlags[trackable.id] = true
+        publisher.updateTrackableState(properties, trackable.id)
+        return SyncAsyncResult()
+    }
+
+    override fun doWhenStopped(exception: Exception) = Unit
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
@@ -1,0 +1,61 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal class RetrySubscribeToPresenceWorker(
+    private val trackable: Trackable,
+    private val ably: Ably,
+    private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+) : Worker {
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        if (!properties.trackables.contains(trackable)) {
+            return SyncAsyncResult(RetrySubscribeToPresenceWorkResult.TrackableRemoved)
+        }
+        return SyncAsyncResult(
+            asyncWork = {
+                val waitForChannelToBeConnectedResult = waitForChannelToBeConnected(trackable)
+                if (waitForChannelToBeConnectedResult.isFailure) {
+                    return@SyncAsyncResult RetrySubscribeToPresenceWorkResult.ChannelFailed
+                }
+
+                val subscribeToPresenceResult = subscribeToPresenceMessages()
+                return@SyncAsyncResult if (subscribeToPresenceResult.isSuccess) {
+                    RetrySubscribeToPresenceWorkResult.Success(trackable)
+                } else {
+                    RetrySubscribeToPresenceWorkResult.Failure(trackable, presenceUpdateListener)
+                }
+            }
+        )
+    }
+
+    private suspend fun subscribeToPresenceMessages(): Result<Unit> {
+        return suspendCoroutine { continuation ->
+            ably.subscribeForPresenceMessages(trackable.id, presenceUpdateListener) { result ->
+                continuation.resume(result)
+            }
+        }
+    }
+
+    private suspend fun waitForChannelToBeConnected(trackable: Trackable): Result<Unit> {
+        return suspendCoroutine { continuation ->
+            ably.subscribeForChannelStateChange(trackable.id) {
+                if (it.state == ConnectionState.ONLINE) {
+                    continuation.resume(Result.success(Unit))
+                }
+                if (it.state == ConnectionState.FAILED) {
+                    continuation.resume(Result.failure(Exception("Channel failed")))
+                }
+            }
+        }
+    }
+
+    override fun doWhenStopped(exception: Exception) = Unit
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
@@ -3,6 +3,8 @@ package com.ably.tracking.publisher.workerqueue.workers
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionState
 import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.logging.w
+import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
@@ -13,6 +15,7 @@ import kotlin.coroutines.suspendCoroutine
 internal class RetrySubscribeToPresenceWorker(
     private val trackable: Trackable,
     private val ably: Ably,
+    private val logHandler: LogHandler?,
     private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
 ) : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
@@ -30,6 +33,10 @@ internal class RetrySubscribeToPresenceWorker(
                 return@SyncAsyncResult if (subscribeToPresenceResult.isSuccess) {
                     RetrySubscribeToPresenceWorkResult.Success(trackable)
                 } else {
+                    logHandler?.w(
+                        "Failed to resubscribe to presence for trackable ${trackable.id}",
+                        subscribeToPresenceResult.exceptionOrNull()
+                    )
                     RetrySubscribeToPresenceWorkResult.Failure(trackable, presenceUpdateListener)
                 }
             }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -33,8 +33,8 @@ class DefaultPublisherTest {
     private val publisher: Publisher =
         DefaultPublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false, null)
 
-    @Test(expected = ConnectionException::class)
-    fun `should return an error when adding a trackable with subscribing to presence error`() {
+    @Test()
+    fun `should not return an error when adding a trackable with subscribing to presence error`() {
         // given
         val trackableId = UUID.randomUUID().toString()
         ably.mockSuspendingConnectSuccess(trackableId)
@@ -50,7 +50,7 @@ class DefaultPublisherTest {
     }
 
     @Test()
-    fun `should disconnect from the channel when adding a trackable with subscribing to presence error`() {
+    fun `should not disconnect from the channel when adding a trackable with subscribing to presence error`() {
         // given
         val trackableId = UUID.randomUUID().toString()
         ably.mockSuspendingConnectSuccess(trackableId)
@@ -67,7 +67,7 @@ class DefaultPublisherTest {
         }
 
         // then
-        coVerify(exactly = 1) {
+        coVerify(exactly = 0) {
             ably.disconnect(trackableId, any())
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -8,6 +8,7 @@ import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
+import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert
@@ -35,6 +36,12 @@ class WorkResultHandlersTest {
         RemoveTrackableWorkResult.Success({}, Trackable("")),
         RemoveTrackableWorkResult.Fail({}, Exception()),
         RemoveTrackableWorkResult.NotPresent({}),
+    )
+    private val retrySubscribeToPresenceWorkResults = listOf(
+        RetrySubscribeToPresenceWorkResult.Success(Trackable("")),
+        RetrySubscribeToPresenceWorkResult.Failure(Trackable(""), {}),
+        RetrySubscribeToPresenceWorkResult.TrackableRemoved,
+        RetrySubscribeToPresenceWorkResult.ChannelFailed,
     )
 
     @Test
@@ -101,6 +108,23 @@ class WorkResultHandlersTest {
             Assert.assertTrue(
                 "Work result ${it::class.simpleName} should return RemoveTrackableResultHandler",
                 handler is RemoveTrackableResultHandler
+            )
+        }
+    }
+
+    @Test
+    fun `should return RetrySubscribeToPresenceResultHandler for each RetrySubscribeToPresenceWorkResult`() {
+        retrySubscribeToPresenceWorkResults.forEach {
+            // given
+            val workResult = it
+
+            // when
+            val handler = getWorkResultHandler(workResult, workerFactory, workerQueue)
+
+            // then
+            Assert.assertTrue(
+                "Work result ${it::class.simpleName} should return RetrySubscribeToPresenceResultHandler",
+                handler is RetrySubscribeToPresenceResultHandler
             )
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -1,7 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.resulthandlers
 
-import com.ably.tracking.ConnectionException
-import com.ably.tracking.ErrorInformation
 import com.ably.tracking.TrackableState
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerFactory
@@ -28,7 +26,7 @@ class WorkResultHandlersTest {
     private val connectionCreatedWorkResults = listOf(
         ConnectionCreatedWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),
         ConnectionCreatedWorkResult.PresenceSuccess(Trackable(""), {}, {}, {}),
-        ConnectionCreatedWorkResult.PresenceFail(Trackable(""), {}, ConnectionException(ErrorInformation(""))),
+        ConnectionCreatedWorkResult.PresenceFail(Trackable(""), {}, {}, {}),
     )
     private val connectionReadyWorkResults = listOf(
         ConnectionReadyWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -31,6 +31,8 @@ class WorkResultHandlersTest {
     )
     private val connectionReadyWorkResults = listOf(
         ConnectionReadyWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),
+        ConnectionReadyWorkResult.OptimalConnectionReady,
+        ConnectionReadyWorkResult.NonOptimalConnectionReady(Trackable(""), {})
     )
     private val removeTrackableWorkResults = listOf(
         RemoveTrackableWorkResult.Success({}, Trackable("")),

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -36,7 +36,7 @@ class ConnectionCreatedWorkerTest {
 
     @Before
     fun setUp() {
-        worker = ConnectionCreatedWorker(trackable, resultCallbackFunction, ably, presenceUpdateListener, {})
+        worker = ConnectionCreatedWorker(trackable, resultCallbackFunction, ably, null, presenceUpdateListener, {})
         every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -10,7 +10,6 @@ import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
 import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
-import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import com.ably.tracking.test.common.mockSuspendingDisconnect
@@ -82,7 +81,6 @@ class ConnectionCreatedWorkerTest {
         runBlocking {
             // given
             ably.mockSubscribeToPresenceError(trackable.id)
-            ably.mockDisconnectSuccess(trackable.id)
 
             // when
             val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
@@ -93,43 +91,6 @@ class ConnectionCreatedWorkerTest {
             val presenceFailResult = asyncResult as ConnectionCreatedWorkResult.PresenceFail
             Assert.assertEquals(trackable, presenceFailResult.trackable)
             Assert.assertEquals(resultCallbackFunction, presenceFailResult.callbackFunction)
-            Assert.assertNotNull(presenceFailResult.exception)
-        }
-    }
-
-    @Test
-    fun `should disconnect from Ably when executing normally and presence enter failed`() {
-        runBlocking {
-            // given
-            ably.mockSubscribeToPresenceError(trackable.id)
-            ably.mockDisconnectSuccess(trackable.id)
-
-            // when
-            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
-
-            // then
-            coVerify(exactly = 1) {
-                ably.disconnect(trackable.id, any())
-            }
-        }
-    }
-
-    @Test
-    fun `should use a copy of presence data when disconnecting when executing normally and presence enter failed`() {
-        runBlocking {
-            // given
-            val originalPresenceData = PresenceData("test-type")
-            mockPresenceData(originalPresenceData)
-            val presenceDataSlot = ably.mockSuspendingDisconnectSuccessAndCapturePresenceData(trackable.id)
-            ably.mockSubscribeToPresenceError(trackable.id)
-
-            // when
-            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
-
-            // then
-            val disconnectPresenceData = presenceDataSlot.captured
-            Assert.assertNotSame("A copy of presence data should be used", originalPresenceData, disconnectPresenceData)
-            Assert.assertEquals("Presence data should be an exact copy", originalPresenceData, disconnectPresenceData)
         }
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -66,14 +66,28 @@ class ConnectionReadyWorkerTest {
     }
 
     @Test
-    fun `should return empty result when executing normally`() {
+    fun `should return optimal connection result when is subscribed to presence`() {
         // given
+        worker = createWorker(isSubscribedToPresence = true)
 
         // when
         val result = worker.doWork(publisherProperties)
 
         // then
-        Assert.assertNull(result.syncWorkResult)
+        Assert.assertTrue(result.syncWorkResult is ConnectionReadyWorkResult.OptimalConnectionReady)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should return non optimal connection result when is not subscribed to presence`() {
+        // given
+        worker = createWorker(isSubscribedToPresence = false)
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertTrue(result.syncWorkResult is ConnectionReadyWorkResult.NonOptimalConnectionReady)
         Assert.assertNull(result.asyncWork)
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.DefaultCorePublisher
@@ -45,17 +46,11 @@ class ConnectionReadyWorkerTest {
     private val hooks = mockk<DefaultCorePublisher.Hooks>(relaxed = true)
     private val corePublisher = mockk<CorePublisher>(relaxed = true)
     private val connectionStateChangeListener: (ConnectionStateChange) -> Unit = {}
+    private val presenceUpdateListener: (PresenceMessage) -> Unit = {}
 
     @Before
     fun setUp() {
-        worker = ConnectionReadyWorker(
-            trackable,
-            resultCallbackFunction,
-            ably,
-            hooks,
-            corePublisher,
-            connectionStateChangeListener
-        )
+        worker = createWorker(isSubscribedToPresence = true)
         every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
         every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
         every { publisherProperties.trackables } returns trackables
@@ -324,4 +319,16 @@ class ConnectionReadyWorkerTest {
     private fun mockTrackableRemovalRequested() {
         every { trackableRemovalGuard.isMarkedForRemoval(trackable) } returns true
     }
+
+    private fun createWorker(isSubscribedToPresence: Boolean) =
+        ConnectionReadyWorker(
+            trackable,
+            resultCallbackFunction,
+            ably,
+            hooks,
+            corePublisher,
+            connectionStateChangeListener,
+            isSubscribedToPresence,
+            presenceUpdateListener,
+        )
 }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceSuccessWorkerTest.kt
@@ -1,0 +1,83 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.publisher.CorePublisher
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+internal class RetrySubscribeToPresenceSuccessWorkerTest {
+    lateinit var worker: RetrySubscribeToPresenceSuccessWorker
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val trackable = Trackable("test-trackable")
+    private val corePublisher = mockk<CorePublisher>(relaxed = true)
+    private val trackableSubscribedToPresenceFlags: MutableMap<String, Boolean> = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        worker = RetrySubscribeToPresenceSuccessWorker(trackable, corePublisher)
+        mockTrackableIsAdded()
+        every { publisherProperties.trackableSubscribedToPresenceFlags } returns trackableSubscribedToPresenceFlags
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should always return an empty result`() {
+        // given
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertNull(result.syncWorkResult)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should not try to update trackable state if the trackable is not in the added trackable set`() {
+        // given
+        mockTrackableIsNotAdded()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            trackableSubscribedToPresenceFlags[trackable.id] = true
+            corePublisher.updateTrackableState(any(), trackable.id)
+        }
+    }
+
+    @Test
+    fun `should set the subscribed to presence flag to true and then update trackable states`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verifyOrder {
+            trackableSubscribedToPresenceFlags[trackable.id] = true
+            corePublisher.updateTrackableState(any(), trackable.id)
+        }
+    }
+
+    private fun mockTrackableIsAdded() {
+        every { publisherProperties.trackables } returns mutableSetOf(trackable)
+    }
+
+    private fun mockTrackableIsNotAdded() {
+        every { publisherProperties.trackables } returns mutableSetOf()
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
@@ -30,7 +30,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
 
     @Before
     fun setUp() {
-        worker = RetrySubscribeToPresenceWorker(trackable, ably, presenceUpdateListener)
+        worker = RetrySubscribeToPresenceWorker(trackable, ably, null, presenceUpdateListener)
         mockTrackableIsAdded()
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
@@ -1,0 +1,152 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
+import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
+import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+internal class RetrySubscribeToPresenceWorkerTest {
+    lateinit var worker: RetrySubscribeToPresenceWorker
+    private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val trackable = Trackable("test-trackable")
+    private val ably = mockk<Ably>(relaxed = true)
+    private val presenceUpdateListener: (PresenceMessage) -> Unit = {}
+
+    @Before
+    fun setUp() {
+        worker = RetrySubscribeToPresenceWorker(trackable, ably, presenceUpdateListener)
+        mockTrackableIsAdded()
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should return trackable removed if the trackable is not in the added trackable set`() {
+        // given
+        mockTrackableIsNotAdded()
+
+        // when
+        val result = worker.doWork(publisherProperties)
+
+        // then
+        Assert.assertTrue(result.syncWorkResult is RetrySubscribeToPresenceWorkResult.TrackableRemoved)
+        Assert.assertNull(result.asyncWork)
+    }
+
+    @Test
+    fun `should not try to subscribe to presence if the trackable is not in the added trackable set`() {
+        // given
+        mockTrackableIsNotAdded()
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 0) {
+            ably.subscribeForPresenceMessages(trackable.id, any(), any())
+        }
+    }
+
+    @Test
+    fun `should return channel failed if the channel went to the failed state`() {
+        runBlocking {
+            // given
+            mockChannelStateChange(ConnectionState.FAILED)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is RetrySubscribeToPresenceWorkResult.ChannelFailed)
+        }
+    }
+
+    @Test
+    fun `should not try to subscribe to presence if the channel went to the failed state`() {
+        runBlocking {
+            // given
+            mockChannelStateChange(ConnectionState.FAILED)
+
+            // when
+            worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            verify(exactly = 0) {
+                ably.subscribeForPresenceMessages(trackable.id, any(), any())
+            }
+        }
+    }
+
+    @Test
+    fun `should return success if the channel went to the online state and subscribe to presence was successful`() {
+        runBlocking {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockSubscribeToPresenceSuccess(trackable.id)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is RetrySubscribeToPresenceWorkResult.Success)
+            // verify result content
+            val successResult = asyncResult as RetrySubscribeToPresenceWorkResult.Success
+            Assert.assertEquals(trackable, successResult.trackable)
+        }
+    }
+
+    @Test
+    fun `should return failure if the channel went to the online state but subscribe to presence has failed`() {
+        runBlocking {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockSubscribeToPresenceError(trackable.id)
+
+            // when
+            val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
+
+            // then
+            Assert.assertTrue(asyncResult is RetrySubscribeToPresenceWorkResult.Failure)
+            // verify result content
+            val failureResult = asyncResult as RetrySubscribeToPresenceWorkResult.Failure
+            Assert.assertEquals(trackable, failureResult.trackable)
+            Assert.assertEquals(presenceUpdateListener, failureResult.presenceUpdateListener)
+        }
+    }
+
+    private fun mockChannelStateChange(newState: ConnectionState) {
+        val channelStateListenerSlot = slot<(ConnectionStateChange) -> Unit>()
+        every {
+            ably.subscribeForChannelStateChange(trackable.id, capture(channelStateListenerSlot))
+        } answers {
+            channelStateListenerSlot.captured.invoke(ConnectionStateChange(newState, null))
+        }
+    }
+
+    private fun mockTrackableIsAdded() {
+        every { publisherProperties.trackables } returns mutableSetOf(trackable)
+    }
+
+    private fun mockTrackableIsNotAdded() {
+        every { publisherProperties.trackables } returns mutableSetOf()
+    }
+}

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -274,16 +274,19 @@ class MainActivity : AppCompatActivity() {
     private fun updateAssetState(trackableState: TrackableState) {
         val textId = when (trackableState) {
             is TrackableState.Online -> R.string.asset_status_online
+            is TrackableState.OnlineNonOptimal -> R.string.asset_status_online
             is TrackableState.Offline -> R.string.asset_status_offline
             is TrackableState.Failed -> R.string.asset_status_failed
         }
         val textColorId = when (trackableState) {
             is TrackableState.Online -> R.color.black
+            is TrackableState.OnlineNonOptimal -> R.color.black
             is TrackableState.Offline -> R.color.mid_grey
             is TrackableState.Failed -> R.color.black
         }
         val backgroundColorId = when (trackableState) {
             is TrackableState.Online -> R.color.asset_online
+            is TrackableState.OnlineNonOptimal -> R.color.asset_online
             is TrackableState.Offline -> R.color.asset_offline
             is TrackableState.Failed -> R.color.asset_failed
         }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -274,19 +274,19 @@ class MainActivity : AppCompatActivity() {
     private fun updateAssetState(trackableState: TrackableState) {
         val textId = when (trackableState) {
             is TrackableState.Online -> R.string.asset_status_online
-            is TrackableState.OnlineNonOptimal -> R.string.asset_status_online
+            is TrackableState.Publishing -> R.string.asset_status_online
             is TrackableState.Offline -> R.string.asset_status_offline
             is TrackableState.Failed -> R.string.asset_status_failed
         }
         val textColorId = when (trackableState) {
             is TrackableState.Online -> R.color.black
-            is TrackableState.OnlineNonOptimal -> R.color.black
+            is TrackableState.Publishing -> R.color.black
             is TrackableState.Offline -> R.color.mid_grey
             is TrackableState.Failed -> R.color.black
         }
         val backgroundColorId = when (trackableState) {
             is TrackableState.Online -> R.color.asset_online
-            is TrackableState.OnlineNonOptimal -> R.color.asset_online
+            is TrackableState.Publishing -> R.color.asset_online
             is TrackableState.Offline -> R.color.asset_offline
             is TrackableState.Failed -> R.color.asset_failed
         }


### PR DESCRIPTION
Previously, the add operation was failing if there was an error when subscribing to presence messages (after successfully entering the presence).
Now, the add operation won't fail but will return a new state which indicates that the trackable is online but is not used optimally (due to lack of presence data). In the meantime the SDK will listen for the channel state changes and will try to resubscribe to presence data each time the channel becomes online. If it succeeds in subscribing to presence the state of the trackable will be updated to notify that it is now using all of its potential.