### PR TITLE
Fix error when trying to connect to a previously closed channel

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -281,6 +281,9 @@ constructor(
                     ably.channels.get(channelName, channelOptions)
                 scope.launch {
                     try {
+                        if (channel.isDetachedOrFailed()) {
+                            channel.attachSuspending()
+                        }
                         channel.enterPresenceSuspending(presenceData)
                         channels[trackableId] = channel
                         callback(Result.success(Unit))
@@ -708,4 +711,7 @@ constructor(
             }
         }
     }
+
+    private fun Channel.isDetachedOrFailed(): Boolean =
+        state == ChannelState.detached || state == ChannelState.failed
 }


### PR DESCRIPTION
We've encountered an error when we tried to add a trackable, that was already added and removed a while ago. It looks like the issue was happening due to the underlying `channel` being in a `detached` state after its removal. A [simple fix](https://github.com/ably/ably-asset-tracking-android/pull/708/commits/77c26468cc23d0b22d2cfd325d521f3d09e8e488) of checking the state and attaching to the channel before attempting to enter its presence seems to solve the issue.

As a part of this PR, I've changed the way we use Ably SDK to a coroutines-based approach. This was done to escape a callback hell that was slowly being created due to the callback-based Ably API :sweat_smile: 