### PR TITLE
Add information about SLF4J warning logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,17 @@ val mapboxNavigation = MapboxNavigationProvider.retrieve()
 Because there is only one `MapboxNavigation` instance, both your app and AAT will use the same object. This means that there can be possible conflicts in usage that can lead to unexpected behaviour.
 Therefore, we do not advise using AAT in applications that already use Mapbox Navigation SDK.
 
+### SLF4J warning logs
+
+AAT has a transitive dependency on the `SLF4J` library and it does not provide any default logger implementation. Because of that you can encounter below warning logs:
+
+```
+W/System.err: SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+W/System.err: SLF4J: Defaulting to no-operation (NOP) logger implementation
+```
+
+This is normal behaviour if no specific SLF4J logger implementation is provided. If you want to fix those warnings you have to provide a SLF4J logger implementation in your project.
+
 ## Contributing
 
 For guidance on how to contribute to this project, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Therefore, we do not advise using AAT in applications that already use Mapbox Na
 
 ### SLF4J warning logs
 
-AAT has a transitive dependency on the `SLF4J` library and it does not provide any default logger implementation. Because of that you can encounter below warning logs:
+AAT has a transitive dependency on the [SLF4J](https://www.slf4j.org/) library but we do not provide a default logger implementation. Because of that you can encounter below warning logs if you have not explicitly provided an implementation:
 
 ```
 W/System.err: SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".


### PR DESCRIPTION
Added info about a known warning logs from SLF4J that are a normal thing if there's no concrete logger implementation provided.