### PR TITLE
Allow to specify the remainPresentFor Ably transport parameter

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -29,6 +29,7 @@ import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Message
+import io.ably.lib.types.Param
 import io.ably.lib.util.Log
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -263,6 +264,14 @@ constructor(
                 this.logHandler = Log.LogHandler { severity, tag, msg, tr -> logMessage(severity, tag, msg, tr) }
                 this.environment = connectionConfiguration.environment
                 this.autoConnect = false
+                if (connectionConfiguration.remainPresentForMilliseconds != null) {
+                    this.transportParams = arrayOf(
+                        Param(
+                            "remainPresentFor",
+                            connectionConfiguration.remainPresentForMilliseconds.toString()
+                        )
+                    )
+                }
             }
             ably = AblyRealtime(clientOptions)
         } catch (exception: AblyException) {

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -15,6 +15,11 @@ data class ConnectionConfiguration(
      * Allows a non-default Ably environment to be used such as 'sandbox'.
      */
     val environment: String? = null,
+    /**
+     * Specifies for how long should the SDK remain present in a channel when the connection is gone.
+     * The minimum value can be 1 second (1000 milliseconds). If not set the default value will be used.
+     */
+    val remainPresentForMilliseconds: Long? = null,
 )
 
 typealias TokenRequestCallback = suspend (TokenParams) -> TokenRequest

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -17,7 +17,7 @@ data class ConnectionConfiguration(
     val environment: String? = null,
     /**
      * Specifies for how long should the SDK remain present in a channel when the connection is gone.
-     * The minimum value can be 1 second (1000 milliseconds). If not set the default value will be used.
+     * For more details please see the [Ably documentation](https://ably.com/docs/realtime/presence#unstable-connections).
      */
     val remainPresentForMilliseconds: Long? = null,
 )

--- a/publishing-java-testing/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
+++ b/publishing-java-testing/src/test/java/com/ably/tracking/example/javapublisher/PublisherInterfaceUsageExamples.java
@@ -66,7 +66,7 @@ public class PublisherInterfaceUsageExamples {
         try {
             publisherBuilder
                 .androidContext(context)
-                .connection(new ConnectionConfiguration(AuthenticationFacade.basic("CLIENT_ID", "ABLY_API_KEY"), null))
+                .connection(new ConnectionConfiguration(AuthenticationFacade.basic("CLIENT_ID", "ABLY_API_KEY"), null, null))
                 .map(new MapConfiguration("MAPBOX_API_KEY"))
                 .resolutionPolicy(resolutionPolicyFactory)
                 .locationSource(LocationSourceRaw.createRaw(new LocationHistoryData(new ArrayList<>()), null))

--- a/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -48,11 +48,11 @@ public class UsageExamples {
     @Test
     public void subscriberBuilderUsageExample() {
         Subscriber.Builder nativeBuilder = Subscriber.subscribers()
-            .connection(new ConnectionConfiguration(AuthenticationFacade.basic("CLIENT_ID", "API_KEY"), null))
+            .connection(new ConnectionConfiguration(AuthenticationFacade.basic("CLIENT_ID", "API_KEY"), null, null))
             // or
-            // .connection(new ConnectionConfiguration(createTokenRequestAuthentication(), null))
+            // .connection(new ConnectionConfiguration(createTokenRequestAuthentication(), null, null))
             // or
-            // .connection(new ConnectionConfiguration(createJwtAuthentication(), null))
+            // .connection(new ConnectionConfiguration(createJwtAuthentication(), null, null))
             .trackingId("TRACKING_ID")
             .resolution(new Resolution(Accuracy.BALANCED, 1000L, 1.0));
         SubscriberFacade.Builder wrappedSubscriberBuilder = SubscriberFacade.Builder.wrap(nativeBuilder);


### PR DESCRIPTION
Added the `remainPresentFor` parameter to the Ably configuration according to the [docs](https://ably.com/docs/realtime/presence#unstable-connections).