### PR TITLE
Expose information about publisher presence from the subscriber SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ try {
 ```
 
 ### Publisher presence
+
 Publisher presence is provided as an experimental API for subscribers which you can use to get information about
 whether the publisher is online or offline. This API is not yet stable and may change in the future.
 
@@ -264,9 +265,11 @@ android {
     }
 }
 ```
+
 Then you can annotate your element of the desired scope with ``@OptIn(Experimental::class)`` annotation.
 
 An example usage of the API is shown below:
+
 ```kotlin
 subscriber.publisherPresence
     .onEach { isOnline -> print(isOnline) } // provide a function to be called when the asset's presnec is changed

--- a/README.md
+++ b/README.md
@@ -251,6 +251,28 @@ try {
 }
 ```
 
+### Publisher presence
+Publisher presence is provided as an experimental API for subscribers which you can use to get information about
+whether the publisher is online or offline. This API is not yet stable and may change in the future.
+
+To use the API you must explicitly opt in to it by adding the following to your `build.gradle` file:
+
+```groovy
+android {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+}
+```
+Then you can annotate your element of the desired scope with ``@OptIn(Experimental::class)`` annotation.
+
+An example usage of the API is shown below:
+```kotlin
+subscriber.publisherPresence
+    .onEach { isOnline -> print(isOnline) } // provide a function to be called when the asset's presnec is changed
+    .launchIn(scope) // coroutines scope on which the statuses are received
+```kotlin
+
 ### UI utilities
 
 #### Location Animator

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ An example usage of the API is shown below:
 subscriber.publisherPresence
     .onEach { isOnline -> print(isOnline) } // provide a function to be called when the asset's presnec is changed
     .launchIn(scope) // coroutines scope on which the statuses are received
-```kotlin
+```
 
 ### UI utilities
 

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ subprojects {
                 kotlinOptions {
                     jvmTarget = '1.8'
                     allWarningsAsErrors = true
+                    freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
                 }
             }
 

--- a/core-sdk/src/main/java/com/ably/tracking/annotations/Experimental.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/annotations/Experimental.kt
@@ -1,0 +1,6 @@
+package com.ably.tracking.annotations
+
+@RequiresOptIn(message = "This is an experimental API. It may change in the future.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class Experimental // Opt-in requirement annotation

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -58,7 +58,7 @@ fun exampleUsage(trackingId: String) {
         .launchIn(scope)
     subscriber.publisherPresence
         .onEach {
-            //TODO provide a function to be called when the publisher changes online/offline status
+            // TODO provide a function to be called when the publisher changes online/offline status
         }
         .launchIn(scope)
     // Request a different resolution when needed.

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.example.subscriber
 import com.ably.tracking.Accuracy
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.Resolution
+import com.ably.tracking.annotations.Experimental
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.subscriber.Subscriber
 import kotlinx.coroutines.CoroutineScope
@@ -20,6 +21,7 @@ val ABLY_API_KEY = ""
 // The client ID for the Ably SDK instance.
 val CLIENT_ID = ""
 
+@OptIn(Experimental::class)
 fun exampleUsage(trackingId: String) {
     val scope = CoroutineScope(Dispatchers.Main)
     // EXAMPLE SNIPPET FROM HERE, WITH EXCESS INDENT REMOVED:
@@ -54,7 +56,11 @@ fun exampleUsage(trackingId: String) {
             // provide a function to be called when the asset changes online/offline status
         }
         .launchIn(scope)
-
+     subscriber.publisherPresence
+        .onEach {
+            // provide a function to be called when the publisher changes online/offline status
+        }
+        .launchIn(scope)
     // Request a different resolution when needed.
     scope.launch {
         try {

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -58,7 +58,7 @@ fun exampleUsage(trackingId: String) {
         .launchIn(scope)
     subscriber.publisherPresence
         .onEach {
-            // provide a function to be called when the publisher changes online/offline status
+            //TODO provide a function to be called when the publisher changes online/offline status
         }
         .launchIn(scope)
     // Request a different resolution when needed.

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -56,7 +56,7 @@ fun exampleUsage(trackingId: String) {
             // provide a function to be called when the asset changes online/offline status
         }
         .launchIn(scope)
-     subscriber.publisherPresence
+    subscriber.publisherPresence
         .onEach {
             // provide a function to be called when the publisher changes online/offline status
         }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -292,16 +292,19 @@ class MainActivity : AppCompatActivity() {
 
     private fun updatePresenceState(trackableState: Boolean) {
         val textColorId = when (trackableState) {
-            true-> R.color.black
+            true -> R.color.black
             false -> R.color.mid_grey
         }
+
         val backgroundColorId = when (trackableState) {
             true -> R.color.asset_online
             false -> R.color.asset_offline
         }
+
         assetPresenceStateTextView.text = if (trackableState) "Presence: Online" else "Presence: Offline"
         assetPresenceStateTextView.setTextColor(ContextCompat.getColor(this, textColorId))
-        assetPresenceStateTextView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(this, backgroundColorId))
+        assetPresenceStateTextView.backgroundTintList =
+            ColorStateList.valueOf(ContextCompat.getColor(this, backgroundColorId))
     }
 
     private fun stopSubscribing() {

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.transition.TransitionManager
 import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
-import com.ably.tracking.annotations.Experimental
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
@@ -32,9 +31,22 @@ import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.asset_information_view.*
-import kotlinx.android.synthetic.main.trackable_input_controls_view.*
+import kotlinx.android.synthetic.main.activity_main.assetInformationContainer
+import kotlinx.android.synthetic.main.activity_main.draggingAreaView
+import kotlinx.android.synthetic.main.activity_main.mapFragmentContainerView
+import kotlinx.android.synthetic.main.activity_main.rootContainer
+import kotlinx.android.synthetic.main.asset_information_view.animationSettingsImageView
+import kotlinx.android.synthetic.main.asset_information_view.assetStateTextView
+import kotlinx.android.synthetic.main.asset_information_view.assetPresenceStateTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionAccuracyTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionDisplacementTextView
+import kotlinx.android.synthetic.main.asset_information_view.publisherResolutionIntervalTextView
+import kotlinx.android.synthetic.main.asset_information_view.resolutionAccuracyTextView
+import kotlinx.android.synthetic.main.asset_information_view.resolutionDisplacementTextView
+import kotlinx.android.synthetic.main.asset_information_view.resolutionIntervalTextView
+import kotlinx.android.synthetic.main.trackable_input_controls_view.progressIndicator
+import kotlinx.android.synthetic.main.trackable_input_controls_view.startButton
+import kotlinx.android.synthetic.main.trackable_input_controls_view.trackableIdEditText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -42,6 +54,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import com.ably.tracking.annotations.Experimental
 
 // The client ID for the Ably SDK instance.
 private const val CLIENT_ID = "<INSERT_CLIENT_ID_HERE>"
@@ -290,18 +303,11 @@ class MainActivity : AppCompatActivity() {
         assetStateTextView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(this, backgroundColorId))
     }
 
-    private fun updatePresenceState(trackableState: Boolean) {
-        val textColorId = when (trackableState) {
-            true -> R.color.black
-            false -> R.color.mid_grey
-        }
+    private fun updatePresenceState(isPresent: Boolean) {
+        val textColorId = if (isPresent) R.color.black else R.color.mid_grey
+        val backgroundColorId = if (isPresent) R.color.asset_online else R.color.asset_offline
 
-        val backgroundColorId = when (trackableState) {
-            true -> R.color.asset_online
-            false -> R.color.asset_offline
-        }
-
-        assetPresenceStateTextView.text = if (trackableState) "Presence: Online" else "Presence: Offline"
+        assetPresenceStateTextView.text = if (isPresent) "Presence: Online" else "Presence: Offline"
         assetPresenceStateTextView.setTextColor(ContextCompat.getColor(this, textColorId))
         assetPresenceStateTextView.backgroundTintList =
             ColorStateList.valueOf(ContextCompat.getColor(this, backgroundColorId))

--- a/subscribing-example-app/src/main/res/layout/asset_information_view.xml
+++ b/subscribing-example-app/src/main/res/layout/asset_information_view.xml
@@ -44,6 +44,21 @@
     app:layout_constraintTop_toTopOf="@id/assetStateLabelTextView"
     tools:ignore="SmallSp" />
 
+  <TextView
+    android:id="@+id/assetPresenceStateTextView"
+    android:layout_width="52dp"
+    android:layout_height="20dp"
+    android:layout_marginStart="16dp"
+    android:background="@drawable/round_rectangle"
+    android:backgroundTint="@color/asset_offline"
+    android:gravity="center"
+    android:text="@string/asset_status_offline"
+    android:textColor="@color/mid_grey"
+    android:textSize="8sp"
+    app:layout_constraintStart_toEndOf="@+id/assetStateTextView"
+    app:layout_constraintTop_toTopOf="@+id/assetStateTextView"
+    tools:ignore="SmallSp" />
+
   <androidx.appcompat.widget.AppCompatImageView
     android:id="@+id/animationSettingsImageView"
     android:layout_width="25dp"

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -26,6 +26,9 @@ internal class DefaultSubscriber(
     override val trackableStates: StateFlow<TrackableState>
         get() = core.trackableStates
 
+    override val publisherPresence: StateFlow<Boolean>
+        get() = core.publisherPresence
+
     override val resolutions: SharedFlow<Resolution>
         get() = core.resolutions
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.annotations.Experimental
 import com.ably.tracking.common.Ably
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -26,6 +27,7 @@ internal class DefaultSubscriber(
     override val trackableStates: StateFlow<TrackableState>
         get() = core.trackableStates
 
+    @Experimental
     override val publisherPresence: StateFlow<Boolean>
         get() = core.publisherPresence
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -64,6 +64,13 @@ interface Subscriber {
         @JvmSynthetic get
 
     /**
+     * The shared flow emitting values when the presence of the publisher changes.
+     * The publisher is present when the value is "true". If the value is "false" the publisher is not present.
+     */
+    val publisherPresence: StateFlow<Boolean>
+        @JvmSynthetic get
+
+    /**
      * The shared flow emitting resolution values when they become available.
      */
     val resolutions: SharedFlow<Resolution>

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.annotations.Experimental
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
@@ -67,6 +68,7 @@ interface Subscriber {
      * The shared flow emitting values when the presence of the publisher changes.
      * The publisher is present when the value is "true". If the value is "false" the publisher is not present.
      */
+    @Experimental
     val publisherPresence: StateFlow<Boolean>
         @JvmSynthetic get
 


### PR DESCRIPTION
A quick draft of a change in the Subscriber API that exposes whether the publisher is present on a channel or not.

The implementation should be good (only emit updates if the publisher presence value changes) but please feel free to improve the API as it was done quickly as a proof of concept :wink: We should add a few integration tests to check this as well.

My additions (Ikbal) 
As addition to what Kacper already did I also
* Added an Experimental annotation (Kotlin's own experimental annotation is deprecated so I followed their guide on recommended [Opt-in annotation](https://kotlinlang.org/docs/opt-in-requirements.html) )
* Added a simple text next to existing trackable state to observe the change on example apps
* Updated Readme on setup and use of new experimental feature


https://user-images.githubusercontent.com/421091/189327405-c3d66c39-3762-4306-ae8c-5c382a209a6d.mov

