### PR TITLE
Fix the waitForChannelReconnection() method implementation

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -751,6 +751,9 @@ constructor(
         try {
             withTimeout(timeoutInMilliseconds) {
                 suspendCancellableCoroutine<Unit> { continuation ->
+                    if (channel.state == ChannelState.attached) {
+                        continuation.resume(Unit)
+                    }
                     channel.on { channelStateChange ->
                         if (channelStateChange.current == ChannelState.attached) {
                             continuation.resume(Unit)


### PR DESCRIPTION
Before adding a state change listener we should first check if channel is already attached. That's because the listener won't notify us about the most recent state change that happened before it was added. So we need to check this by ourselves.