### PR TITLE
Do not destroy the Mapbox instance when removing the last trackable

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -29,7 +29,7 @@ class MapboxTests {
         val mapbox: Mapbox = createMapbox(context)
 
         // when
-        mapbox.stopAndClose()
+        mapbox.close()
 
         // then
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -432,7 +432,7 @@ constructor(
     override fun stopLocationUpdates(properties: PublisherProperties) {
         properties.isTracking = false
         mapbox.unregisterLocationObserver()
-        mapbox.stopAndClose()
+        mapbox.stopTrip()
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -66,6 +66,7 @@ internal interface CorePublisher {
     fun removeCurrentDestination(properties: PublisherProperties)
     fun startLocationUpdates(properties: PublisherProperties)
     fun stopLocationUpdates(properties: PublisherProperties)
+    fun closeMapbox()
     fun processNextWaitingEnhancedLocationUpdate(properties: PublisherProperties, trackableId: String)
     fun saveEnhancedLocationForFurtherSending(properties: PublisherProperties, trackableId: String, location: Location)
     fun retrySendingEnhancedLocation(
@@ -433,6 +434,10 @@ constructor(
         properties.isTracking = false
         mapbox.unregisterLocationObserver()
         mapbox.stopTrip()
+    }
+
+    override fun closeMapbox() {
+        mapbox.close()
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -180,6 +180,10 @@ constructor(
         workerFactory = DefaultWorkerFactory(ably, hooks, this, policy, mapbox, this, logHandler)
         workerQueue = DefaultWorkerQueue(properties, scope, workerFactory)
         ably.subscribeForAblyStateChange { enqueue(workerFactory.createWorker(WorkerParams.AblyConnectionStateChange(it))) }
+        mapbox.setLocationHistoryListener { historyData -> scope.launch { _locationHistory.emit(historyData) } }
+    }
+
+    private fun registerLocationObserver() {
         mapbox.registerLocationObserver(object : LocationUpdatesObserver {
             override fun onRawLocationChanged(rawLocation: Location) {
                 logHandler?.v("$TAG Raw location received: $rawLocation")
@@ -201,7 +205,6 @@ constructor(
                 )
             }
         })
-        mapbox.setLocationHistoryListener { historyData -> scope.launch { _locationHistory.emit(historyData) } }
     }
 
     private fun enqueue(worker: Worker) {
@@ -443,6 +446,7 @@ constructor(
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     override fun startLocationUpdates(properties: PublisherProperties) {
         properties.isTracking = true
+        registerLocationObserver()
         mapbox.startTrip()
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
@@ -24,6 +24,7 @@ internal class StopWorker(
                     if (properties.isTracking) {
                         corePublisher.stopLocationUpdates(properties)
                     }
+                    corePublisher.closeMapbox()
                     ably.close(properties.presenceData)
                     properties.dispose()
                     callbackFunction(Result.success(Unit))

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -114,14 +114,11 @@ class CorePublisherResolutionTest(
     }
 
     private val corePublisher: CorePublisher
-    private val locationUpdatesObserver: LocationUpdatesObserver
+    private lateinit var locationUpdatesObserver: LocationUpdatesObserver
 
     init {
-        val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
-        every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
         corePublisher =
             createCorePublisher(ably, mapbox, resolutionPolicyFactory, RoutingProfile.DRIVING, null, false, false, null)
-        locationUpdatesObserver = locationUpdatesObserverSlot.captured
     }
 
     @Test
@@ -157,10 +154,13 @@ class CorePublisherResolutionTest(
     }
 
     private fun addTrackable(trackable: Trackable) {
+        val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
+        every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
         ably.mockCreateSuspendingConnectionSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable)
         }
+        locationUpdatesObserver = locationUpdatesObserverSlot.captured
     }
 
     private suspend fun addTrackableToCorePublisher(trackable: Trackable): StateFlow<TrackableState> {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
@@ -78,6 +78,19 @@ class StopWorkerTest {
     }
 
     @Test
+    fun `should close the whole Mapbox`() {
+        // given
+
+        // when
+        worker.doWork(publisherProperties)
+
+        // then
+        verify(exactly = 1) {
+            corePublisher.closeMapbox()
+        }
+    }
+
+    @Test
     fun `should close the whole Ably object`() {
         // given
 


### PR DESCRIPTION
Previously, when you removed the last trackable from the publisher the whole instance of Mapbox was being closed and destroyed. Now, it only stops the trip and location updates instead. Stopping the publisher still should both stop the trip and close the Mapbox instance.