### PR TITLE
Start and stop the Ably connection manually depending on the number of added trackables

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -247,6 +247,7 @@ constructor(
                 this.logLevel = Log.VERBOSE
                 this.logHandler = Log.LogHandler { severity, tag, msg, tr -> logMessage(severity, tag, msg, tr) }
                 this.environment = connectionConfiguration.environment
+                this.autoConnect = false
             }
             ably = AblyRealtime(clientOptions)
         } catch (exception: AblyException) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -724,15 +724,14 @@ constructor(
     /**
      * Closes [AblyRealtime] and waits until it's either closed or failed.
      * If the connection is already closed it returns immediately.
-     * If the connection is already failed it throws a [ConnectionException].
+     * If the connection is already failed it returns immediately as closing a failed connection should be a no-op
+     * according to the Ably features spec (https://sdk.ably.com/builds/ably/specification/main/features/#state-conditions-and-operations).
      *
      * @throws ConnectionException if the [AblyRealtime] state changes to [ConnectionState.failed].
      */
     private suspend fun AblyRealtime.closeSuspending() {
-        if (connection.state.isClosed()) {
+        if (connection.state.isClosed() || connection.state.isFailed()) {
             return
-        } else if (connection.state.isFailed()) {
-            throw connection.reason.toTrackingException()
         }
         suspendCancellableCoroutine<Unit> { continuation ->
             connection.on {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -754,9 +754,10 @@ constructor(
         override var state: PublisherState = PublisherState.IDLE
             set(value) {
                 // Once we stop publisher it should never change its state
-                if (field != PublisherState.STOPPED) {
-                    field = value
+                if (field == PublisherState.STOPPED) {
+                    throw PublisherStoppedException()
                 }
+                field = value
             }
         override val hasNoTrackablesAddingOrAdded: Boolean
             get() = trackables.isEmpty() && !duplicateTrackableGuard.isCurrentlyAddingAnyTrackable()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -683,7 +683,6 @@ constructor(
         areRawLocationsEnabled: Boolean?,
     ) : PublisherProperties {
         private var isDisposed: Boolean = false
-        override var isStopped: Boolean = false
         override var locationEngineResolution: Resolution = locationEngineResolution
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val isLocationEngineResolutionConstant: Boolean = isLocationEngineResolutionConstant
@@ -752,10 +751,13 @@ constructor(
         override val trackableRemovalGuard: TrackableRemovalGuard = DefaultTrackableRemovalGuard()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val areRawLocationsEnabled: Boolean = areRawLocationsEnabled ?: false
-        override var isConnectingToAbly: Boolean = false
-            get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
-        override var isStoppingAbly: Boolean = false
-            get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
+        override var state: PublisherState = PublisherState.IDLE
+            set(value) {
+                // Once we stop publisher it should never change its state
+                if (field != PublisherState.STOPPED) {
+                    field = value
+                }
+            }
         override val hasNoTrackablesAddingOrAdded: Boolean
             get() = trackables.isEmpty() && !duplicateTrackableGuard.isCurrentlyAddingAnyTrackable()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -752,6 +752,12 @@ constructor(
         override val trackableRemovalGuard: TrackableRemovalGuard = DefaultTrackableRemovalGuard()
             get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
         override val areRawLocationsEnabled: Boolean = areRawLocationsEnabled ?: false
+        override var isConnectingToAbly: Boolean = false
+            get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
+        override var isStoppingAbly: Boolean = false
+            get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
+        override val hasNoTrackablesAddingOrAdded: Boolean
+            get() = trackables.isEmpty() && !duplicateTrackableGuard.isCurrentlyAddingAnyTrackable()
 
         override fun dispose() {
             trackables.clear()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -24,7 +24,6 @@ internal interface PublisherProperties {
     val requests: MutableMap<String, MutableMap<Subscriber, Resolution>>
     val resolutions: MutableMap<String, Resolution>
     var active: Trackable?
-    var isStopped: Boolean
     var locationEngineResolution: Resolution
     val isLocationEngineResolutionConstant: Boolean
     var isTracking: Boolean
@@ -44,8 +43,7 @@ internal interface PublisherProperties {
     val enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationUpdate>
     val rawLocationsPublishingState: LocationsPublishingState<LocationUpdate>
     val areRawLocationsEnabled: Boolean
-    var isConnectingToAbly: Boolean
-    var isStoppingAbly: Boolean
     val hasNoTrackablesAddingOrAdded: Boolean
+    var state: PublisherState
     fun dispose()
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -44,5 +44,8 @@ internal interface PublisherProperties {
     val enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationUpdate>
     val rawLocationsPublishingState: LocationsPublishingState<LocationUpdate>
     val areRawLocationsEnabled: Boolean
+    var isConnectingToAbly: Boolean
+    var isStoppingAbly: Boolean
+    val hasNoTrackablesAddingOrAdded: Boolean
     fun dispose()
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherState.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherState.kt
@@ -1,0 +1,28 @@
+package com.ably.tracking.publisher
+
+enum class PublisherState {
+    /**
+     * The publisher is created but has no connection to Ably.
+     */
+    IDLE,
+
+    /**
+     * The publisher is trying to connect to Ably.
+     */
+    CONNECTING,
+
+    /**
+     * The publisher is connected to Ably.
+     */
+    CONNECTED,
+
+    /**
+     * The publisher is trying to disconnect from Ably.
+     */
+    DISCONNECTING,
+
+    /**
+     * The publisher is stopped and should not be used anymore.
+     */
+    STOPPED
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/DublicateTrackableGuard.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/guards/DublicateTrackableGuard.kt
@@ -11,6 +11,7 @@ internal interface DuplicateTrackableGuard {
     fun startAddingTrackable(trackable: Trackable)
     fun finishAddingTrackable(trackable: Trackable, result: Result<AddTrackableResult>)
     fun isCurrentlyAddingTrackable(trackable: Trackable): Boolean
+    fun isCurrentlyAddingAnyTrackable(): Boolean
     fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction)
     fun clear(trackable: Trackable)
     fun clearAll()
@@ -61,6 +62,15 @@ internal class DefaultDuplicateTrackableGuard : DuplicateTrackableGuard {
      */
     override fun isCurrentlyAddingTrackable(trackable: Trackable): Boolean {
         return trackablesCurrentlyBeingAdded.contains(trackable)
+    }
+
+    /**
+     * Checks if the adding process for any trackable is already ongoing.
+     *
+     * @return True if any trackable is currently being added, false otherwise.
+     */
+    override fun isCurrentlyAddingAnyTrackable(): Boolean {
+        return trackablesCurrentlyBeingAdded.isNotEmpty()
     }
 
     /**

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/DefaultWorkerQueue.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/DefaultWorkerQueue.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.publisher.workerqueue
 
 import com.ably.tracking.publisher.DefaultCorePublisher
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.PublisherStoppedException
 import com.ably.tracking.publisher.workerqueue.resulthandlers.getWorkResultHandler
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
@@ -27,7 +28,7 @@ internal class DefaultWorkerQueue(
 
     private suspend fun executeWorkers() {
         for (worker in workerChannel) {
-            if (publisherProperties.isStopped) {
+            if (publisherProperties.state == PublisherState.STOPPED) {
                 worker.doWhenStopped(PublisherStoppedException())
             } else {
                 execute(worker)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -79,6 +79,7 @@ internal class DefaultWorkerFactory(
                 params.trackable,
                 params.callbackFunction,
                 params.exception,
+                params.isConnectedToAbly,
                 ably,
             )
             is WorkerParams.ConnectionCreated -> ConnectionCreatedWorker(
@@ -229,6 +230,7 @@ internal sealed class WorkerParams {
         val trackable: Trackable,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
         val exception: Exception,
+        val isConnectedToAbly: Boolean,
     ) : WorkerParams()
 
     object ChangeLocationEngineResolution : WorkerParams()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -22,6 +22,7 @@ import com.ably.tracking.publisher.workerqueue.workers.AddTrackableWorker
 import com.ably.tracking.publisher.workerqueue.workers.ChangeLocationEngineResolutionWorker
 import com.ably.tracking.publisher.workerqueue.workers.ChangeRoutingProfileWorker
 import com.ably.tracking.publisher.workerqueue.workers.ChannelConnectionStateChangeWorker
+import com.ably.tracking.publisher.workerqueue.workers.StoppingConnectionFinishedWorker
 import com.ably.tracking.publisher.workerqueue.workers.ConnectionCreatedWorker
 import com.ably.tracking.publisher.workerqueue.workers.ConnectionReadyWorker
 import com.ably.tracking.publisher.workerqueue.workers.DestinationSetWorker
@@ -78,6 +79,7 @@ internal class DefaultWorkerFactory(
                 params.trackable,
                 params.callbackFunction,
                 params.exception,
+                ably,
             )
             is WorkerParams.ConnectionCreated -> ConnectionCreatedWorker(
                 params.trackable,
@@ -112,10 +114,12 @@ internal class DefaultWorkerFactory(
                 params.callbackFunction,
                 corePublisher,
                 params.shouldRecalculateResolutionCallback,
+                ably,
             )
             is WorkerParams.TrackableRemovalRequested -> TrackableRemovalRequestedWorker(
                 params.trackable,
                 params.callbackFunction,
+                ably,
                 params.result,
             )
             is WorkerParams.AblyConnectionStateChange -> AblyConnectionStateChangeWorker(
@@ -204,6 +208,7 @@ internal class DefaultWorkerFactory(
                 corePublisher,
                 params.timeoutInMilliseconds,
             )
+            WorkerParams.StoppingConnectionFinished -> StoppingConnectionFinishedWorker()
         }
     }
 }
@@ -330,4 +335,6 @@ internal sealed class WorkerParams {
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
         val result: Result<Unit>,
     ) : WorkerParams()
+
+    object StoppingConnectionFinished : WorkerParams()
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableFailedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableFailedResultHandler.kt
@@ -1,0 +1,16 @@
+package com.ably.tracking.publisher.workerqueue.resulthandlers
+
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
+import com.ably.tracking.publisher.workerqueue.results.AddTrackableFailedWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+
+internal class AddTrackableFailedResultHandler(
+    private val workerFactory: WorkerFactory
+) : WorkResultHandler<AddTrackableFailedWorkResult> {
+    override fun handle(workResult: AddTrackableFailedWorkResult): Worker? =
+        when (workResult) {
+            AddTrackableFailedWorkResult.StopConnectionCompleted ->
+                workerFactory.createWorker(WorkerParams.StoppingConnectionFinished)
+        }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -18,7 +18,7 @@ internal class AddTrackableResultHandler(
             is AddTrackableWorkResult.Fail ->
                 return workerFactory.createWorker(
                     WorkerParams.AddTrackableFailed(
-                        workResult.trackable, workResult.callbackFunction, workResult.exception as Exception
+                        workResult.trackable, workResult.callbackFunction, workResult.exception as Exception, workResult.isConnectedToAbly
                     )
                 )
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/AddTrackableResultHandler.kt
@@ -31,6 +31,16 @@ internal class AddTrackableResultHandler(
                         workResult.channelStateChangeListener
                     )
                 )
+
+            is AddTrackableWorkResult.WorkDelayed ->
+                return workerFactory.createWorker(
+                    WorkerParams.AddTrackable(
+                        workResult.trackable,
+                        workResult.callbackFunction,
+                        workResult.presenceUpdateListener,
+                        workResult.channelStateChangeListener,
+                    )
+                )
         }
         return null
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/DisconnectSuccessResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/DisconnectSuccessResultHandler.kt
@@ -1,0 +1,16 @@
+package com.ably.tracking.publisher.workerqueue.resulthandlers
+
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
+import com.ably.tracking.publisher.workerqueue.results.DisconnectSuccessWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+
+internal class DisconnectSuccessResultHandler(
+    private val workerFactory: WorkerFactory
+) : WorkResultHandler<DisconnectSuccessWorkResult> {
+    override fun handle(workResult: DisconnectSuccessWorkResult): Worker? =
+        when (workResult) {
+            DisconnectSuccessWorkResult.StopConnectionCompleted ->
+                workerFactory.createWorker(WorkerParams.StoppingConnectionFinished)
+        }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/TrackableRemovalRequestedResultHandler.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/TrackableRemovalRequestedResultHandler.kt
@@ -1,0 +1,16 @@
+package com.ably.tracking.publisher.workerqueue.resulthandlers
+
+import com.ably.tracking.publisher.workerqueue.WorkerFactory
+import com.ably.tracking.publisher.workerqueue.WorkerParams
+import com.ably.tracking.publisher.workerqueue.results.TrackableRemovalRequestedWorkResult
+import com.ably.tracking.publisher.workerqueue.workers.Worker
+
+internal class TrackableRemovalRequestedResultHandler(
+    private val workerFactory: WorkerFactory
+) : WorkResultHandler<TrackableRemovalRequestedWorkResult> {
+    override fun handle(workResult: TrackableRemovalRequestedWorkResult): Worker? =
+        when (workResult) {
+            TrackableRemovalRequestedWorkResult.StopConnectionCompleted ->
+                workerFactory.createWorker(WorkerParams.StoppingConnectionFinished)
+        }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlers.kt
@@ -2,11 +2,14 @@ package com.ably.tracking.publisher.workerqueue.resulthandlers
 
 import com.ably.tracking.publisher.workerqueue.WorkerFactory
 import com.ably.tracking.publisher.workerqueue.WorkerQueue
+import com.ably.tracking.publisher.workerqueue.results.AddTrackableFailedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.ConnectionReadyWorkResult
+import com.ably.tracking.publisher.workerqueue.results.DisconnectSuccessWorkResult
 import com.ably.tracking.publisher.workerqueue.results.RemoveTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.RetrySubscribeToPresenceWorkResult
+import com.ably.tracking.publisher.workerqueue.results.TrackableRemovalRequestedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.WorkResult
 
 @Suppress("UNCHECKED_CAST")
@@ -21,5 +24,8 @@ internal fun getWorkResultHandler(
         is ConnectionReadyWorkResult -> ConnectionReadyResultHandler(workerFactory) as WorkResultHandler<WorkResult>
         is RemoveTrackableWorkResult -> RemoveTrackableResultHandler(workerFactory, workerQueue) as WorkResultHandler<WorkResult>
         is RetrySubscribeToPresenceWorkResult -> RetrySubscribeToPresenceResultHandler(workerFactory) as WorkResultHandler<WorkResult>
+        is TrackableRemovalRequestedWorkResult -> TrackableRemovalRequestedResultHandler(workerFactory) as WorkResultHandler<WorkResult>
+        is AddTrackableFailedWorkResult -> AddTrackableFailedResultHandler(workerFactory) as WorkResultHandler<WorkResult>
+        is DisconnectSuccessWorkResult -> DisconnectSuccessResultHandler(workerFactory) as WorkResultHandler<WorkResult>
         else -> throw IllegalArgumentException("Invalid workResult provided")
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -50,6 +50,13 @@ internal sealed class AddTrackableWorkResult : WorkResult() {
         val exception: Throwable?,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>
     ) : AddTrackableWorkResult()
+
+    internal data class WorkDelayed(
+        val trackable: Trackable,
+        val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>,
+        val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
+        val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
+    ) : AddTrackableWorkResult()
 }
 
 internal sealed class ConnectionCreatedWorkResult : WorkResult() {
@@ -118,4 +125,16 @@ internal sealed class RemoveTrackableWorkResult : WorkResult() {
     internal data class NotPresent(
         val callbackFunction: ResultCallbackFunction<Boolean>
     ) : RemoveTrackableWorkResult()
+}
+
+internal sealed class TrackableRemovalRequestedWorkResult : WorkResult() {
+    internal object StopConnectionCompleted : TrackableRemovalRequestedWorkResult()
+}
+
+internal sealed class AddTrackableFailedWorkResult : WorkResult() {
+    internal object StopConnectionCompleted : AddTrackableFailedWorkResult()
+}
+
+internal sealed class DisconnectSuccessWorkResult : WorkResult() {
+    internal object StopConnectionCompleted : DisconnectSuccessWorkResult()
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/results/WorkResult.kt
@@ -48,6 +48,7 @@ internal sealed class AddTrackableWorkResult : WorkResult() {
     internal data class Fail(
         val trackable: Trackable,
         val exception: Throwable?,
+        val isConnectedToAbly: Boolean,
         val callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>
     ) : AddTrackableWorkResult()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorker.kt
@@ -1,19 +1,34 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
+import com.ably.tracking.common.Ably
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.results.AddTrackableFailedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 
 internal class AddTrackableFailedWorker(
     private val trackable: Trackable,
     private val callbackFunction: AddTrackableCallbackFunction,
-    val exception: Exception
+    val exception: Exception,
+    private val ably: Ably,
 ) : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        if (properties.isConnectingToAbly) {
+            properties.isConnectingToAbly = false
+        }
+
         val failureResult = Result.failure<AddTrackableResult>(exception)
         callbackFunction(failureResult)
         properties.duplicateTrackableGuard.finishAddingTrackable(trackable, failureResult)
         properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
+
+        if (properties.hasNoTrackablesAddingOrAdded) {
+            properties.isStoppingAbly = true
+            return SyncAsyncResult(asyncWork = {
+                ably.stopConnection()
+                AddTrackableFailedWorkResult.StopConnectionCompleted
+            })
+        }
 
         return SyncAsyncResult()
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -9,10 +9,16 @@ import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.AddTrackableWorkResult
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 
 internal typealias AddTrackableResult = StateFlow<TrackableState>
 internal typealias AddTrackableCallbackFunction = ResultCallbackFunction<AddTrackableResult>
+
+/**
+ * How long should we wait before re-queueing the work if Ably connection manipulation is in progress.
+ */
+private const val WORK_DELAY_IN_MILLISECONDS = 200L
 
 internal class AddTrackableWorker(
     private val trackable: Trackable,
@@ -31,11 +37,30 @@ internal class AddTrackableWorker(
                 SyncAsyncResult(AddTrackableWorkResult.AlreadyIn(properties.trackableStateFlows[trackable.id]!!, callbackFunction))
             }
             else -> {
+                if (properties.isConnectingToAbly || properties.isStoppingAbly) {
+                    return SyncAsyncResult(
+                        asyncWork = {
+                            // delay work until Ably connection manipulation ends
+                            delay(WORK_DELAY_IN_MILLISECONDS)
+                            AddTrackableWorkResult.WorkDelayed(trackable, callbackFunction, presenceUpdateListener, channelStateChangeListener)
+                        }
+                    )
+                }
+                val isAddingTheFirstTrackable = properties.hasNoTrackablesAddingOrAdded
+                if (isAddingTheFirstTrackable) {
+                    properties.isConnectingToAbly = true
+                }
                 properties.duplicateTrackableGuard.startAddingTrackable(trackable)
                 val presenceData = properties.presenceData.copy()
 
                 SyncAsyncResult(
                     asyncWork = {
+                        if (isAddingTheFirstTrackable) {
+                            val startAblyConnectionResult = ably.startConnection()
+                            if (startAblyConnectionResult.isFailure) {
+                                AddTrackableWorkResult.Fail(trackable, startAblyConnectionResult.exceptionOrNull(), callbackFunction)
+                            }
+                        }
                         val connectResult = ably.connect(
                             trackableId = trackable.id,
                             presenceData = presenceData,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -38,16 +38,16 @@ internal class AddTrackableWorker(
             properties.trackables.contains(trackable) -> {
                 SyncAsyncResult(AddTrackableWorkResult.AlreadyIn(properties.trackableStateFlows[trackable.id]!!, callbackFunction))
             }
+            properties.state == PublisherState.CONNECTING || properties.state == PublisherState.DISCONNECTING -> {
+                SyncAsyncResult(
+                    asyncWork = {
+                        // delay work until Ably connection manipulation ends
+                        delay(WORK_DELAY_IN_MILLISECONDS)
+                        AddTrackableWorkResult.WorkDelayed(trackable, callbackFunction, presenceUpdateListener, channelStateChangeListener)
+                    }
+                )
+            }
             else -> {
-                if (properties.state == PublisherState.CONNECTING || properties.state == PublisherState.DISCONNECTING) {
-                    return SyncAsyncResult(
-                        asyncWork = {
-                            // delay work until Ably connection manipulation ends
-                            delay(WORK_DELAY_IN_MILLISECONDS)
-                            AddTrackableWorkResult.WorkDelayed(trackable, callbackFunction, presenceUpdateListener, channelStateChangeListener)
-                        }
-                    )
-                }
                 val isAddingTheFirstTrackable = properties.hasNoTrackablesAddingOrAdded
                 if (isAddingTheFirstTrackable) {
                     properties.state = PublisherState.CONNECTING

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -17,7 +17,8 @@ internal typealias AddTrackableResult = StateFlow<TrackableState>
 internal typealias AddTrackableCallbackFunction = ResultCallbackFunction<AddTrackableResult>
 
 /**
- * How long should we wait before re-queueing the work if Ably connection manipulation is in progress.
+ * How long should we wait before re-queueing the work if starting or stopping Ably connection is in progress.
+ * If after the delay the Ably connection process is still in progress the work will be re-queued again.
  */
 private const val WORK_DELAY_IN_MILLISECONDS = 200L
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -7,6 +7,7 @@ import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.logging.w
 import com.ably.tracking.logging.LogHandler
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.ConnectionCreatedWorkResult
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
@@ -22,9 +23,9 @@ internal class ConnectionCreatedWorker(
     private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
 ) : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
-        if (properties.isConnectingToAbly) {
+        if (properties.state == PublisherState.CONNECTING) {
             // If we've made up this far it means the [AddTrackableWorker] succeeded and there's a working Ably connection
-            properties.isConnectingToAbly = false
+            properties.state = PublisherState.CONNECTED
         }
         if (properties.trackableRemovalGuard.isMarkedForRemoval(trackable)) {
             // Leave Ably channel.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -22,6 +22,10 @@ internal class ConnectionCreatedWorker(
     private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
 ) : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        if (properties.isConnectingToAbly) {
+            // If we've made up this far it means the [AddTrackableWorker] succeeded and there's a working Ably connection
+            properties.isConnectingToAbly = false
+        }
         if (properties.trackableRemovalGuard.isMarkedForRemoval(trackable)) {
             // Leave Ably channel.
             val presenceData = properties.presenceData.copy()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.DisconnectSuccessWorkResult
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
@@ -31,7 +32,7 @@ internal class DisconnectSuccessWorker(
 
         val removedTheLastTrackable = properties.hasNoTrackablesAddingOrAdded
         if (removedTheLastTrackable) {
-            properties.isStoppingAbly = true
+            properties.state = PublisherState.DISCONNECTING
             return SyncAsyncResult(asyncWork = {
                 ably.stopConnection()
                 DisconnectSuccessWorkResult.StopConnectionCompleted

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
@@ -36,7 +37,7 @@ internal class StopWorker(
             }
         }
         // We should mark the publisher as stopped no matter if the whole stopping process completed successfully.
-        properties.isStopped = true
+        properties.state = PublisherState.STOPPED
         return SyncAsyncResult()
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StoppingConnectionFinishedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StoppingConnectionFinishedWorker.kt
@@ -1,11 +1,12 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
 
 internal class StoppingConnectionFinishedWorker() : Worker {
     override fun doWork(properties: PublisherProperties): SyncAsyncResult {
-        properties.isStoppingAbly = false
+        properties.state = PublisherState.IDLE
         return SyncAsyncResult()
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StoppingConnectionFinishedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StoppingConnectionFinishedWorker.kt
@@ -1,0 +1,13 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
+
+internal class StoppingConnectionFinishedWorker() : Worker {
+    override fun doWork(properties: PublisherProperties): SyncAsyncResult {
+        properties.isStoppingAbly = false
+        return SyncAsyncResult()
+    }
+
+    override fun doWhenStopped(exception: Exception) = Unit
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.RemoveTrackableRequestedException
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.results.SyncAsyncResult
@@ -29,7 +30,7 @@ internal class TrackableRemovalRequestedWorker(
         )
         val removedTheLastTrackable = properties.hasNoTrackablesAddingOrAdded
         if (removedTheLastTrackable) {
-            properties.isStoppingAbly = true
+            properties.state = PublisherState.DISCONNECTING
             return SyncAsyncResult(asyncWork = {
                 ably.stopConnection()
                 TrackableRemovalRequestedWorkResult.StopConnectionCompleted

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/resulthandlers/WorkResultHandlersTest.kt
@@ -22,7 +22,7 @@ class WorkResultHandlersTest {
     private val addTrackableWorkResults = listOf(
         AddTrackableWorkResult.AlreadyIn(MutableStateFlow(TrackableState.Online), {}),
         AddTrackableWorkResult.Success(Trackable(""), {}, {}, {}),
-        AddTrackableWorkResult.Fail(Trackable(""), null, {}),
+        AddTrackableWorkResult.Fail(Trackable(""), null, false, {}),
     )
     private val connectionCreatedWorkResults = listOf(
         ConnectionCreatedWorkResult.RemovalRequested(Trackable(""), {}, Result.success(Unit)),

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
@@ -24,10 +25,11 @@ class AddTrackableFailedWorkerTest {
     private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
     private val duplicateTrackableGuard = mockk<DuplicateTrackableGuard>(relaxed = true)
     private val trackableRemovalGuard = mockk<TrackableRemovalGuard>(relaxed = true)
+    private val ably = mockk<Ably>(relaxed = true)
 
     @Before
     fun setUp() {
-        worker = AddTrackableFailedWorker(trackable, resultCallbackFunction, exception)
+        worker = AddTrackableFailedWorker(trackable, resultCallbackFunction, exception, ably)
         every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
         every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
@@ -29,7 +29,7 @@ class AddTrackableFailedWorkerTest {
 
     @Before
     fun setUp() {
-        worker = AddTrackableFailedWorker(trackable, resultCallbackFunction, exception, ably)
+        worker = AddTrackableFailedWorker(trackable, resultCallbackFunction, exception, true, ably)
         every { publisherProperties.duplicateTrackableGuard } returns duplicateTrackableGuard
         every { publisherProperties.trackableRemovalGuard } returns trackableRemovalGuard
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.publisher.workerqueue.workers
 import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionState
 import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.ResultCallbackFunction
@@ -28,6 +29,7 @@ class DisconnectSuccessWorkerTest {
     private val corePublisher = mockk<CorePublisher>(relaxed = true)
     private val recalculateResolutionCallbackFunction = mockk<() -> Unit>(relaxed = true)
     private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
+    private val ably = mockk<Ably>(relaxed = true)
 
     @Before
     fun setUp() {
@@ -36,6 +38,7 @@ class DisconnectSuccessWorkerTest {
             resultCallbackFunction,
             corePublisher,
             recalculateResolutionCallbackFunction,
+            ably,
         )
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.CorePublisher
 import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.test.common.mockCloseFailure
 import com.ably.tracking.test.common.mockCloseSuccessWithDelay
 import io.mockk.CapturingSlot
@@ -139,7 +140,7 @@ class StopWorkerTest {
 
         // then
         verify(exactly = 1) {
-            publisherProperties setProperty PublisherProperties::isStopped.name value true
+            publisherProperties setProperty PublisherProperties::state.name value PublisherState.STOPPED
         }
     }
 
@@ -153,7 +154,7 @@ class StopWorkerTest {
 
         // then
         verify(exactly = 1) {
-            publisherProperties setProperty PublisherProperties::isStopped.name value true
+            publisherProperties setProperty PublisherProperties::state.name value PublisherState.STOPPED
         }
     }
 
@@ -168,7 +169,7 @@ class StopWorkerTest {
 
         // then
         verify(exactly = 1) {
-            publisherProperties setProperty PublisherProperties::isStopped.name value true
+            publisherProperties setProperty PublisherProperties::state.name value PublisherState.STOPPED
         }
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
@@ -1,6 +1,7 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.RemoveTrackableRequestedException
@@ -27,6 +28,7 @@ class TrackableRemovalRequestedWorkerTest {
     private val publisherProperties = mockk<PublisherProperties>(relaxed = true)
     private val trackableRemovalGuard = TrackableRemovalGuardSpy()
     private val duplicateTrackableGuard = DuplicateTrackableGuardSpy()
+    private val ably = mockk<Ably>(relaxed = true)
 
     @Before
     fun setUp() {
@@ -110,7 +112,7 @@ class TrackableRemovalRequestedWorkerTest {
     }
 
     private fun prepareWorkerWithResult(result: Result<Unit>) {
-        worker = TrackableRemovalRequestedWorker(trackable, resultCallbackFunction, result)
+        worker = TrackableRemovalRequestedWorker(trackable, resultCallbackFunction, ably, result)
     }
 
     private fun captureResultCallbackFunctionResult(): CapturingSlot<Result<StateFlow<TrackableState>>> {
@@ -136,6 +138,8 @@ private class DuplicateTrackableGuardSpy : DuplicateTrackableGuard {
     }
 
     override fun isCurrentlyAddingTrackable(trackable: Trackable): Boolean = false
+
+    override fun isCurrentlyAddingAnyTrackable(): Boolean = false
 
     override fun saveDuplicateAddHandler(trackable: Trackable, callbackFunction: AddTrackableCallbackFunction) = Unit
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorker.kt
@@ -20,17 +20,22 @@ internal class StartConnectionWorker(
     ): Properties {
         subscriberInteractor.updateTrackableState(properties)
         doAsyncWork {
-            val result = ably.connect(
-                trackableId,
-                properties.presenceData,
-                useRewind = true,
-                willSubscribe = true
-            )
-
-            if (result.isSuccess) {
-                postWork(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction))
+            val startAblyConnectionResult = ably.startConnection()
+            if (startAblyConnectionResult.isFailure) {
+                callbackFunction(startAblyConnectionResult)
             } else {
-                callbackFunction(result)
+                val result = ably.connect(
+                    trackableId,
+                    properties.presenceData,
+                    useRewind = true,
+                    willSubscribe = true
+                )
+
+                if (result.isSuccess) {
+                    postWork(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction))
+                } else {
+                    callbackFunction(result)
+                }
             }
         }
         return properties

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -9,6 +9,8 @@ import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockConnectFailure
+import com.ably.tracking.test.common.mockStartConnectionFailure
+import com.ably.tracking.test.common.mockStartConnectionSuccess
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
@@ -38,6 +40,7 @@ internal class StartConnectionWorkerTest {
     fun `should call ably connect and post update trackable worker specification on success`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockStartConnectionSuccess()
         ably.mockConnectSuccess(trackableId)
 
         // when
@@ -49,6 +52,7 @@ internal class StartConnectionWorkerTest {
         Assert.assertEquals(initialProperties, updatedProperties)
         verify { subscriberInteractor.updateTrackableState(initialProperties) }
         coVerify {
+            ably.startConnection()
             ably.connect(
                 trackableId, initialProperties.presenceData,
                 useRewind = true,
@@ -62,6 +66,7 @@ internal class StartConnectionWorkerTest {
     fun `should call ably connect and notify callback on failure`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockStartConnectionSuccess()
         ably.mockConnectFailure(trackableId)
 
         // when
@@ -73,6 +78,34 @@ internal class StartConnectionWorkerTest {
         Assert.assertEquals(initialProperties, updatedProperties)
         verify { subscriberInteractor.updateTrackableState(initialProperties) }
         coVerify {
+            ably.startConnection()
+            ably.connect(
+                trackableId, initialProperties.presenceData,
+                useRewind = true,
+                willSubscribe = true
+            )
+        }
+        verify { callbackFunction.invoke(match { it.isFailure }) }
+        Assert.assertTrue(postedWorks.isEmpty())
+    }
+
+    @Test
+    fun `should notify callback about failure when starting Ably connection fails`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockStartConnectionFailure()
+        ably.mockConnectSuccess(trackableId)
+
+        // when
+        val updatedProperties =
+            startConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(initialProperties, updatedProperties)
+        verify { subscriberInteractor.updateTrackableState(initialProperties) }
+        coVerify { ably.startConnection() }
+        coVerify(exactly = 0) {
             ably.connect(
                 trackableId, initialProperties.presenceData,
                 useRewind = true,

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -16,6 +16,14 @@ fun Ably.mockCreateConnectionSuccess(trackableId: String) {
     mockSubscribeToPresenceSuccess(trackableId)
 }
 
+fun Ably.mockStartConnectionSuccess() {
+    coEvery { startConnection() } returns Result.success(Unit)
+}
+
+fun Ably.mockStartConnectionFailure() {
+    coEvery { startConnection() } returns Result.failure(anyConnectionException())
+}
+
 fun Ably.mockConnectSuccess(trackableId: String) {
     val callbackSlot = slot<(Result<Unit>) -> Unit>()
     every {


### PR DESCRIPTION
Another approach to the start/stop Ably connection issue, this time using the worker queue architecture to achieve this. Requirements:

- The connection should be stopped when the publisher is created (hence the `autoConnect = false` is used in the `Ably` wrapper)
- When the first trackable is added the connection should be started
- When the last trackable is removed the connection should be stopped

I've made sure that no trackables are being added when the Ably connection is starting or stopping by delaying the add worker if a connection change is happening at the moment.