### PR TITLE
Change auth callback functions to suspending ones

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -12,6 +12,7 @@ import com.google.gson.JsonObject
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.rest.Auth
 import io.ably.lib.types.ClientOptions
+import kotlinx.coroutines.runBlocking
 
 /**
  * Extension converting Ably Realtime connection state to the equivalent [ConnectionState] API presented to users of
@@ -84,13 +85,17 @@ val Authentication.clientOptions: ClientOptions
 
         this@clientOptions.tokenRequestCallback?.let { tokenRequestCallback ->
             authCallback = Auth.TokenCallback {
-                tokenRequestCallback(it.toTracking()).toAuth()
+                runBlocking {
+                    tokenRequestCallback(it.toTracking()).toAuth()
+                }
             }
         }
 
         this@clientOptions.jwtCallback?.let { jwtCallback ->
             authCallback = Auth.TokenCallback {
-                jwtCallback(it.toTracking())
+                runBlocking {
+                    jwtCallback(it.toTracking())
+                }
             }
         }
 

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -2,8 +2,8 @@ package com.ably.tracking.connection
 
 data class ConnectionConfiguration(val authentication: Authentication)
 
-typealias TokenRequestCallback = (TokenParams) -> TokenRequest
-typealias JwtCallback = (TokenParams) -> String
+typealias TokenRequestCallback = suspend (TokenParams) -> TokenRequest
+typealias JwtCallback = suspend (TokenParams) -> String
 
 sealed class Authentication(
     val clientId: String,


### PR DESCRIPTION
Those callback functions are used to call some async API to get the auth token. Because they require to return the token, the users would have to make a blocking call from them to get the required data. Given the above, we can as well make them `suspend` which would make it easier for users to leverage the coroutines in their code.