### PR TITLE
Replace @JvmSynthetic with a custom type alias annotation

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/annotation/KotlinOnly.kt
+++ b/common/src/main/java/com/ably/tracking/common/annotation/KotlinOnly.kt
@@ -1,0 +1,3 @@
+package com.ably.tracking.common.annotation
+
+typealias KotlinOnly = JvmSynthetic

--- a/common/src/main/java/com/ably/tracking/common/annotation/KotlinOnly.kt
+++ b/common/src/main/java/com/ably/tracking/common/annotation/KotlinOnly.kt
@@ -1,3 +1,6 @@
 package com.ably.tracking.common.annotation
 
+/**
+ * An alias for the [JvmSynthetic] annotation that is used in the project to hide annotated methods from the Java API.
+ */
 typealias KotlinOnly = JvmSynthetic

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -5,6 +5,9 @@ data class ConnectionConfiguration(val authentication: Authentication)
 typealias TokenRequestCallback = (TokenParams) -> TokenRequest
 typealias JwtCallback = (TokenParams) -> String
 
+// We have to duplicate the KotlinOnly annotation from the "common" module as this module does not have access to it
+private typealias KotlinOnly = JvmSynthetic
+
 sealed class Authentication(
     val clientId: String,
     val basicApiKey: String?,
@@ -38,7 +41,7 @@ sealed class Authentication(
          * @param callback Callback that will be called with [TokenParams] each time a [TokenRequest] needs to be obtained.
          * @param clientId ID of the client
          */
-        @JvmSynthetic
+        @KotlinOnly
         fun tokenRequest(clientId: String, callback: TokenRequestCallback): Authentication =
             TokenAuthentication(clientId, callback)
 
@@ -46,7 +49,7 @@ sealed class Authentication(
          * @param callback Callback that will be called with [TokenParams] each time a JWT string needs to be obtained.
          * @param clientId ID of the client
          */
-        @JvmSynthetic
+        @KotlinOnly
         fun jwt(clientId: String, callback: JwtCallback): Authentication =
             JwtAuthentication(clientId, callback)
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.publisher
 
 import android.app.Notification
 import com.ably.tracking.Resolution
+import com.ably.tracking.common.annotation.KotlinOnly
 
 data class MapConfiguration(val apiKey: String)
 
@@ -403,7 +404,7 @@ class LocationSourceRaw private constructor(
 ) :
     LocationSource() {
     companion object {
-        @JvmSynthetic
+        @KotlinOnly
         fun create(historyData: LocationHistoryData, onDataEnded: (() -> Unit)? = null) =
             LocationSourceRaw(historyData, onDataEnded)
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -9,6 +9,7 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.annotation.KotlinOnly
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.TimeoutCancellationException
@@ -44,7 +45,7 @@ interface Publisher {
      *
      * @throws ConnectionException when something goes wrong with the Ably connection
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun track(trackable: Trackable): StateFlow<TrackableState>
 
     /**
@@ -58,7 +59,7 @@ interface Publisher {
      *
      * @throws ConnectionException when something goes wrong with the Ably connection
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun add(trackable: Trackable): StateFlow<TrackableState>
 
     /**
@@ -72,7 +73,7 @@ interface Publisher {
      * @return `true` if the object was known to this publisher, otherise `false`.
      * @throws ConnectionException when something goes wrong with the Ably connection
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun remove(trackable: Trackable): Boolean
 
     /**
@@ -92,19 +93,19 @@ interface Publisher {
      * The shared flow emitting location values when they become available.
      */
     val locations: SharedFlow<LocationUpdate>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting all trackables tracked by the publisher.
      */
     val trackables: SharedFlow<Set<Trackable>>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting trip location history when it becomes available.
      */
     val locationHistory: SharedFlow<LocationHistoryData>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * Returns a trackable state flow representing the [TrackableState] for an already added [Trackable].
@@ -112,7 +113,7 @@ interface Publisher {
      * @param trackableId The ID of an already added trackable.
      * @return [StateFlow] that represents the [TrackableState] of the added [Trackable]. If the trackable doesn't exist it returns null.
      */
-    @JvmSynthetic
+    @KotlinOnly
     fun getTrackableState(trackableId: String): StateFlow<TrackableState>?
 
     /**
@@ -124,7 +125,7 @@ interface Publisher {
      * @throws ConnectionException If something goes wrong during connection closing
      * @throws TimeoutCancellationException If the operation does not complete in the [timeoutInMilliseconds] time
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun stop(timeoutInMilliseconds: Long = 30_000L)
 
     /**

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.annotation.KotlinOnly
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
@@ -39,39 +40,39 @@ interface Subscriber {
      *
      * @param resolution The preferred resolution or null if has no resolution preference.
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun resolutionPreference(resolution: Resolution?)
 
     /**
      * The shared flow emitting enhanced location values when they become available.
      */
     val locations: SharedFlow<LocationUpdate>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting raw location values when they become available.
      * Raw locations are disabled by default. You need to enable them in the Publishing SDK.
      */
     val rawLocations: SharedFlow<LocationUpdate>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting values when the state of the trackable changes.
      */
     val trackableStates: StateFlow<TrackableState>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting resolution values when they become available.
      */
     val resolutions: SharedFlow<Resolution>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * The shared flow emitting the estimated next location update intervals in milliseconds when they become available.
      */
     val nextLocationUpdateIntervals: SharedFlow<Long>
-        @JvmSynthetic get
+        @KotlinOnly get
 
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be
@@ -79,7 +80,7 @@ interface Subscriber {
      *
      * @throws ConnectionException If something goes wrong during connection closing
      */
-    @JvmSynthetic
+    @KotlinOnly
     suspend fun stop()
 
     /**
@@ -132,7 +133,7 @@ interface Subscriber {
          * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
          * @throws ConnectionException If something goes wrong during connection initialization
          */
-        @JvmSynthetic
+        @KotlinOnly
         @Throws(BuilderConfigurationIncompleteException::class, ConnectionException::class)
         suspend fun start(): Subscriber
     }


### PR DESCRIPTION
The `@JvmSynthetic` annotation is not very descriptive and does not explain why we are using it. That's why we've introduced a type alias for it, to change its name and make it more meaningful.