### PR TITLE
Allow to enable or disable the cycling profile

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -18,6 +18,7 @@ import com.ably.tracking.publisher.LocationSource
 import com.ably.tracking.publisher.MapConfiguration
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.PublisherNotificationProvider
+import com.ably.tracking.publisher.VehicleProfile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -121,6 +122,7 @@ class PublisherService : Service() {
             .sendResolution(appPreferences.shouldSendResolution())
             .predictions(appPreferences.shouldEnablePredictions())
             .constantLocationEngineResolution(createConstantLocationEngineResolution())
+            .vehicleProfile(VehicleProfile.BICYCLE)
             .start()
 
     private fun createDefaultResolution(): Resolution =

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -53,6 +53,7 @@ class MapboxTests {
             true,
             null,
             null,
+            VehicleProfile.CAR,
         )
 
     private fun getLocationData(context: Context): LocationHistoryData {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/ConfigurationModels.kt
@@ -422,3 +422,18 @@ class LocationSourceRaw private constructor(
 interface DataEndedCallback {
     fun onDataEnded()
 }
+
+/**
+ * Represents the vehicle that's used by the publisher.
+ */
+enum class VehicleProfile {
+    /**
+     * For cars and motorcycles.
+     */
+    CAR,
+
+    /**
+     * For bicycles and pedestrians.
+     */
+    BICYCLE,
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -261,6 +261,15 @@ interface Publisher {
         fun constantLocationEngineResolution(resolution: Resolution?): Builder
 
         /**
+         * **OPTIONAL** Set the type of vehicle being used by the publisher user.
+         * If not set then the default value is [VehicleProfile.CAR].
+         *
+         * @param profile The type of vehicle.
+         * @return A new instance of the builder with this property changed.
+         */
+        fun vehicleProfile(profile: VehicleProfile): Builder
+
+        /**
          * Creates a [Publisher] and starts publishing.
          *
          * The returned publisher instance does not start in a state whereby it is actively tracking anything. If

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -25,6 +25,7 @@ internal data class PublisherBuilder(
     val predictionsEnabled: Boolean = true,
     val rawHistoryCallback: ((String) -> Unit)? = null,
     val constantLocationEngineResolution: Resolution? = null,
+    val vehicleProfile: VehicleProfile = VehicleProfile.CAR,
 ) : Publisher.Builder {
 
     override fun connection(configuration: ConnectionConfiguration): Publisher.Builder =
@@ -69,6 +70,9 @@ internal data class PublisherBuilder(
     override fun constantLocationEngineResolution(resolution: Resolution?): Publisher.Builder =
         this.copy(constantLocationEngineResolution = resolution)
 
+    override fun vehicleProfile(profile: VehicleProfile): Publisher.Builder =
+        this.copy(vehicleProfile = profile)
+
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     override fun start(): Publisher {
         if (isMissingRequiredFields()) {
@@ -88,6 +92,7 @@ internal data class PublisherBuilder(
                 predictionsEnabled,
                 rawHistoryCallback,
                 constantLocationEngineResolution,
+                vehicleProfile,
             ),
             resolutionPolicyFactory!!,
             routingProfile,


### PR DESCRIPTION
Added a new API that will allow users to enable or disable the cycling profile during publisher creation.
I enabled the profile in the example app for now and created an issue to make it configurable in the future https://github.com/ably/ably-asset-tracking-android/issues/728.