### PR TITLE
Add token-based auth configuration that do not require to specify client ID

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,5 +1,24 @@
 # Upgrade / Migration Guide
 
+## Version 1.3.0 to 1.4.0
+
+### Token based auth configuration
+
+The preferred way of using token based auth has changed. Now, the `clientId` is not required when using either `tokenRequest` or `jwt` auth.
+The client ID will be inferred from the token provided to the AAT SDK from the auth token callback.
+
+```kotlin
+Authentication.tokenRequest {
+    // return a token request (AAT will use its client ID)
+}
+
+Authentication.jwt {
+    // return a JWT token (AAT will use its client ID)
+}
+```
+
+The old methods that required a `clientId` have been deprecated and will be removed in a future release.
+
 ## Version 1.1.1 to 1.2.0
 
 ### Update the Ably Asset Tracking dependency

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -112,7 +112,7 @@ fun Auth.TokenParams.toTracking(): TokenParams =
     object : TokenParams {
         override val ttl: Long = this@toTracking.ttl
         override val capability: String? = this@toTracking.capability
-        override val clientId: String = this@toTracking.clientId
+        override val clientId: String? = this@toTracking.clientId
         override val timestamp: Long = this@toTracking.timestamp
     }
 

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -57,6 +57,10 @@ sealed class Authentication(
          * @param callback Callback that will be called with [TokenParams] each time a [TokenRequest] needs to be obtained.
          * @param clientId ID of the client
          */
+        @Deprecated(
+            message = "You should not need to provide the client ID when you are using a token-based auth",
+            replaceWith = ReplaceWith("Authentication.tokenRequest(callback)"),
+        )
         @JvmSynthetic
         fun tokenRequest(clientId: String, callback: TokenRequestCallback): Authentication =
             TokenAuthentication(clientId, callback)
@@ -72,6 +76,10 @@ sealed class Authentication(
          * @param callback Callback that will be called with [TokenParams] each time a JWT string needs to be obtained.
          * @param clientId ID of the client
          */
+        @Deprecated(
+            message = "You should not need to provide the client ID when you are using a token-based auth",
+            replaceWith = ReplaceWith("Authentication.jwt(callback)"),
+        )
         @JvmSynthetic
         fun jwt(clientId: String, callback: JwtCallback): Authentication =
             JwtAuthentication(clientId, callback)

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
@@ -47,13 +47,13 @@ class AuthenticationTests {
         Authentication.basic(CLIENT_ID, ABLY_API_KEY)
 
     private fun createTokenAuthenticationConfiguration(ably: AblyRealtime): Authentication =
-        Authentication.tokenRequest(CLIENT_ID) { requestParameters ->
+        Authentication.tokenRequest { requestParameters ->
             // use Ably SDK to create a signed token request (this should normally be done by user auth servers)
             val ablyTokenRequest = ably.auth.createTokenRequest(
                 Auth.TokenParams().apply {
                     ttl = requestParameters.ttl
                     capability = requestParameters.capability
-                    clientId = requestParameters.clientId
+                    clientId = CLIENT_ID
                     timestamp = requestParameters.timestamp
                 },
                 Auth.AuthOptions(ABLY_API_KEY)
@@ -72,7 +72,7 @@ class AuthenticationTests {
         }
 
     private fun createJwtAuthenticationConfiguration(): Authentication =
-        Authentication.jwt(CLIENT_ID) { tokenParams ->
+        Authentication.jwt { tokenParams ->
             // use TokenParams to create a signed JWT (this should normally be done by user auth servers)
             val keyParts = ABLY_API_KEY.split(":")
             val keyName = keyParts[0]
@@ -88,7 +88,7 @@ class AuthenticationTests {
                 .claim("iat", currentTimestampInSeconds)
                 .claim("exp", tokenExpirationTimestampInSeconds)
                 .claim("x-ably-capability", tokenCapability)
-                .claim("x-ably-clientId", tokenParams.clientId)
+                .claim("x-ably-clientId", CLIENT_ID)
                 .signWith(SignatureAlgorithm.HS256, keySecret.toByteArray())
                 .compact()
         }

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/RequestingNewTokenTest.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/RequestingNewTokenTest.kt
@@ -86,7 +86,7 @@ class RequestingNewTokenTest {
         newEnabledTrackableIds: List<String>,
     ): Authentication {
         var requestedForFirstTime = true
-        return Authentication.tokenRequest(CLIENT_ID) { requestParameters ->
+        return Authentication.tokenRequest { requestParameters ->
             // Create different token capabilities when called for the first time and when called next times
             val capabilities = if (requestedForFirstTime) {
                 requestedForFirstTime = false
@@ -100,7 +100,7 @@ class RequestingNewTokenTest {
                 Auth.TokenParams().apply {
                     ttl = requestParameters.ttl
                     capability = capabilities
-                    clientId = requestParameters.clientId
+                    clientId = CLIENT_ID
                     timestamp = requestParameters.timestamp
                 },
                 Auth.AuthOptions(ABLY_API_KEY)


### PR DESCRIPTION
I added a version of `tokenRequest` and `jwt` auth methods that do not require a `clientId`. 
This should be the default approach when using token-based auth, therefore, the methods that require client ID are now deprecated.
There was no mention of token-based auth in the `README` so I put information about new auth options in the `UPDATING` guide.