### PR TITLE
Upgrade Mapbox Nav SDK to 2.7.0

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -6,26 +6,6 @@
 
 Update the versions of Ably Asset Tracking dependency (or dependencies) you're using to `1.1.0-rc.7`.
 
-### Use the Mapbox snapshot repository
-
-In Ably Asset Tracking version 1.1.0 we are using a special version of the navigation profile which requires us to use the Mapbox snapshot repository. In order to do that you need to add this repository in you `build.gradle` file (preferably next to the main Mapbox repository declaration):
-
-```groovy
-repositories {
-    // Mapbox Snapshot repository required to get the new asset tracking navigation profile.
-    maven {
-        url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
-        authentication {
-            basic(BasicAuthentication)
-        }
-        credentials {
-            username = 'mapbox'
-            password = property('MAPBOX_DOWNLOADS_TOKEN')
-        }
-    }
-}
-```
-
 ### Publisher builder adjustments
 
 It is not required, but highly advisable, to turn off the location predictions for the publisher. This can be done through the publisher builder by calling `predictions(false)`.

--- a/build.gradle
+++ b/build.gradle
@@ -67,17 +67,6 @@ allprojects {
                 password = property('MAPBOX_DOWNLOADS_TOKEN')
             }
         }
-        // Mapbox Snapshot repository required to get the new asset tracking navigation profile.
-        maven {
-            url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                username = 'mapbox'
-                password = property('MAPBOX_DOWNLOADS_TOKEN')
-            }
-        }
     }
 }
 

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
     implementation 'pub.devrel:easypermissions:3.0.0'
     // This version needs to be compatible with the "com.mapbox.navigation:core" dependency version from publishing-sdk.
-    implementation 'com.mapbox.maps:android:10.3.0'
+    implementation 'com.mapbox.maps:android:10.7.0'
 
     if (useCrashlytics) {
         // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -22,14 +22,10 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation('com.mapbox.navigation:core:2.3.0') {
+    implementation('com.mapbox.navigation:core:2.7.0-rc.1') {
         // We provide a custom trip notification so we exclude the default one.
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"
-    }
-    // The special asset tracking profile for the Mapbox Navigation.
-    implementation("com.mapbox.navigator:mapbox-navigation-native:ak-2.3-tracking-profile-4-SNAPSHOT") {
-        force = true
     }
 
     // Dependencies needed for replacing Mapbox modules.
@@ -40,7 +36,7 @@ dependencies {
     // Only the Core SDK portion of the MapBox Maps SDK for Android.
     // https://docs.mapbox.com/android/maps/overview/
     // https://docs.mapbox.com/android/core/overview/
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:5.0.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:5.0.2'
 
     // Advanced geospatial analysis - used i.e. for calculating distance between points.
     // https://docs.mapbox.com/android/java/guides/turf/


### PR DESCRIPTION
I upgraded to the newest version `2.7.0-rc.1` which includes the special asset tracking profile. Therefore, we can stop using the snapshot repository so I've removed anything related to it as well.