### PR TITLE
Subscriber workers unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ subprojects {
                 // the Android runtime unless we include this dependency. See:
                 // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
-
+                testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
                 testImplementation 'io.mockk:mockk:1.12.2'
             } else {
                 testImplementation 'org.mockito:mockito-core:3.6.28'

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -6,11 +6,12 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.createLocation
-import com.ably.tracking.test.common.mockCreateSuspendingConnectionSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationFailure
 import com.ably.tracking.test.common.mockSendEnhancedLocationFailureThenSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
 import com.ably.tracking.test.common.mockSendRawLocationSuccess
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -161,7 +162,8 @@ class CorePublisherLocationUpdatesPublishingTest {
     ) {
         val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
         every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
-        ably.mockCreateSuspendingConnectionSuccess(trackable.id)
+        ably.mockConnectSuccess(trackable.id)
+        ably.mockSubscribeToPresenceSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable, corePublisher)
         }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -7,7 +7,8 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ClientTypes
 import com.ably.tracking.common.PresenceData
-import com.ably.tracking.test.common.mockCreateSuspendingConnectionSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -81,7 +82,8 @@ class CorePublisherPresenceDataTest {
     }
 
     private fun addTrackable(trackable: Trackable, corePublisher: CorePublisher) {
-        ably.mockCreateSuspendingConnectionSuccess(trackable.id)
+        ably.mockConnectSuccess(trackable.id)
+        ably.mockSubscribeToPresenceSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable, corePublisher)
         }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -7,8 +7,9 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.createLocation
-import com.ably.tracking.test.common.mockCreateSuspendingConnectionSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockSendEnhancedLocationSuccess
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfConstants
@@ -156,7 +157,8 @@ class CorePublisherResolutionTest(
     private fun addTrackable(trackable: Trackable) {
         val locationUpdatesObserverSlot = slot<LocationUpdatesObserver>()
         every { mapbox.registerLocationObserver(capture(locationUpdatesObserverSlot)) } just runs
-        ably.mockCreateSuspendingConnectionSuccess(trackable.id)
+        ably.mockConnectSuccess(trackable.id)
+        ably.mockSubscribeToPresenceSuccess(trackable.id)
         runBlocking(Dispatchers.IO) {
             addTrackableToCorePublisher(trackable)
         }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -4,12 +4,10 @@ import android.annotation.SuppressLint
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockConnectFailureThenSuccess
-import com.ably.tracking.test.common.mockCreateSuspendingConnectionSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
-import com.ably.tracking.test.common.mockSuspendingConnectSuccess
-import com.ably.tracking.test.common.mockSuspendingDisconnectSuccess
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
@@ -37,7 +35,7 @@ class DefaultPublisherTest {
     fun `should not return an error when adding a trackable with subscribing to presence error`() {
         // given
         val trackableId = UUID.randomUUID().toString()
-        ably.mockSuspendingConnectSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
         ably.mockDisconnectSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
@@ -53,8 +51,8 @@ class DefaultPublisherTest {
     fun `should not disconnect from the channel when adding a trackable with subscribing to presence error`() {
         // given
         val trackableId = UUID.randomUUID().toString()
-        ably.mockSuspendingConnectSuccess(trackableId)
-        ably.mockSuspendingDisconnectSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
+        ably.mockDisconnectSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when
@@ -77,7 +75,8 @@ class DefaultPublisherTest {
         // given
         val trackableId = UUID.randomUUID().toString()
         val trackable = Trackable(trackableId)
-        ably.mockCreateSuspendingConnectionSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
 
         // when
         runBlocking {
@@ -120,7 +119,8 @@ class DefaultPublisherTest {
         // given
         val trackableId = UUID.randomUUID().toString()
         val trackable = Trackable(trackableId)
-        ably.mockCreateSuspendingConnectionSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
 
         // when
         runBlocking {
@@ -181,7 +181,8 @@ class DefaultPublisherTest {
         val trackableId = UUID.randomUUID().toString()
         val trackable = Trackable(trackableId)
         val callsOrder = mutableListOf<Int>()
-        ably.mockCreateSuspendingConnectionSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
 
         // when
         runBlocking {
@@ -207,7 +208,8 @@ class DefaultPublisherTest {
     fun `should clear the route if the new active trackable does not have a destination`() {
         // given
         val trackableWithoutDestination = Trackable(UUID.randomUUID().toString())
-        ably.mockCreateSuspendingConnectionSuccess(trackableWithoutDestination.id)
+        ably.mockConnectSuccess(trackableWithoutDestination.id)
+        ably.mockSubscribeToPresenceSuccess(trackableWithoutDestination.id)
 
         // when
         runBlocking {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
@@ -8,8 +8,8 @@ import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
 import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
-import com.ably.tracking.test.common.mockSuspendingConnectFailure
-import com.ably.tracking.test.common.mockSuspendingConnectSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockConnectFailure
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -121,7 +121,7 @@ class AddTrackableWorkerTest {
         runBlocking {
             // given
             mockTrackableIsNeitherAddedNorCurrentlyBeingAdded()
-            ably.mockSuspendingConnectSuccess(trackable.id)
+            ably.mockConnectSuccess(trackable.id)
 
             // when
             val result = worker.doWork(publisherProperties)
@@ -141,7 +141,7 @@ class AddTrackableWorkerTest {
         runBlocking {
             // given
             mockTrackableIsNeitherAddedNorCurrentlyBeingAdded()
-            ably.mockSuspendingConnectFailure(trackable.id)
+            ably.mockConnectFailure(trackable.id)
 
             // when
             val result = worker.doWork(publisherProperties)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -10,9 +10,9 @@ import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
 import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
+import com.ably.tracking.test.common.mockDisconnect
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
-import com.ably.tracking.test.common.mockSuspendingDisconnect
 import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
 import io.mockk.clearAllMocks
 import io.mockk.coVerify
@@ -113,7 +113,7 @@ class ConnectionCreatedWorkerTest {
             // given
             mockTrackableRemovalRequested()
             val disconnectResult = Result.success(Unit)
-            ably.mockSuspendingDisconnect(trackable.id, disconnectResult)
+            ably.mockDisconnect(trackable.id, disconnectResult)
 
             // when
             val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -14,7 +14,7 @@ import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
 import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
-import com.ably.tracking.test.common.mockSuspendingDisconnect
+import com.ably.tracking.test.common.mockDisconnect
 import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
 import io.mockk.clearAllMocks
 import io.mockk.coVerify
@@ -255,7 +255,7 @@ class ConnectionReadyWorkerTest {
             // given
             mockTrackableRemovalRequested()
             val disconnectResult = Result.success(Unit)
-            ably.mockSuspendingDisconnect(trackable.id, disconnectResult)
+            ably.mockDisconnect(trackable.id, disconnectResult)
 
             // when
             val asyncResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
@@ -9,7 +9,7 @@ import com.ably.tracking.publisher.guards.DuplicateTrackableGuard
 import com.ably.tracking.publisher.guards.TrackableRemovalGuard
 import com.ably.tracking.publisher.workerqueue.assertNotNullAndExecute
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
-import com.ably.tracking.test.common.mockSuspendingDisconnect
+import com.ably.tracking.test.common.mockDisconnect
 import com.ably.tracking.test.common.mockSuspendingDisconnectSuccessAndCapturePresenceData
 import io.mockk.clearAllMocks
 import io.mockk.coVerify
@@ -97,7 +97,7 @@ class RemoveTrackableWorkerTest {
         runBlocking {
             // given
             mockTrackableAlreadyAdded()
-            ably.mockSuspendingDisconnect(trackable.id, Result.success(Unit))
+            ably.mockDisconnect(trackable.id, Result.success(Unit))
 
             // when
             val asyncWorkResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()
@@ -116,7 +116,7 @@ class RemoveTrackableWorkerTest {
             // given
             mockTrackableAlreadyAdded()
             val disconnectException = Exception("test")
-            ably.mockSuspendingDisconnect(trackable.id, Result.failure(disconnectException))
+            ably.mockDisconnect(trackable.id, Result.failure(disconnectException))
 
             // when
             val asyncWorkResult = worker.doWork(publisherProperties).asyncWork.assertNotNullAndExecute()

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
@@ -38,5 +38,4 @@ internal class ChangeResolutionWorkerTest {
         Assert.assertEquals(updatedResolution, updatedProperties.presenceData.resolution)
         verify { callbackFunction.invoke(match { it.isSuccess }) }
     }
-
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
@@ -1,0 +1,42 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.test.common.mockUpdatePresenceDataSuccess
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class ChangeResolutionWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val trackableId = "123123"
+    private val updatedResolution = Resolution(Accuracy.HIGH, 10, 10.0)
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val changeResolutionWorker = ChangeResolutionWorker(ably, trackableId, updatedResolution, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+
+    @Test
+    fun `should return Properties with updated resolution and notify callback`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockUpdatePresenceDataSuccess(trackableId)
+
+        // when
+        val updatedProperties = changeResolutionWorker.doWork(initialProperties, asyncWorks.appendWork()) {}
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(updatedResolution, updatedProperties.presenceData.resolution)
+        verify { callbackFunction.invoke(match { it.isSuccess }) }
+    }
+
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
@@ -1,0 +1,41 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.test.common.mockDisconnectSuccess
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class DisconnectWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val trackableId = "123123"
+    private val callbackFunction: () -> Unit = mockk(relaxed = true)
+    private val disconnectWorker = DisconnectWorker(ably, trackableId, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+
+    @Test
+    fun `should call ably disconnect and notify callback`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockDisconnectSuccess(trackableId)
+
+        // when
+        val updatedProperties = disconnectWorker.doWork(initialProperties, asyncWorks.appendWork()) {}
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(initialProperties, updatedProperties)
+        coVerify { ably.disconnect(trackableId, initialProperties.presenceData) }
+        verify { callbackFunction.invoke() }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -80,5 +80,6 @@ internal class StartConnectionWorkerTest {
             )
         }
         verify { callbackFunction.invoke(match { it.isFailure }) }
+        Assert.assertTrue(postedWorks.isEmpty())
     }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -7,8 +7,8 @@ import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.subscriber.Properties
 import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
-import com.ably.tracking.test.common.mockSuspendingConnectFailure
-import com.ably.tracking.test.common.mockSuspendingConnectSuccess
+import com.ably.tracking.test.common.mockConnectSuccess
+import com.ably.tracking.test.common.mockConnectFailure
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
@@ -38,7 +38,7 @@ internal class StartConnectionWorkerTest {
     fun `should call ably connect and post update trackable worker specification on success`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
-        ably.mockSuspendingConnectSuccess(trackableId)
+        ably.mockConnectSuccess(trackableId)
 
         // when
         val updatedProperties =
@@ -62,7 +62,7 @@ internal class StartConnectionWorkerTest {
     fun `should call ably connect and notify callback on failure`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
-        ably.mockSuspendingConnectFailure(trackableId)
+        ably.mockConnectFailure(trackableId)
 
         // when
         val updatedProperties =

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -1,0 +1,84 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import com.ably.tracking.test.common.mockSuspendingConnectFailure
+import com.ably.tracking.test.common.mockSuspendingConnectSuccess
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class StartConnectionWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val trackableId = "123123"
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { updateTrackableState(any()) } just runs
+    }
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val startConnectionWorker = StartConnectionWorker(ably, subscriberInteractor, trackableId, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should call ably connect and post update trackable worker specification on success`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockSuspendingConnectSuccess(trackableId)
+
+        // when
+        val updatedProperties =
+            startConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(initialProperties, updatedProperties)
+        verify { subscriberInteractor.updateTrackableState(initialProperties) }
+        coVerify {
+            ably.connect(
+                trackableId, initialProperties.presenceData,
+                useRewind = true,
+                willSubscribe = true
+            )
+        }
+        Assert.assertEquals(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction), postedWorks[0])
+    }
+
+    @Test
+    fun `should call ably connect and notify callback on failure`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockSuspendingConnectFailure(trackableId)
+
+        // when
+        val updatedProperties =
+            startConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(initialProperties, updatedProperties)
+        verify { subscriberInteractor.updateTrackableState(initialProperties) }
+        coVerify {
+            ably.connect(
+                trackableId, initialProperties.presenceData,
+                useRewind = true,
+                willSubscribe = true
+            )
+        }
+        verify { callbackFunction.invoke(match { it.isFailure }) }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
@@ -1,0 +1,63 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import com.ably.tracking.test.common.mockCloseFailure
+import com.ably.tracking.test.common.mockCloseSuccessWithDelay
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class StopConnectionWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { notifyAssetIsOffline() } just runs
+    }
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val stopConnectionWorker = StopConnectionWorker(ably, subscriberInteractor, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should call ably close and notify callback with success`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockCloseSuccessWithDelay(10)
+
+        // when
+        val updatedProperties =
+            stopConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
+
+        // then
+        Assert.assertEquals(true, updatedProperties.isStopped)
+        verify { callbackFunction.invoke(match { it.isSuccess }) }
+        verify { subscriberInteractor.notifyAssetIsOffline() }
+    }
+
+    @Test
+    fun `should call ably close and notify callback with failure when it fails`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockCloseFailure()
+
+        // when
+        stopConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
+
+        // then
+        verify { callbackFunction.invoke(match { it.isFailure }) }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
@@ -43,7 +43,7 @@ internal class StopConnectionWorkerTest {
             stopConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
 
         // then
-        Assert.assertEquals(true, updatedProperties.isStopped)
+        Assert.assertTrue(updatedProperties.isStopped)
         verify { callbackFunction.invoke(match { it.isSuccess }) }
         verify { subscriberInteractor.notifyAssetIsOffline() }
     }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
@@ -1,0 +1,97 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.PresenceAction
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import com.ably.tracking.test.common.mockSubscribeToPresenceError
+import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
+import io.mockk.CapturingSlot
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class SubscribeForPresenceMessagesWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val trackableId = "123123"
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val subscribeForPresenceMessagesWorker =
+        SubscribeForPresenceMessagesWorker(ably, trackableId, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should post update presence work when presence listener is called`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        val presenceListenerSlot: CapturingSlot<(PresenceMessage) -> Unit> = slot()
+        val presenceMessage = createPresenceMessage()
+        ably.mockSubscribeToPresenceSuccess(trackableId, presenceListenerSlot)
+
+        // when
+        subscribeForPresenceMessagesWorker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+        asyncWorks.executeAll()
+        presenceListenerSlot.captured.invoke(presenceMessage)
+
+        // then
+        Assert.assertEquals(WorkerSpecification.UpdatePublisherPresence(presenceMessage), postedWorks[1])
+    }
+
+    private fun createPresenceMessage() = PresenceMessage(
+        PresenceAction.PRESENT_OR_ENTER,
+        PresenceData(ClientTypes.PUBLISHER, null, null),
+        clientId = ""
+    )
+
+    @Test
+    fun `should post subscribe to channel work when subscribe to presence returns success`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockSubscribeToPresenceSuccess(trackableId)
+
+        // when
+        subscribeForPresenceMessagesWorker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(WorkerSpecification.SubscribeToChannel(callbackFunction), postedWorks[0])
+    }
+
+    @Test
+    fun `should post disconnect work when subscribe to presence returns failure`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockSubscribeToPresenceError(trackableId)
+
+        // when
+        subscribeForPresenceMessagesWorker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertTrue(postedWorks[0] is WorkerSpecification.Disconnect)
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeToChannelWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeToChannelWorkerTest.kt
@@ -1,0 +1,53 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class SubscribeToChannelWorkerTest {
+
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { subscribeForChannelState() } just runs
+        every { subscribeForEnhancedEvents(any()) } just runs
+        every { subscribeForRawEvents(any()) } just runs
+    }
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val subscribeToChannelWorker =
+        SubscribeToChannelWorker(subscriberInteractor, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should notify callback after calling subscriberInteractor`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+
+        // when
+        subscribeToChannelWorker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        verify {
+            subscriberInteractor.subscribeForChannelState()
+            subscriberInteractor.subscribeForEnhancedEvents(initialProperties.presenceData)
+            subscriberInteractor.subscribeForRawEvents(initialProperties.presenceData)
+            callbackFunction.invoke(match { it.isSuccess })
+        }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateChannelConnectionStateWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateChannelConnectionStateWorkerTest.kt
@@ -1,0 +1,50 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class UpdateChannelConnectionStateWorkerTest {
+
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { updateTrackableState(any()) } just runs
+    }
+    private val channelConnectionStateChange = ConnectionStateChange(ConnectionState.ONLINE, null)
+    private val updateChannelConnectionStateWorker =
+        UpdateChannelConnectionStateWorker(channelConnectionStateChange, subscriberInteractor)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should call updateTrackableState and update properties`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+
+        // when
+        val updatedProperties =
+            updateChannelConnectionStateWorker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+        // then
+        Assert.assertEquals(channelConnectionStateChange, updatedProperties.lastChannelConnectionStateChange)
+        verify { subscriberInteractor.updateTrackableState(updatedProperties) }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
@@ -23,9 +23,9 @@ internal class UpdateConnectionStateWorkerTest {
     private val subscriberInteractor: SubscriberInteractor = mockk {
         every { updateTrackableState(any()) } just runs
     }
-    private val channelConnectionStateChange = ConnectionStateChange(ConnectionState.ONLINE, null)
+    private val connectionStateChange = ConnectionStateChange(ConnectionState.ONLINE, null)
     private val updateConnectionStateWorker =
-        UpdateConnectionStateWorker(channelConnectionStateChange, subscriberInteractor)
+        UpdateConnectionStateWorker(connectionStateChange, subscriberInteractor)
 
     private val asyncWorks = mutableListOf<suspend () -> Unit>()
     private val postedWorks = mutableListOf<WorkerSpecification>()
@@ -44,7 +44,7 @@ internal class UpdateConnectionStateWorkerTest {
             )
 
         // then
-        Assert.assertEquals(channelConnectionStateChange, updatedProperties.lastConnectionStateChange)
+        Assert.assertEquals(connectionStateChange, updatedProperties.lastConnectionStateChange)
         verify { subscriberInteractor.updateTrackableState(updatedProperties) }
     }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
@@ -1,0 +1,50 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.ConnectionStateChange
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class UpdateConnectionStateWorkerTest {
+
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { updateTrackableState(any()) } just runs
+    }
+    private val channelConnectionStateChange = ConnectionStateChange(ConnectionState.ONLINE, null)
+    private val updateConnectionStateWorker =
+        UpdateConnectionStateWorker(channelConnectionStateChange, subscriberInteractor)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should call updateTrackableState and update properties`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+
+        // when
+        val updatedProperties =
+            updateConnectionStateWorker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+        // then
+        Assert.assertEquals(channelConnectionStateChange, updatedProperties.lastConnectionStateChange)
+        verify { subscriberInteractor.updateTrackableState(updatedProperties) }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorkerTest.kt
@@ -1,0 +1,101 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.PresenceAction
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class UpdatePublisherPresenceWorkerTest {
+
+    private val subscriberInteractor: SubscriberInteractor = mockk {
+        every { updatePublisherPresence(any(), any()) } just runs
+        every { updateTrackableState(any()) } just runs
+        every { updatePublisherResolutionInformation(any()) } just runs
+    }
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should call subscriber interactor for PRESENT_OR_ENTER presence message`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        val presenceMessage = createPresenceMessage(PresenceAction.PRESENT_OR_ENTER)
+        val worker = UpdatePublisherPresenceWorker(presenceMessage, subscriberInteractor)
+
+        // when
+        worker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        verify {
+            subscriberInteractor.updatePublisherPresence(initialProperties, true)
+            subscriberInteractor.updateTrackableState(initialProperties)
+            subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
+        }
+    }
+
+    @Test
+    fun `should call subscriber interactor for LEAVE_OR_ABSENT presence message`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        val presenceMessage = createPresenceMessage(PresenceAction.LEAVE_OR_ABSENT)
+        val worker = UpdatePublisherPresenceWorker(presenceMessage, subscriberInteractor)
+
+        // when
+        worker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        verify {
+            subscriberInteractor.updatePublisherPresence(initialProperties, false)
+            subscriberInteractor.updateTrackableState(initialProperties)
+        }
+    }
+
+    @Test
+    fun `should call subscriber interactor for UPDATE presence message`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        val presenceMessage = createPresenceMessage(PresenceAction.UPDATE)
+        val worker = UpdatePublisherPresenceWorker(presenceMessage, subscriberInteractor)
+
+        // when
+        worker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        verify {
+            subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
+        }
+    }
+
+    private fun createPresenceMessage(action: PresenceAction) = PresenceMessage(
+        action,
+        PresenceData(ClientTypes.PUBLISHER, null, null),
+        clientId = ""
+    )
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
@@ -15,4 +15,3 @@ internal fun MutableList<WorkerSpecification>.appendSpecification(): (WorkerSpec
     { asyncWork ->
         add(asyncWork)
     }
-

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
@@ -12,6 +12,6 @@ suspend fun MutableList<suspend () -> Unit>.executeAll() {
 }
 
 internal fun MutableList<WorkerSpecification>.appendSpecification(): (WorkerSpecification) -> Unit =
-    { asyncWork ->
-        add(asyncWork)
+    { workSpecification ->
+        add(workSpecification)
     }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
@@ -1,0 +1,18 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+
+fun MutableList<suspend () -> Unit>.appendWork(): (suspend () -> Unit) -> Unit =
+    { asyncWork ->
+        add(asyncWork)
+    }
+
+suspend fun MutableList<suspend () -> Unit>.executeAll() {
+    forEach { it.invoke() }
+}
+
+internal fun MutableList<WorkerSpecification>.appendSpecification(): (WorkerSpecification) -> Unit =
+    { asyncWork ->
+        add(asyncWork)
+    }
+

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -11,11 +11,6 @@ import io.mockk.every
 import io.mockk.slot
 import kotlinx.coroutines.delay
 
-fun Ably.mockCreateSuspendingConnectionSuccess(trackableId: String) {
-    mockSuspendingConnectSuccess(trackableId)
-    mockSubscribeToPresenceSuccess(trackableId)
-}
-
 fun Ably.mockCreateConnectionSuccess(trackableId: String) {
     mockConnectSuccess(trackableId)
     mockSubscribeToPresenceSuccess(trackableId)
@@ -28,15 +23,17 @@ fun Ably.mockConnectSuccess(trackableId: String) {
     } answers {
         callbackSlot.captured(Result.success(Unit))
     }
-}
 
-fun Ably.mockSuspendingConnectSuccess(trackableId: String) {
     coEvery {
         connect(trackableId, any(), any(), any(), any())
     } returns Result.success(Unit)
 }
 
-fun Ably.mockSuspendingConnectFailure(trackableId: String) {
+fun Ably.mockConnectFailure(trackableId: String) {
+    val callbackSlot = slot<(Result<Unit>) -> Unit>()
+    every { connect(trackableId, any(), any(), any(), any(), capture(callbackSlot)) } answers {
+        callbackSlot.captured(Result.failure(anyConnectionException()))
+    }
     coEvery {
         connect(trackableId, any(), any(), any(), any())
     } returns Result.failure(anyConnectionException())
@@ -92,25 +89,6 @@ fun Ably.mockDisconnect(trackableId: String, result: Result<Unit>) {
 
 fun Ably.mockDisconnectSuccess(trackableId: String) {
     mockDisconnect(trackableId, Result.success(Unit))
-}
-
-fun Ably.mockDisconnectSuccessAndCapturePresenceData(trackableId: String): CapturingSlot<PresenceData> {
-    val callbackSlot = slot<(Result<Unit>) -> Unit>()
-    val presenceDataSlot = slot<PresenceData>()
-    every {
-        disconnect(trackableId, capture(presenceDataSlot), capture(callbackSlot))
-    } answers {
-        callbackSlot.captured(Result.success(Unit))
-    }
-    return presenceDataSlot
-}
-
-fun Ably.mockSuspendingDisconnect(trackableId: String, result: Result<Unit>) {
-    coEvery { disconnect(trackableId, any()) } returns result
-}
-
-fun Ably.mockSuspendingDisconnectSuccess(trackableId: String) {
-    mockSuspendingDisconnect(trackableId, Result.success(Unit))
 }
 
 fun Ably.mockSuspendingDisconnectSuccessAndCapturePresenceData(trackableId: String): CapturingSlot<PresenceData> {


### PR DESCRIPTION
This PR adds unit tests for workers created during the Subscriber event queue refactor defined in #660 