### PR TITLE
Draft: wrapping calls in runBocking lifted up from Mapbox.kt

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/MapboxTests.kt
@@ -10,6 +10,7 @@ import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.test.android.common.NOTIFICATION_CHANNEL_ID
 import com.ably.tracking.test.android.common.createNotificationChannel
 import com.google.gson.Gson
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -22,7 +23,7 @@ class MapboxTests {
     private val gson = Gson()
 
     @Test
-    fun shouldNotThrowErrorWhenMapboxIsStartedAndStoppedWithoutStartingTrip() {
+    fun shouldNotThrowErrorWhenMapboxIsStartedAndStoppedWithoutStartingTrip() = runBlocking {
         // given
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         createNotificationChannel(context)
@@ -56,7 +57,8 @@ class MapboxTests {
         )
 
     private fun getLocationData(context: Context): LocationHistoryData {
-        val historyString = context.assets.open("location_history_small.txt").use { String(it.readBytes()) }
+        val historyString =
+            context.assets.open("location_history_small.txt").use { String(it.readBytes()) }
         return gson.fromJson(historyString, LocationHistoryData::class.java)
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorker.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.publisher.Mapbox
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.ResolutionPolicy
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+import kotlinx.coroutines.runBlocking
 
 internal class ChangeLocationEngineResolutionWorker(
     private val policy: ResolutionPolicy,
@@ -13,7 +14,9 @@ internal class ChangeLocationEngineResolutionWorker(
         if (!properties.isLocationEngineResolutionConstant) {
             val newResolution = policy.resolve(properties.resolutions.values.toSet())
             properties.locationEngineResolution = newResolution
-            mapbox.changeResolution(newResolution)
+            runBlocking {
+                mapbox.changeResolution(newResolution)
+            }
         }
         return SyncAsyncResult()
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -11,6 +11,7 @@ import com.ably.tracking.test.common.mockSendEnhancedLocationFailure
 import com.ably.tracking.test.common.mockSendEnhancedLocationFailureThenSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
 import com.ably.tracking.test.common.mockSendRawLocationSuccess
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -160,7 +161,7 @@ class CorePublisherLocationUpdatesPublishingTest {
         corePublisher: CorePublisher = this.corePublisher
     ) {
         val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
-        every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
+        coEvery { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
         ably.mockCreateSuspendingConnectionSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable, corePublisher)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -155,7 +156,7 @@ class CorePublisherResolutionTest(
 
     private fun addTrackable(trackable: Trackable) {
         val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
-        every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
+        coEvery { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
         ably.mockCreateSuspendingConnectionSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -12,7 +12,6 @@ import com.ably.tracking.test.common.mockSuspendingConnectSuccess
 import com.ably.tracking.test.common.mockSuspendingDisconnectSuccess
 import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import java.util.UUID
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -215,7 +214,7 @@ class DefaultPublisherTest {
         }
 
         // then
-        verify(exactly = 1) {
+        coVerify(exactly = 1) {
             mapbox.clearRoute()
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ChangeLocationEngineResolutionWorkerTest.kt
@@ -6,6 +6,7 @@ import com.ably.tracking.publisher.Mapbox
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.ResolutionPolicy
 import io.mockk.clearAllMocks
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -85,7 +86,7 @@ class ChangeLocationEngineResolutionWorkerTest {
         worker.doWork(publisherProperties)
 
         // then
-        verify(exactly = 1) {
+        coVerify(exactly = 1) {
             mapbox.changeResolution(newlyCalculatedResolution)
         }
     }
@@ -99,7 +100,7 @@ class ChangeLocationEngineResolutionWorkerTest {
         worker.doWork(publisherProperties)
 
         // then
-        verify(exactly = 0) {
+        coVerify(exactly = 0) {
             resolutionPolicy.resolve(any<Set<Resolution>>())
             publisherProperties.locationEngineResolution = any()
             mapbox.changeResolution(any())


### PR DESCRIPTION
`runBlocking` using the main dispatcher replaced with `withContext`. Affected methods are now `suspended`, and calls to them are wrapped in `runBlocking` without a specified dispatcher.

Extracted anonymous `LocationUpdatesObserver` implementation in `CorePublisher` to internal class for readability.

Resolves #680 