### PR TITLE
Check publisher state before emitting state on flow

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -472,7 +472,11 @@ constructor(
         }
         if (newTrackableState != properties.trackableStates[trackableId]) {
             properties.trackableStates[trackableId] = newTrackableState
-            scope.launch { properties.trackableStateFlows[trackableId]?.emit(newTrackableState) }
+            scope.launch {
+                if (properties.state != PublisherState.STOPPED){
+                    properties.trackableStateFlows[trackableId]?.emit(newTrackableState)
+                }
+            }
         }
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -473,7 +473,7 @@ constructor(
         if (newTrackableState != properties.trackableStates[trackableId]) {
             properties.trackableStates[trackableId] = newTrackableState
             scope.launch {
-                if (properties.state != PublisherState.STOPPED){
+                if (properties.state != PublisherState.STOPPED) {
                     properties.trackableStateFlows[trackableId]?.emit(newTrackableState)
                 }
             }


### PR DESCRIPTION
This is a workaround fix for https://github.com/ably/ably-asset-tracking-android/issues/808

After some investigation and a fruitful conversation with @KacperKluka, it turns out that `runBlocking` in `StopWorker` will block the processing of some coroutines which have started but not finished yet. This causes a race condition on accessing `trackableStateFlows`.  In this case when trackable state emission block is entered and `StopWorker` has started working, it is possible for `trackableStateFlows` gets in an inconsistent state before in the time it was accessed.

I was able to reproduce this adding a `delay()` inside the coroutine block and saw that crash happens when I add, remove a trackable and then stop the publisher. I was also able to see that this was not happening after I added the code that does fix.

This is a workaround fix that checks the state of publisher before accessing `trackableStateFlows` to protect the clients from crashing in such an edge case.

Closes  https://github.com/ably/ably-asset-tracking-android/issues/808