### PR TITLE
Handle connection resume exception

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -326,7 +326,7 @@ constructor(
             if (channels.contains(trackableId)) {
                 val channelToRemove = channels[trackableId]!!
                 try {
-                    retryIfChannelConnectionFails(channelToRemove) {
+                    retryChannelOperationIfConnectionResumeFails(channelToRemove) {
                         disconnectChannel(channelToRemove, presenceData)
                     }
                     channels.remove(trackableId)
@@ -447,7 +447,7 @@ constructor(
     private fun sendMessage(channel: Channel, message: Message?, callback: (Result<Unit>) -> Unit) {
         scope.launch {
             try {
-                retryIfChannelConnectionFails(channel) {
+                retryChannelOperationIfConnectionResumeFails(channel) {
                     sendMessage(channel, message)
                 }
                 callback(Result.success(Unit))
@@ -554,7 +554,7 @@ constructor(
         scope.launch {
             val trackableChannel = channels[trackableId] ?: return@launch
             try {
-                retryIfChannelConnectionFails(trackableChannel) {
+                retryChannelOperationIfConnectionResumeFails(trackableChannel) {
                     updatePresenceData(trackableChannel, presenceData)
                 }
                 callback(Result.success(Unit))
@@ -617,7 +617,7 @@ constructor(
      * reconnect and retries the [operation], otherwise it rethrows the exception. If the [operation] fails for
      * the second time the exception is rethrown no matter if it was the "connection resume" exception or not.
      */
-    private suspend fun retryIfChannelConnectionFails(channel: Channel, operation: suspend () -> Unit) {
+    private suspend fun retryChannelOperationIfConnectionResumeFails(channel: Channel, operation: suspend () -> Unit) {
         try {
             operation()
         } catch (exception: ConnectionException) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -622,8 +622,20 @@ constructor(
             operation()
         } catch (exception: ConnectionException) {
             if (exception.isConnectionResumeException()) {
-                waitForChannelReconnection(channel)
-                operation()
+                logHandler?.w(
+                    "Connection resume failed for channel ${channel.name}, waiting for the channel to be reconnected",
+                    exception
+                )
+                try {
+                    waitForChannelReconnection(channel)
+                    operation()
+                } catch (secondException: ConnectionException) {
+                    logHandler?.w(
+                        "Retrying the operation on channel ${channel.name} has failed for the second time",
+                        secondException
+                    )
+                    throw secondException
+                }
             } else {
                 throw exception
             }


### PR DESCRIPTION
From time to time we might get the "Connection resume failed" exception from `ably-android` due to the fact that a new connection was established. Because of that, all messages that we were trying to send using the old connection will receive the error. This should not be propagated immediately to the SDK users and it should be handled on the AAT side.

Therefore, I've wrapped all the Ably SDK calls that might throw this exception in a method that will retry those calls if a "connection resume failed" error is received. https://github.com/ably/ably-asset-tracking-android/pull/665/commits/cfadcae2fb075295f72d9fe769498ffd31a1235a
To do that in a clean way I had to first refactor the `Ably` wrapper to use coroutines (but still have the callback-based API). https://github.com/ably/ably-asset-tracking-android/pull/665/commits/72ce740fdbbd0330813f44d1a3e668113bae9022