### PR TITLE
Add docs about exceptions thrown by the stop() methods

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -11,6 +11,7 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -119,6 +120,9 @@ interface Publisher {
      * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
      *
      * @param timeoutInMilliseconds After this duration the stopping procedure will be canceled. Default value is 30 seconds.
+     *
+     * @throws ConnectionException If something goes wrong during connection closing
+     * @throws TimeoutCancellationException If the operation does not complete in the [timeoutInMilliseconds] time
      */
     @JvmSynthetic
     suspend fun stop(timeoutInMilliseconds: Long = 30_000L)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -76,6 +76,8 @@ interface Subscriber {
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be
      * restarted.
+     *
+     * @throws ConnectionException If something goes wrong during connection closing
      */
     @JvmSynthetic
     suspend fun stop()


### PR DESCRIPTION
I've added the missing information about types of exceptions thrown when calling the `stop()` method in both Publisher and Subscriber SDK.