### PR TITLE
Update Publisher Builder required configuration docs

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -193,7 +193,7 @@ interface Publisher {
         fun logHandler(logHandler: LogHandler): Builder
 
         /**
-         * Sets the notification that will be displayed for the background tracking service.
+         * **REQUIRED** Sets the notification that will be displayed for the background tracking service.
          * Please note that this notification will be removed when you call the [stop] method.
          *
          * @param notificationProvider It will be used to create the notification.


### PR DESCRIPTION
The `backgroundTrackingNotificationProvider()` method is required to create a publisher but it was not annotated as "required". Now an appropriate description is in place.