### PR TITLE
Send Mapbox's keyPoints as skipped locations

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -292,9 +292,11 @@ constructor(
                 properties.lastSentEnhancedLocations[trackableId],
                 properties.resolutions[trackableId]
             ) -> {
+                properties.skippedEnhancedLocations.addAll(trackableId, enhancedLocationUpdate.intermediateLocations)
                 sendEnhancedLocationUpdate(enhancedLocationUpdate, properties, trackableId)
             }
             else -> {
+                properties.skippedEnhancedLocations.addAll(trackableId, enhancedLocationUpdate.intermediateLocations)
                 saveEnhancedLocationForFurtherSending(properties, trackableId, enhancedLocationUpdate.location)
                 processNextWaitingEnhancedLocationUpdate(properties, trackableId)
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/SkippedLocations.kt
@@ -31,6 +31,17 @@ internal class SkippedLocations {
     }
 
     /**
+     * Adds locations from the [locations] list to the list of skipped locations for the specified trackable.
+     * If by adding a location the list exceeds its size limit, then the oldest location from the list is removed.
+     *
+     * @param trackableId The ID of the trackable.
+     * @param locations The list of locations that will be added to the skipped locations list.
+     */
+    fun addAll(trackableId: String, locations: List<Location>) {
+        locations.forEach { add(trackableId, it) }
+    }
+
+    /**
      * Returns the skipped locations list sorted by time for the specified trackable.
      * If no locations are added for a trackable then it returns an empty list.
      *


### PR DESCRIPTION
This is a draft of an experiment. We want to check whether treating the Mapbox's `keyPoints` (or AAT's `intermediateLocations`) as `skippedLocations` improves the UX of AAT.

From my short tests the biggest problem is that the `keyPoints` have no accuracy value which results in an odd "blinking" animation of the accuracy circle on the subscriber side.

Another issue was that when I tried to change my position before and after a crossroad (so that the straight line connecting those two locations goes over buildings) the `keyPoints` were not created. This may be because I was using an emulator and mocked locations but this won't be an issue in a real life where a rider is constantly travelling with some speed and bearing. On second thought it might also be connected to the AAT cycling profile that allows for taking shortcuts.

This video shows the "blinking" accuracy animation (don't worry about the map marker jumping, that's not a fault of `keyPoints`)

https://user-images.githubusercontent.com/62378170/188450467-8a20e6ce-75d7-4951-9ce6-984dbd46560f.mp4

