### PR TITLE
Allow to choose the vehicle profile in the example app

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -26,6 +26,7 @@ class AppPreferences private constructor(context: Context) {
         context.getString(R.string.preferences_simulation_channel_name_key)
     private val S3_FILE_KEY = context.getString(R.string.preferences_s3_file_key)
     private val ROUTING_PROFILE_KEY = context.getString(R.string.preferences_routing_profile_key)
+    private val VEHICLE_PROFILE_KEY = context.getString(R.string.preferences_vehicle_profile_key)
     private val RESOLUTION_ACCURACY_KEY = context.getString(R.string.preferences_resolution_accuracy_key)
     private val RESOLUTION_DESIRED_INTERVAL_KEY =
         context.getString(R.string.preferences_resolution_desired_interval_key)
@@ -46,6 +47,7 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_SIMULATION_CHANNEL = context.getString(R.string.default_simulation_channel)
     private val DEFAULT_S3_FILE = ""
     private val DEFAULT_ROUTING_PROFILE = RoutingProfileType.DRIVING.name
+    private val DEFAULT_VEHICLE_PROFILE = VehicleProfileType.CAR.name
     private val DEFAULT_RESULTION_ACCURACY = Accuracy.BALANCED.name
     private val DEFAULT_RESULTION_DESIRED_INTERVAL = 1000L
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
@@ -65,6 +67,9 @@ class AppPreferences private constructor(context: Context) {
 
     fun getRoutingProfile(): RoutingProfileType =
         RoutingProfileType.valueOf(preferences.getString(ROUTING_PROFILE_KEY, DEFAULT_ROUTING_PROFILE)!!)
+
+    fun getVehicleProfile(): VehicleProfileType =
+        VehicleProfileType.valueOf(preferences.getString(VEHICLE_PROFILE_KEY, DEFAULT_VEHICLE_PROFILE)!!)
 
     fun getResolutionAccuracy(): Accuracy =
         preferences.getString(RESOLUTION_ACCURACY_KEY, DEFAULT_RESULTION_ACCURACY)!!.let { Accuracy.valueOf(it) }

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -18,7 +18,6 @@ import com.ably.tracking.publisher.LocationSource
 import com.ably.tracking.publisher.MapConfiguration
 import com.ably.tracking.publisher.Publisher
 import com.ably.tracking.publisher.PublisherNotificationProvider
-import com.ably.tracking.publisher.VehicleProfile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -122,7 +121,7 @@ class PublisherService : Service() {
             .sendResolution(appPreferences.shouldSendResolution())
             .predictions(appPreferences.shouldEnablePredictions())
             .constantLocationEngineResolution(createConstantLocationEngineResolution())
-            .vehicleProfile(VehicleProfile.BICYCLE)
+            .vehicleProfile(appPreferences.getVehicleProfile().toAssetTracking())
             .start()
 
     private fun createDefaultResolution(): Resolution =

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/SettingsActivity.kt
@@ -22,6 +22,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         addPreferencesFromResource(R.xml.settings_preferences)
         setupLocationSourcePreference()
         setupRoutingProfilePreference()
+        setupVehicleProfilePreference()
         setupDefaultResolutionPreferences()
         setupConstantLocationEngineResolutionPreferences()
         loadS3Preferences()
@@ -78,6 +79,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 .toTypedArray()
             entryValues = RoutingProfileType.values().map { it.name }.toTypedArray()
             value = appPreferences.getRoutingProfile().name
+        }
+    }
+
+    private fun setupVehicleProfilePreference() {
+        val appPreferences = AppPreferences.getInstance(requireContext())
+        (findPreference(getString(R.string.preferences_vehicle_profile_key)) as ListPreference?)?.apply {
+            entries = VehicleProfileType.values()
+                .map { getString(it.displayNameResourceId) }
+                .toTypedArray()
+            entryValues = VehicleProfileType.values().map { it.name }.toTypedArray()
+            value = appPreferences.getVehicleProfile().name
         }
     }
 

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/VehicleProfileType.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/VehicleProfileType.kt
@@ -1,0 +1,15 @@
+package com.ably.tracking.example.publisher
+
+import androidx.annotation.StringRes
+import com.ably.tracking.publisher.VehicleProfile
+
+enum class VehicleProfileType(@StringRes val displayNameResourceId: Int) {
+    CAR(R.string.vehicle_profile_car),
+    BICYCLE(R.string.vehicle_profile_bicycle),
+}
+
+fun VehicleProfileType.toAssetTracking(): VehicleProfile =
+    when (this) {
+        VehicleProfileType.CAR -> VehicleProfile.CAR
+        VehicleProfileType.BICYCLE -> VehicleProfile.BICYCLE
+    }

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -77,4 +77,8 @@
   <string name="routing_profile_cycling">Cycling</string>
   <string name="routing_profile_walking">Walking</string>
   <string name="routing_profile_driving_traffic">Driving with traffic data</string>
+
+  <string name="preferences_vehicle_profile_label">Vehicle profile</string>
+  <string name="vehicle_profile_car">Car</string>
+  <string name="vehicle_profile_bicycle">Bicycle</string>
 </resources>

--- a/publishing-example-app/src/main/res/values/untranslatable_strings.xml
+++ b/publishing-example-app/src/main/res/values/untranslatable_strings.xml
@@ -14,5 +14,6 @@
   <string name="preferences_constant_resolution_accuracy_key" translatable="false">constant_resolution_accuracy</string>
   <string name="preferences_constant_resolution_desired_interval_key" translatable="false">constant_resolution_desired_interval</string>
   <string name="preferences_constant_resolution_minimum_displacement_key" translatable="false">constant_resolution_minimum_displacement</string>
+  <string name="preferences_vehicle_profile_key" translatable="false">vehicle_profile</string>
 </resources>
 

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -37,6 +37,12 @@
       android:title="@string/preferences_routing_profile_label"
       app:useSimpleSummaryProvider="true" />
 
+    <ListPreference
+      android:key="@string/preferences_vehicle_profile_key"
+      android:layout="@layout/preference_with_summary_layout"
+      android:title="@string/preferences_vehicle_profile_label"
+      app:useSimpleSummaryProvider="true" />
+
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
I added a preference to the setting screen that enable to choose the vehicle profile. Choosing the `Bicycle` profile will enable the cycling profile.
![Screenshot from 2022-08-05 12-13-30](https://user-images.githubusercontent.com/62378170/183056301-cad86184-29ec-46e3-b614-17a1456bbec0.png)

