### PR TITLE
Timber debug log tree planted in both example apps

### DIFF
--- a/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublishingExampleApplication.kt
+++ b/publishing-example-app/src/main/java/com/ably/tracking/example/publisher/PublishingExampleApplication.kt
@@ -4,12 +4,15 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
 import androidx.multidex.MultiDexApplication
+import timber.log.Timber
+import timber.log.Timber.DebugTree
 
 const val NOTIFICATION_CHANNEL_ID = "PublisherServiceChannelId"
 
 class PublishingExampleApplication : MultiDexApplication() {
     override fun onCreate() {
         super.onCreate()
+        Timber.plant(DebugTree())
         S3Helper.init(this)
         createNotificationChannel()
     }

--- a/subscribing-example-app/src/main/AndroidManifest.xml
+++ b/subscribing-example-app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
   package="com.ably.tracking.example.subscriber">
 
   <application
+    android:name=".SubscribingExampleApplication"
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/SubscribingExampleApplication.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/SubscribingExampleApplication.kt
@@ -1,0 +1,12 @@
+package com.ably.tracking.example.subscriber
+
+import androidx.multidex.MultiDexApplication
+import timber.log.Timber
+import timber.log.Timber.DebugTree
+
+class SubscribingExampleApplication : MultiDexApplication() {
+    override fun onCreate() {
+        super.onCreate()
+        Timber.plant(DebugTree())
+    }
+}

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/SubscribingExampleApplication.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/SubscribingExampleApplication.kt
@@ -1,10 +1,10 @@
 package com.ably.tracking.example.subscriber
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
-class SubscribingExampleApplication : MultiDexApplication() {
+class SubscribingExampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Timber.plant(DebugTree())


### PR DESCRIPTION
In this PR, I've added the code required for Timber logging to work. We are using calls to Timber across the app for logging, but they do not do anything when no tree is planted.

Resolves #818 