### PR TITLE
Add prefix to secret names, as used for their instances at org-level.

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -35,9 +35,9 @@ jobs:
         ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         ORG_GRADLE_PROJECT_GITHUB_ACTOR: ${{ github.actor }}
         ORG_GRADLE_PROJECT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.MAVEN_SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
         echo "Publishing version ${{ github.event.inputs.version }} to GitHub Packages..."
         ./gradlew publish -PpublishTarget=GitHubPackages

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -35,9 +35,9 @@ jobs:
         ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         ORG_GRADLE_PROJECT_OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         ORG_GRADLE_PROJECT_OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.MAVEN_SIGNING_KEY_RING_FILE_BASE64 }}
       run: |
         echo "Publishing version ${{ github.event.inputs.version }} to MavenCentral..."
         ./gradlew -PpublishTarget=MavenCentral publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,9 @@ defined to be used by our publishing workflows.
 to be used by Gradle's
 [Signing Plugin](https://docs.gradle.org/current/userguide/signing_plugin.html):
 
-- `SIGNING_KEY_ID`: The public key ID.
-- `SIGNING_KEY_PASSWORD`: The passphrase that was used to protect the private key.
-- `SIGNING_KEY_RING_FILE_BASE64`: The contents of the secret key ring file that contains the private key, base64 encoded so that it can be injected as a GitHub secret (encode from macOS using `openssl base64 < signing.key.gpg | pbcopy`).
+- `MAVEN_SIGNING_KEY_ID`: The public key ID.
+- `MAVEN_SIGNING_KEY_PASSWORD`: The passphrase that was used to protect the private key.
+- `MAVEN_SIGNING_KEY_RING_FILE_BASE64`: The contents of the secret key ring file that contains the private key, base64 encoded so that it can be injected as a GitHub secret (encode from macOS using `openssl base64 < signing.key.gpg | pbcopy`).
 
 ### Sonatype for Maven Central
 


### PR DESCRIPTION
Matching changes made in response to the creation of https://github.com/ably/ably-java/pull/791, creating the need for Maven signing and OSSRH secrets to be used by more than one repository, meaning they had to be moved to org-level.