### PR TITLE
Always disable the predictions mechanism

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/AppPreferences.kt
@@ -34,7 +34,6 @@ class AppPreferences private constructor(context: Context) {
         context.getString(R.string.preferences_resolution_minimum_displacement_key)
     private val SEND_RAW_LOCATIONS_KEY = context.getString(R.string.preferences_send_raw_locations_key)
     private val SEND_RESOLUTION_KEY = context.getString(R.string.preferences_send_resolution_key)
-    private val ENABLE_PREDICTIONS_KEY = context.getString(R.string.preferences_send_resolution_key)
     private val ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION_KEY =
         context.getString(R.string.preferences_enable_constant_resolution_key)
     private val CONSTANT_RESOLUTION_ACCURACY_KEY =
@@ -53,7 +52,6 @@ class AppPreferences private constructor(context: Context) {
     private val DEFAULT_RESULTION_MINIMUM_DISPLACEMENT = 1.0f
     private val DEFAULT_SEND_RAW_LOCATIONS = false
     private val DEFAULT_SEND_RESOLUTION = true
-    private val DEFAULT_ENABLE_PREDICTIONS = true
     private val DEFAULT_ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION = false
 
     fun getLocationSource(): LocationSourceType =
@@ -87,9 +85,6 @@ class AppPreferences private constructor(context: Context) {
 
     fun shouldSendResolution() =
         preferences.getBoolean(SEND_RESOLUTION_KEY, DEFAULT_SEND_RESOLUTION)
-
-    fun shouldEnablePredictions() =
-        preferences.getBoolean(ENABLE_PREDICTIONS_KEY, DEFAULT_ENABLE_PREDICTIONS)
 
     fun isConstantLocationEngineResolutionEnabled() = preferences.getBoolean(
         ENABLE_CONSTANT_LOCATION_ENGINE_RESOLUTION_KEY,

--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublisherService.kt
@@ -119,7 +119,6 @@ class PublisherService : Service() {
             )
             .rawLocations(appPreferences.shouldSendRawLocations())
             .sendResolution(appPreferences.shouldSendResolution())
-            .predictions(appPreferences.shouldEnablePredictions())
             .constantLocationEngineResolution(createConstantLocationEngineResolution())
             .vehicleProfile(appPreferences.getVehicleProfile().toAssetTracking())
             .start()

--- a/publishing-example-app/src/main/res/values/strings.xml
+++ b/publishing-example-app/src/main/res/values/strings.xml
@@ -50,7 +50,6 @@
   <string name="preferences_debug_category_title">Debug</string>
   <string name="preferences_send_raw_locations_label">Send raw location updates</string>
   <string name="preferences_send_resolution_label">Send resolution</string>
-  <string name="preferences_enable_predictions_label">Enable predictions</string>
   <string name="preferences_enable_constant_resolution_label">Use constant location engine resolution</string>
   <string name="trackable_list_empty_state_header">No assets</string>
   <string name="trackable_list_empty_state_message">Trackable assets will be listed here when added</string>

--- a/publishing-example-app/src/main/res/values/untranslatable_strings.xml
+++ b/publishing-example-app/src/main/res/values/untranslatable_strings.xml
@@ -9,7 +9,6 @@
   <string name="preferences_resolution_minimum_displacement_key" translatable="false">default_resolution_minimum_displacement</string>
   <string name="preferences_send_raw_locations_key" translatable="false">send_raw_locations</string>
   <string name="preferences_send_resolution_key" translatable="false">send_resolution</string>
-  <string name="preferences_enable_predictions_key" translatable="false">enable_predictions</string>
   <string name="preferences_enable_constant_resolution_key" translatable="false">enable_constant_resolution</string>
   <string name="preferences_constant_resolution_accuracy_key" translatable="false">constant_resolution_accuracy</string>
   <string name="preferences_constant_resolution_desired_interval_key" translatable="false">constant_resolution_desired_interval</string>

--- a/publishing-example-app/src/main/res/xml/settings_preferences.xml
+++ b/publishing-example-app/src/main/res/xml/settings_preferences.xml
@@ -123,12 +123,6 @@
       android:layout="@layout/switch_preference_layout"
       android:title="@string/preferences_send_resolution_label" />
 
-    <SwitchPreferenceCompat
-      android:defaultValue="true"
-      android:key="@string/preferences_enable_predictions_key"
-      android:layout="@layout/switch_preference_layout"
-      android:title="@string/preferences_enable_predictions_label" />
-
   </PreferenceCategory>
 
 </PreferenceScreen>

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -50,7 +50,6 @@ class MapboxTests {
                         .build()
             },
             12345,
-            true,
             null,
             null,
             VehicleProfile.CAR,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -191,7 +191,6 @@ internal class DefaultMapbox(
     private val logHandler: LogHandler?,
     private val notificationProvider: PublisherNotificationProvider,
     private val notificationId: Int,
-    predictionsEnabled: Boolean,
     private val rawHistoryCallback: ((String) -> Unit)?,
     constantLocationEngineResolution: Resolution?,
     vehicleProfile: VehicleProfile,
@@ -214,6 +213,7 @@ internal class DefaultMapbox(
         setupTripNotification(notificationProvider, notificationId)
         val mapboxBuilder = NavigationOptions.Builder(context).accessToken(mapConfiguration.apiKey)
             .deviceProfile(createDeviceProfile(vehicleProfile))
+            .navigatorPredictionMillis(0L) // Setting this to 0 disables location predictions
             .locationEngine(getBestLocationEngine(context, logHandler))
         locationSource?.let {
             when (it) {
@@ -230,10 +230,6 @@ internal class DefaultMapbox(
 
         // Explanation from the Mapbox team: "By disabling this setting we strive for predictability and stability"
         InternalUtils.setUnconditionalPollingPatience(Long.MAX_VALUE)
-
-        if (!predictionsEnabled) {
-            mapboxBuilder.navigatorPredictionMillis(0L) // Setting this to 0 disables location predictions
-        }
 
         if (constantLocationEngineResolution != null) {
             mapboxBuilder.locationEngineRequest(constantLocationEngineResolution.toLocationEngineRequest())

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -230,15 +230,6 @@ interface Publisher {
         fun sendResolution(enabled: Boolean): Builder
 
         /**
-         * **OPTIONAL** Enables using predictions for enhanced location updates.
-         * By default this is enabled.
-         *
-         * @param enabled Whether the predictions for enhanced locations are enabled.
-         * @return A new instance of the builder with this property changed.
-         */
-        fun predictions(enabled: Boolean): Builder
-
-        /**
          * EXPERIMENTAL API
          * **OPTIONAL** Specifies a callback that will be called with the filepath of raw history data from the Navigation SDK component.
          * This will be probably removed in the future. Do not use this in the production environment.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -22,7 +22,6 @@ internal data class PublisherBuilder(
     val locationSource: LocationSource? = null,
     val areRawLocationsEnabled: Boolean? = null,
     val sendResolutionEnabled: Boolean = true,
-    val predictionsEnabled: Boolean = true,
     val rawHistoryCallback: ((String) -> Unit)? = null,
     val constantLocationEngineResolution: Resolution? = null,
     val vehicleProfile: VehicleProfile = VehicleProfile.CAR,
@@ -61,9 +60,6 @@ internal data class PublisherBuilder(
     override fun sendResolution(enabled: Boolean): Publisher.Builder =
         this.copy(sendResolutionEnabled = enabled)
 
-    override fun predictions(enabled: Boolean): Publisher.Builder =
-        this.copy(predictionsEnabled = enabled)
-
     override fun rawHistoryDataCallback(callback: (String) -> Unit): Publisher.Builder =
         this.copy(rawHistoryCallback = callback)
 
@@ -89,7 +85,6 @@ internal data class PublisherBuilder(
                 logHandler,
                 notificationProvider!!,
                 notificationId!!,
-                predictionsEnabled,
                 rawHistoryCallback,
                 constantLocationEngineResolution,
                 vehicleProfile,


### PR DESCRIPTION
When the predictions are disabled the AAT provides the best results. Because we don't want the customers to experience bad results because of our default configuration, we are going to remove the option to enable/disable predictions mechanism and keep it disabled at all time.