### PR TITLE
Update camera less frequently in the subscriber example app

### DIFF
--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -75,7 +75,9 @@ class MainActivity : AppCompatActivity() {
     private var resolution: Resolution =
         Resolution(Accuracy.MAXIMUM, desiredInterval = 1000L, minimumDisplacement = 1.0)
     private var locationUpdateIntervalInMilliseconds = resolution.desiredInterval
-    private val enhancedLocationAnimator: LocationAnimator = CoreLocationAnimator()
+    private val enhancedLocationAnimator: LocationAnimator = CoreLocationAnimator(
+        animationStepsBetweenCameraUpdates = 5,
+    )
     private val rawLocationAnimator: LocationAnimator = CoreLocationAnimator()
     private val animationOptionsManager = AnimationOptionsManager()
 


### PR DESCRIPTION
The camera will move every 5 location updates which should make the UX better and won't collide with the smoothness of the map marker animation.