### PR TITLE
Release 1.1.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change log
 
+## [1.1.0-rc.3](https://github.com/ably/ably-asset-tracking-android/tree/v1.1.0-rc.3)
+
+Version 1.1 of the Ably Asset Tracking SDKs for Android brings changes to both the publishing and subscribing SDKs,
+and their corresponding example apps, that make the subscriber's marker animate much more smoothly.
+
+[Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.1.0-rc.2...v1.1.0-rc.3)
+
+**Fixed bugs:**
+
+- Handle exception when getting presence messages but channel is in the suspended state [\#663](https://github.com/ably/ably-asset-tracking-android/issues/663)
+- Handle the "Connection resume failed" exception from ably-java [\#662](https://github.com/ably/ably-asset-tracking-android/issues/662)
+
+**Closed issues:**
+
+- Refactor / simplify event queue that is implemented in CorePublisher [\#522](https://github.com/ably/ably-asset-tracking-android/issues/522)
+
+**Merged pull requests:**
+
+- Handle connection resume exception [\#665](https://github.com/ably/ably-asset-tracking-android/pull/665) ([KacperKluka](https://github.com/KacperKluka))
+- Improve add trackable process [\#664](https://github.com/ably/ably-asset-tracking-android/pull/664) ([KacperKluka](https://github.com/KacperKluka))
+- Add timeout to stopping the publisher [\#661](https://github.com/ably/ably-asset-tracking-android/pull/661) ([KacperKluka](https://github.com/KacperKluka))
+- Integration: Refactor event queue [\#607](https://github.com/ably/ably-asset-tracking-android/pull/607) ([KacperKluka](https://github.com/KacperKluka))
+
 ## [1.1.0-rc.2](https://github.com/ably/ably-asset-tracking-android/tree/v1.1.0-rc.2)
 
 Version 1.1 of the Ably Asset Tracking SDKs for Android brings changes to both the publishing and subscribing SDKs,

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ you can then add the Ably Asset Tracking dependency that you require in your Gra
 ```groovy
 dependencies {
     // Publishers, developing in Kotlin, will need the Publishing SDK
-    implementation 'com.ably.tracking:publishing-sdk:1.1.0-rc.2'
+    implementation 'com.ably.tracking:publishing-sdk:1.1.0-rc.3'
 
     // Subscribers, developing in Kotlin, will need the Subscribing SDK
-    implementation 'com.ably.tracking:subscribing-sdk:1.1.0-rc.2'
+    implementation 'com.ably.tracking:subscribing-sdk:1.1.0-rc.3'
 }
 ```
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -4,7 +4,7 @@
 
 ### Update the Ably Asset Tracking dependency
 
-Update the versions of Ably Asset Tracking dependency (or dependencies) you're using to `1.1.0-rc.2`.
+Update the versions of Ably Asset Tracking dependency (or dependencies) you're using to `1.1.0-rc.3`.
 
 ### Use the Mapbox snapshot repository
 
@@ -40,7 +40,7 @@ In version 1.1.0 we've added a new module that aims to improve the experience of
 
 ```groovy
 dependencies {
-    implementation 'com.ably.tracking:ui-sdk:1.1.0-rc.2'
+    implementation 'com.ably.tracking:ui-sdk:1.1.0-rc.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
 
     // version MUST conform to the Semantic Versioning Specification (https://semver.org/) version 2.0.0
     // on incrementing this value, ensure to also increment versionCode in android defaultConfig (also in this file)
-    version = '1.1.0-rc.2'
+    version = '1.1.0-rc.3'
 
     // Values used to publish the SDK to maven repositories.
     ext {
@@ -122,7 +122,7 @@ subprojects {
                 // projects in this repository. Therefore, this same version number is used for SDK and
                 // example app projects alike.
                 // - versionCode MUST be incremented by 1 for each release from the main branch
-                versionCode 20
+                versionCode 21
                 versionName version
 
                 testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
This release fixes 2 bugs related to the way we use `ably-java` and contains the publisher's core event queue refactor. As a part of the refactoring, the `stop()` method now accepts an timeout which is set to 30 seconds by default.