### PR TITLE
Process initial presence messages before returning a Subscriber instance

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -92,7 +92,7 @@ interface Ably {
     /**
      * Returns current messages from the trackable channel's presence.
      * Should be called only when there's an existing channel for the [trackableId].
-     * If a channel for the [trackableId] doesn't exist then nothing happens.
+     * If a channel for the [trackableId] doesn't exist then this method returns a Result with an empty list.
      *
      * @param trackableId The ID of the trackable channel.
      *

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -691,15 +691,14 @@ constructor(
     /**
      * Warning: This method might block the current thread due to the presence.get(true) call.
      */
-    private fun getAllCurrentMessagesFromPresence(channel: Channel): List<PresenceMessage> {
-        return channel.presence.get(true).mapNotNull { presenceMessage ->
+    private fun getAllCurrentMessagesFromPresence(channel: Channel): List<PresenceMessage> =
+        channel.presence.get(true).mapNotNull { presenceMessage ->
             presenceMessage.toTracking(gson).also {
                 if (it == null) {
                     logHandler?.w("Presence message in unexpected format: $presenceMessage")
                 }
             }
         }
-    }
 
     override fun updatePresenceData(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
         scope.launch {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
@@ -62,7 +62,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
 
         // then
         verify(exactly = 0) {
-            ably.subscribeForPresenceMessages(trackable.id, any(), any())
+            ably.subscribeForPresenceMessages(trackable.id, any(), any<(Result<Unit>) -> Unit>())
         }
     }
 
@@ -91,7 +91,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
 
             // then
             verify(exactly = 0) {
-                ably.subscribeForPresenceMessages(trackable.id, any(), any())
+                ably.subscribeForPresenceMessages(trackable.id, any(), any<(Result<Unit>) -> Unit>())
             }
         }
     }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/PresenceMessageProcessor.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/PresenceMessageProcessor.kt
@@ -1,0 +1,32 @@
+package com.ably.tracking.subscriber
+
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.PresenceAction
+import com.ably.tracking.common.PresenceMessage
+
+internal fun processPresenceMessage(
+    presenceMessage: PresenceMessage,
+    properties: Properties,
+    subscriberInteractor: SubscriberInteractor,
+) {
+    when (presenceMessage.action) {
+        PresenceAction.PRESENT_OR_ENTER -> {
+            if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
+                subscriberInteractor.updatePublisherPresence(properties, true)
+                subscriberInteractor.updateTrackableState(properties)
+                subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
+            }
+        }
+        PresenceAction.LEAVE_OR_ABSENT -> {
+            if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
+                subscriberInteractor.updatePublisherPresence(properties, false)
+                subscriberInteractor.updateTrackableState(properties)
+            }
+        }
+        PresenceAction.UPDATE -> {
+            if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
+                subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
+            }
+        }
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
@@ -8,6 +8,7 @@ import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DisconnectWorker
+import com.ably.tracking.subscriber.workerqueue.workers.ProcessInitialPresenceMessagesWorker
 import com.ably.tracking.subscriber.workerqueue.workers.StartConnectionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.StopConnectionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.SubscribeForPresenceMessagesWorker
@@ -71,6 +72,11 @@ internal class WorkerFactory(
                 subscriberInteractor,
                 params.callbackFunction
             )
+            is WorkerSpecification.ProcessInitialPresenceMessages -> ProcessInitialPresenceMessagesWorker(
+                params.presenceMessages,
+                subscriberInteractor,
+                params.callbackFunction,
+            )
         }
 }
 
@@ -111,5 +117,10 @@ internal sealed class WorkerSpecification {
 
     data class StopConnection(
         val callbackFunction: ResultCallbackFunction<Unit>
+    ) : WorkerSpecification()
+
+    data class ProcessInitialPresenceMessages(
+        val presenceMessages: List<PresenceMessage>,
+        val callbackFunction: ResultCallbackFunction<Unit>,
     ) : WorkerSpecification()
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorker.kt
@@ -1,0 +1,27 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.processPresenceMessage
+import com.ably.tracking.subscriber.workerqueue.CallbackWorker
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+
+internal class ProcessInitialPresenceMessagesWorker(
+    private val presenceMessages: List<PresenceMessage>,
+    private val subscriberInteractor: SubscriberInteractor,
+    callbackFunction: ResultCallbackFunction<Unit>,
+) : CallbackWorker(callbackFunction) {
+    override fun doWork(
+        properties: Properties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): Properties {
+        presenceMessages.forEach { presenceMessage ->
+            processPresenceMessage(presenceMessage, properties, subscriberInteractor)
+        }
+        postWork(WorkerSpecification.SubscribeToChannel(callbackFunction))
+        return properties
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorker.kt
@@ -19,12 +19,13 @@ internal class SubscribeForPresenceMessagesWorker(
     ): Properties {
         doAsyncWork {
             val currentPresenceMessagesResult = ably.getCurrentPresence(trackableId)
-            val initialPresenceMessages: List<PresenceMessage> = try {
-                currentPresenceMessagesResult.getOrThrow()
-            } catch (error: Throwable) {
-                postDisconnectWork(postWork, Result.failure(error))
-                return@doAsyncWork
-            }
+            val initialPresenceMessages: List<PresenceMessage> =
+                try {
+                    currentPresenceMessagesResult.getOrThrow()
+                } catch (error: Throwable) {
+                    postDisconnectWork(postWork, Result.failure(error))
+                    return@doAsyncWork
+                }
 
             val subscribeForPresenceMessagesResult = ably.subscribeForPresenceMessages(
                 trackableId = trackableId,

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorker.kt
@@ -1,10 +1,9 @@
 package com.ably.tracking.subscriber.workerqueue.workers
 
-import com.ably.tracking.common.ClientTypes
-import com.ably.tracking.common.PresenceAction
 import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.processPresenceMessage
 import com.ably.tracking.subscriber.workerqueue.Worker
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 
@@ -17,26 +16,7 @@ internal class UpdatePublisherPresenceWorker(
         doAsyncWork: (suspend () -> Unit) -> Unit,
         postWork: (WorkerSpecification) -> Unit
     ): Properties {
-        when (presenceMessage.action) {
-            PresenceAction.PRESENT_OR_ENTER -> {
-                if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
-                    subscriberInteractor.updatePublisherPresence(properties, true)
-                    subscriberInteractor.updateTrackableState(properties)
-                    subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
-                }
-            }
-            PresenceAction.LEAVE_OR_ABSENT -> {
-                if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
-                    subscriberInteractor.updatePublisherPresence(properties, false)
-                    subscriberInteractor.updateTrackableState(properties)
-                }
-            }
-            PresenceAction.UPDATE -> {
-                if (presenceMessage.data.type == ClientTypes.PUBLISHER) {
-                    subscriberInteractor.updatePublisherResolutionInformation(presenceMessage.data)
-                }
-            }
-        }
+        processPresenceMessage(presenceMessage, properties, subscriberInteractor)
         return properties
     }
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockCreateConnectionSuccess
 import com.ably.tracking.test.common.mockDisconnectSuccess
+import com.ably.tracking.test.common.mockGetCurrentPresenceSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -21,6 +22,7 @@ class DefaultSubscriberTest {
         // given
         ably.mockCreateConnectionSuccess(trackableId)
         ably.mockDisconnectSuccess(trackableId)
+        ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when
@@ -36,6 +38,7 @@ class DefaultSubscriberTest {
         // given
         ably.mockCreateConnectionSuccess(trackableId)
         ably.mockDisconnectSuccess(trackableId)
+        ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorkerTest.kt
@@ -1,0 +1,90 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.PresenceAction
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.PresenceMessage
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.Properties
+import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.processPresenceMessage
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class ProcessInitialPresenceMessagesWorkerTest {
+
+    private val subscriberInteractor: SubscriberInteractor = mockk()
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Before
+    fun setup() {
+        mockkStatic("com.ably.tracking.subscriber.PresenceMessageProcessorKt")
+        every { processPresenceMessage(any(), any(), any()) } just runs
+    }
+
+    @After
+    fun cleanup() {
+        unmockkStatic("com.ably.tracking.subscriber.PresenceMessageProcessorKt")
+    }
+
+    @Test
+    fun `should process all presence messages`() = runBlockingTest {
+        // given
+        val initialProperties = anyProperties()
+        val presenceMessages = listOf(anyPresenceMessage(), anyPresenceMessage(), anyPresenceMessage())
+        val worker = ProcessInitialPresenceMessagesWorker(presenceMessages, subscriberInteractor) {}
+
+        // when
+        worker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        verify(exactly = presenceMessages.size) {
+            processPresenceMessage(any(), initialProperties, subscriberInteractor)
+        }
+    }
+
+    @Test
+    fun `should post subscribe to channel work after processing presence messages`() = runBlockingTest {
+        // given
+        val callbackFunction: ResultCallbackFunction<Unit> = {}
+        val worker = ProcessInitialPresenceMessagesWorker(emptyList(), subscriberInteractor, callbackFunction)
+
+        // when
+        worker.doWork(
+            anyProperties(),
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        Assert.assertEquals(WorkerSpecification.SubscribeToChannel(callbackFunction), postedWorks[0])
+    }
+
+    private fun anyPresenceMessage() = PresenceMessage(
+        PresenceAction.PRESENT_OR_ENTER,
+        PresenceData(ClientTypes.PUBLISHER, null, null),
+        clientId = ""
+    )
+
+    private fun anyProperties() = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
@@ -10,6 +10,8 @@ import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.subscriber.Properties
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import com.ably.tracking.test.common.mockGetCurrentPresenceError
+import com.ably.tracking.test.common.mockGetCurrentPresenceSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.CapturingSlot
@@ -38,6 +40,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
         val presenceListenerSlot: CapturingSlot<(PresenceMessage) -> Unit> = slot()
         val presenceMessage = createPresenceMessage()
+        ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceSuccess(trackableId, presenceListenerSlot)
 
         // when
@@ -60,9 +63,11 @@ internal class SubscribeForPresenceMessagesWorkerTest {
     )
 
     @Test
-    fun `should post subscribe to channel work when subscribe to presence returns success`() = runBlockingTest {
+    fun `should post process initial presence messages work when both get current presence and subscribe to presence return success`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        val initialPresenceMessages = listOf(anyPresenceMessage())
+        ably.mockGetCurrentPresenceSuccess(trackableId, initialPresenceMessages)
         ably.mockSubscribeToPresenceSuccess(trackableId)
 
         // when
@@ -74,13 +79,14 @@ internal class SubscribeForPresenceMessagesWorkerTest {
         asyncWorks.executeAll()
 
         // then
-        Assert.assertEquals(WorkerSpecification.SubscribeToChannel(callbackFunction), postedWorks[0])
+        Assert.assertEquals(WorkerSpecification.ProcessInitialPresenceMessages(initialPresenceMessages, callbackFunction), postedWorks[0])
     }
 
     @Test
     fun `should post disconnect work when subscribe to presence returns failure`() = runBlockingTest {
         // given
         val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when
@@ -94,4 +100,26 @@ internal class SubscribeForPresenceMessagesWorkerTest {
         // then
         Assert.assertTrue(postedWorks[0] is WorkerSpecification.Disconnect)
     }
+
+    @Test
+    fun `should post disconnect work when get current presence returns failure`() = runBlockingTest {
+        // given
+        val initialProperties = Properties(Resolution(Accuracy.BALANCED, 100, 100.0))
+        ably.mockGetCurrentPresenceError(trackableId)
+        ably.mockSubscribeToPresenceSuccess(trackableId)
+
+        // when
+        subscribeForPresenceMessagesWorker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertTrue(postedWorks[0] is WorkerSpecification.Disconnect)
+    }
+
+    private fun anyPresenceMessage() =
+        PresenceMessage(PresenceAction.PRESENT_OR_ENTER, PresenceData(ClientTypes.PUBLISHER), "any-client-id")
 }

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -72,7 +72,7 @@ fun Ably.mockSubscribeToPresenceSuccess(
     } answers {
         callbackSlot.captured(Result.success(Unit))
     }
-    coEvery { subscribeForPresenceMessages(trackableId, capture(listenerSlot)) } returns Result.success(Unit)
+    coEvery { subscribeForPresenceMessages(trackableId, capture(listenerSlot), any<Boolean>()) } returns Result.success(Unit)
 }
 
 fun Ably.mockSubscribeToPresenceError(trackableId: String) {
@@ -82,7 +82,18 @@ fun Ably.mockSubscribeToPresenceError(trackableId: String) {
     } answers {
         callbackSlot.captured(Result.failure(anyConnectionException()))
     }
-    coEvery { subscribeForPresenceMessages(trackableId, any()) } returns Result.failure(anyConnectionException())
+    coEvery { subscribeForPresenceMessages(trackableId, any(), any<Boolean>()) } returns Result.failure(anyConnectionException())
+}
+
+fun Ably.mockGetCurrentPresenceSuccess(
+    trackableId: String,
+    currentPresenceMessage: List<PresenceMessage> = emptyList(),
+) {
+    coEvery { getCurrentPresence(trackableId) } returns Result.success(currentPresenceMessage)
+}
+
+fun Ably.mockGetCurrentPresenceError(trackableId: String) {
+    coEvery { getCurrentPresence(trackableId) } returns Result.failure(anyConnectionException())
 }
 
 fun Ably.mockDisconnect(trackableId: String, result: Result<Unit>) {


### PR DESCRIPTION
Previously, the current presence messages were emitted to the presence listener and handled after the subscriber instance was returned. Now, processing of the initial presence messages is a step in the subscriber creation procedure. I've tried to make as few changes as possible to not interfere with the ongoing Publisher refactor and Ably wrapper refactor work.