### PR TITLE
Fix location animator progress exceeding 100%

### DIFF
--- a/ui-sdk/src/main/java/com/ably/tracking/ui/animation/CoreLocationAnimator.kt
+++ b/ui-sdk/src/main/java/com/ably/tracking/ui/animation/CoreLocationAnimator.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import android.view.animation.LinearInterpolator
 import com.ably.tracking.Location
 import com.ably.tracking.LocationUpdate
+import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -140,6 +141,7 @@ class CoreLocationAnimator(
             timeElapsedFromStartInMilliseconds = SystemClock.uptimeMillis() - startTimeInMillis
             timeProgressPercentage = timeElapsedFromStartInMilliseconds / animationStep.durationInMilliseconds.toFloat()
             distanceProgressPercentage = interpolator.getInterpolation(timeProgressPercentage)
+            distanceProgressPercentage = min(distanceProgressPercentage, 1f) // the progress should be 100% max
             _positionsFlow.emit(
                 interpolateLinear(distanceProgressPercentage, animationStep.startPosition, animationStep.endPosition)
             )


### PR DESCRIPTION
The progress should not exceed 100% as it may lead to wrong animation results.