### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log
 
+## [1.1.1](https://github.com/ably/ably-asset-tracking-android/tree/v1.1.1)
+
+[Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.1.0...v1.1.1)
+
+**Fixed bugs:**
+
+- Bad location updates when predictions are enabled [\#734](https://github.com/ably/ably-asset-tracking-android/issues/734)
+
+**Merged pull requests:**
+
+- Update camera less frequently in the subscriber example app [\#737](https://github.com/ably/ably-asset-tracking-android/pull/737) ([KacperKluka](https://github.com/KacperKluka))
+- Always disable the predictions mechanism [\#733](https://github.com/ably/ably-asset-tracking-android/pull/733) ([KacperKluka](https://github.com/KacperKluka))
+
 ## [1.1.0](https://github.com/ably/ably-asset-tracking-android/tree/v1.1.0)
 
 Version 1.1 of the Ably Asset Tracking SDKs for Android brings changes to both the publishing and subscribing SDKs,

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ you can then add the Ably Asset Tracking dependency that you require in your Gra
 ```groovy
 dependencies {
     // Publishers, developing in Kotlin, will need the Publishing SDK
-    implementation 'com.ably.tracking:publishing-sdk:1.1.0'
+    implementation 'com.ably.tracking:publishing-sdk:1.1.1'
 
     // Subscribers, developing in Kotlin, will need the Subscribing SDK
-    implementation 'com.ably.tracking:subscribing-sdk:1.1.0'
+    implementation 'com.ably.tracking:subscribing-sdk:1.1.1'
 
     // Subscribers, developing in Kotlin, can optionally use the UI utilities
-    implementation 'com.ably.tracking:ui-sdk:1.1.0'
+    implementation 'com.ably.tracking:ui-sdk:1.1.1'
 }
 ```
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,5 +1,16 @@
 # Upgrade / Migration Guide
 
+## Version 1.1.0 to 1.1.1
+
+### Update the Ably Asset Tracking dependency
+
+Update the versions of Ably Asset Tracking dependency (or dependencies) you're using to `1.1.1`.
+
+### Publisher builder adjustments
+
+Because AAT works best when the predictions are disabled we decided to remove the option to enable predictions.
+Since this version the predictions are always disabled and the method `predictions()` was removed from the publisher builder.
+
 ## Version 1.0.0 to 1.1.0
 
 ### Update the Ably Asset Tracking dependency

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
 
     // version MUST conform to the Semantic Versioning Specification (https://semver.org/) version 2.0.0
     // on incrementing this value, ensure to also increment versionCode in android defaultConfig (also in this file)
-    version = '1.1.0'
+    version = '1.1.1'
 
     // Values used to publish the SDK to maven repositories.
     ext {
@@ -111,7 +111,7 @@ subprojects {
                 // projects in this repository. Therefore, this same version number is used for SDK and
                 // example app projects alike.
                 // - versionCode MUST be incremented by 1 for each release from the main branch
-                versionCode 26
+                versionCode 27
                 versionName version
 
                 testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
Removed the `predictions()` method to always provide the best location result for AAT users.