### PR TITLE
wrapInResultCallback utility function added to CallbackFunctionModels.kt

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/CallbackFunctionModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/CallbackFunctionModels.kt
@@ -1,5 +1,9 @@
 package com.ably.tracking.common
 
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
 /**
  * Defines a function type, to be implemented in Kotlin code utilising the Ably Asset Tracking SDKs, allowing that code
  * to handle events using that function as a callback (typically using a lamda expression).
@@ -11,3 +15,12 @@ typealias CallbackFunction<T> = (T) -> Unit
  * to handle an event indicating the result of an asynchronous operation.
  */
 typealias ResultCallbackFunction<T> = CallbackFunction<Result<T>>
+
+fun <T> Continuation<T>.wrapInResultCallback(): ResultCallbackFunction<T> =
+    { result ->
+        try {
+            resume(result.getOrThrow())
+        } catch (exception: Exception) {
+            resumeWithException(exception)
+        }
+    }

--- a/common/src/main/java/com/ably/tracking/common/CallbackFunctionModels.kt
+++ b/common/src/main/java/com/ably/tracking/common/CallbackFunctionModels.kt
@@ -16,6 +16,10 @@ typealias CallbackFunction<T> = (T) -> Unit
  */
 typealias ResultCallbackFunction<T> = CallbackFunction<Result<T>>
 
+/**
+ * Utility function adapts [Continuation] to fit in [ResultCallbackFunction] signature. Callback result is unpacked and
+ * used to resume the continuation.
+ */
 fun <T> Continuation<T>.wrapInResultCallback(): ResultCallbackFunction<T> =
     { result ->
         try {


### PR DESCRIPTION
After investigating, I've realized that moving `suspendCoroutine` to `WorkerQueue` or even to `CoreSubscriber` would introduce too much complexity.
Few workers have callbacks and would block coroutine, and we would need to distinguish them. Also, we are chaining some of the workers using the original callback on the whole chain.

In this PR I have introduced a utility function to share boilerplate code between blocking calls to enqueue