### PR TITLE
Mapbox navigation dependency version updated to 2.8.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Firstly, you have to exclude the notification module from Mapbox Navigation SDK 
 implementation ('com.ably.tracking:publishing-sdk:1.3.0')
 
 // The Mapbox Navigation SDK.
-implementation ('com.mapbox.navigation:android:2.8.0-rc.1') {
+implementation ('com.mapbox.navigation:android:2.8.0-rc.2') {
     exclude group: "com.mapbox.navigation", module: "notification"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Firstly, you have to exclude the notification module from Mapbox Navigation SDK 
 implementation ('com.ably.tracking:publishing-sdk:1.3.0')
 
 // The Mapbox Navigation SDK.
-implementation ('com.mapbox.navigation:android:2.7.0') {
+implementation ('com.mapbox.navigation:android:2.8.0-rc.1') {
     exclude group: "com.mapbox.navigation", module: "notification"
 }
 ```

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
 }
 
-final useCrashlytics = project.file('google-services.json').exists();
+final useCrashlytics = project.file('google-services.json').exists()
 if (useCrashlytics) {
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.google.firebase.crashlytics'
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
     implementation 'pub.devrel:easypermissions:3.0.0'
     // This version needs to be compatible with the "com.mapbox.navigation:core" dependency version from publishing-sdk.
-    implementation 'com.mapbox.maps:android:10.7.0'
+    implementation 'com.mapbox.maps:android:10.8.0'
 
     if (useCrashlytics) {
         // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation('com.mapbox.navigation:core:2.7.0') {
+    implementation('com.mapbox.navigation:core:2.8.0-rc.1') {
         // We provide a custom trip notification so we exclude the default one.
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation('com.mapbox.navigation:core:2.8.0-rc.1') {
+    implementation('com.mapbox.navigation:core:2.8.0-rc.2') {
         // We provide a custom trip notification so we exclude the default one.
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -142,7 +142,7 @@ internal interface Mapbox {
 /**
  * Singleton object used to hold the created instances of [Mapbox] interface implementations ([DefaultMapbox]).
  * Uses reference counting to check whether we should destroy the [MapboxNavigation] when a [Mapbox] instance is stopped.
- * This object is safe to use across multiple threads as it uses an [AtomicInteger] as the counter and [Volatile] annotation on the instance field.
+ * This object is safe to use across multiple threads as it uses [synchronized], an [AtomicInteger] as the counter, and [Volatile] annotation on the instance field.
  */
 private object MapboxInstanceProvider {
 
@@ -152,7 +152,7 @@ private object MapboxInstanceProvider {
     private val counter = AtomicInteger(0)
 
     /**
-     * Call to get a MapboxNavigation instance is needed. When no instance is already created will create a new one using provided options.
+     * Call to get a MapboxNavigation instance. When no instance is already created will create a new one using provided options.
      *
      * @param navigationOptions options to be used if MapboxNavigation needs to be instantiated.
      */

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -158,24 +158,26 @@ private object MapboxInstanceProvider {
      */
 
     @Suppress("VisibleForTests")
-    fun createOrRetrieve(navigationOptions: NavigationOptions): MapboxNavigation {
-        counter.incrementAndGet()
-        return mapboxNavigation ?: MapboxNavigation(navigationOptions).also { mapboxNavigation = it }
-    }
+    fun createOrRetrieve(navigationOptions: NavigationOptions): MapboxNavigation =
+        synchronized(this) {
+            counter.incrementAndGet()
+            mapboxNavigation ?: MapboxNavigation(navigationOptions).also { mapboxNavigation = it }
+        }
 
     /**
      * Call when previously obtained MapboxNavigation instance is no longer used. Will call onDestroy if this was the last reference.
      *
      * @return A [Boolean] that indicates whether MapboxNavigation was destroyed
      */
-    fun destroyIfPossible(): Boolean {
-        val wasLastInstance = counter.decrementAndGet() == 0
-        if (wasLastInstance) {
-            mapboxNavigation?.onDestroy()
-            mapboxNavigation = null
+    fun destroyIfPossible(): Boolean =
+        synchronized(this) {
+            val wasLastInstance = counter.decrementAndGet() == 0
+            if (wasLastInstance) {
+                mapboxNavigation?.onDestroy()
+                mapboxNavigation = null
+            }
+            wasLastInstance
         }
-        return wasLastInstance
-    }
 }
 
 /**

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -151,12 +151,23 @@ private object MapboxInstanceProvider {
 
     private val counter = AtomicInteger(0)
 
+    /**
+     * Call to get a MapboxNavigation instance is needed. When no instance is already created will create a new one using provided options.
+     *
+     * @param navigationOptions options to be used if MapboxNavigation needs to be instantiated.
+     */
+
     @Suppress("VisibleForTests")
     fun createOrRetrieve(navigationOptions: NavigationOptions): MapboxNavigation {
         counter.incrementAndGet()
         return mapboxNavigation ?: MapboxNavigation(navigationOptions).also { mapboxNavigation = it }
     }
 
+    /**
+     * Call when previously obtained MapboxNavigation instance is no longer used. Will call onDestroy if this was the last reference.
+     *
+     * @return A [Boolean] that indicates whether MapboxNavigation was destroyed
+     */
     fun destroyIfPossible(): Boolean {
         val wasLastInstance = counter.decrementAndGet() == 0
         if (wasLastInstance) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Mapbox.kt
@@ -247,6 +247,7 @@ internal class DefaultMapbox(
 
         runBlocking(mainDispatcher) {
             mapboxNavigation = MapboxInstanceProvider.createOrRetrieve(mapboxBuilder.build())
+            logHandler?.v("$TAG obtained MapboxNavigation instance")
             setupRouteClearingWhenDestinationIsReached()
         }
     }


### PR DESCRIPTION
Mapbox sdk version updated to `2.8.0-rc.1`. 
The previously used `MapboxNavigationProvider` is now deprecated. After consulting with Mapbox [here](https://github.com/mapbox-collab/Ably-DH-Collab/issues/15), we've decided to create our own implementation.

Resolves #759 