### PR TITLE
Support static token authentication

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -88,40 +88,36 @@ val Authentication.clientOptions: ClientOptions
     get() = ClientOptions().apply {
         clientId = this@clientOptions.clientId
 
-        this@clientOptions.tokenRequestConfiguration?.let { tokenRequestConfiguration ->
-            tokenRequestConfiguration.callback?.let { tokenRequestCallback ->
-                authCallback = Auth.TokenCallback {
-                    runBlocking {
-                        try {
-                            tokenRequestCallback(it.toTracking()).toAuth()
-                        } catch (exception: TokenAuthException) {
-                            throw exception.toAblyException()
-                        }
+        this@clientOptions.tokenRequestConfiguration?.callback?.let { tokenRequestCallback ->
+            authCallback = Auth.TokenCallback {
+                runBlocking {
+                    try {
+                        tokenRequestCallback(it.toTracking()).toAuth()
+                    } catch (exception: TokenAuthException) {
+                        throw exception.toAblyException()
                     }
                 }
-            }
-
-            tokenRequestConfiguration.staticTokenRequest?.let { staticTokenRequest ->
-                authCallback = Auth.TokenCallback { staticTokenRequest.toAuth() }
             }
         }
 
-        this@clientOptions.jwtConfiguration?.let { jwtConfiguration ->
-            jwtConfiguration.callback?.let { jwtCallback ->
-                authCallback = Auth.TokenCallback {
-                    runBlocking {
-                        try {
-                            jwtCallback(it.toTracking())
-                        } catch (exception: TokenAuthException) {
-                            throw exception.toAblyException()
-                        }
+        this@clientOptions.tokenRequestConfiguration?.staticTokenRequest?.let { staticTokenRequest ->
+            authCallback = Auth.TokenCallback { staticTokenRequest.toAuth() }
+        }
+
+        this@clientOptions.jwtConfiguration?.callback?.let { jwtCallback ->
+            authCallback = Auth.TokenCallback {
+                runBlocking {
+                    try {
+                        jwtCallback(it.toTracking())
+                    } catch (exception: TokenAuthException) {
+                        throw exception.toAblyException()
                     }
                 }
             }
+        }
 
-            jwtConfiguration.staticJwt?.let { staticJwt ->
-                authCallback = Auth.TokenCallback { staticJwt }
-            }
+        this@clientOptions.jwtConfiguration?.staticJwt?.let { staticJwt ->
+            authCallback = Auth.TokenCallback { staticJwt }
         }
 
         this@clientOptions.basicApiKey?.let { basicApiKey ->

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -88,27 +88,39 @@ val Authentication.clientOptions: ClientOptions
     get() = ClientOptions().apply {
         clientId = this@clientOptions.clientId
 
-        this@clientOptions.tokenRequestCallback?.let { tokenRequestCallback ->
-            authCallback = Auth.TokenCallback {
-                runBlocking {
-                    try {
-                        tokenRequestCallback(it.toTracking()).toAuth()
-                    } catch (exception: TokenAuthException) {
-                        throw exception.toAblyException()
+        this@clientOptions.tokenRequestConfiguration?.let { tokenRequestConfiguration ->
+            tokenRequestConfiguration.callback?.let { tokenRequestCallback ->
+                authCallback = Auth.TokenCallback {
+                    runBlocking {
+                        try {
+                            tokenRequestCallback(it.toTracking()).toAuth()
+                        } catch (exception: TokenAuthException) {
+                            throw exception.toAblyException()
+                        }
                     }
                 }
             }
+
+            tokenRequestConfiguration.staticTokenRequest?.let { staticTokenRequest ->
+                authCallback = Auth.TokenCallback { staticTokenRequest.toAuth() }
+            }
         }
 
-        this@clientOptions.jwtCallback?.let { jwtCallback ->
-            authCallback = Auth.TokenCallback {
-                runBlocking {
-                    try {
-                        jwtCallback(it.toTracking())
-                    } catch (exception: TokenAuthException) {
-                        throw exception.toAblyException()
+        this@clientOptions.jwtConfiguration?.let { jwtConfiguration ->
+            jwtConfiguration.callback?.let { jwtCallback ->
+                authCallback = Auth.TokenCallback {
+                    runBlocking {
+                        try {
+                            jwtCallback(it.toTracking())
+                        } catch (exception: TokenAuthException) {
+                            throw exception.toAblyException()
+                        }
                     }
                 }
+            }
+
+            jwtConfiguration.staticJwt?.let { staticJwt ->
+                authCallback = Auth.TokenCallback { staticJwt }
             }
         }
 

--- a/core-sdk-java/src/main/java/com/ably/tracking/java/AuthenticationFacade.kt
+++ b/core-sdk-java/src/main/java/com/ably/tracking/java/AuthenticationFacade.kt
@@ -48,7 +48,7 @@ class AuthenticationFacade {
             }
 
         /**
-         * Authentication method that uses the Token Request.
+         * Authentication method that uses a static Token Request.
          * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
          *
          * @param staticTokenRequest The already created [TokenRequest] that will be used each time the SDK needs to authenticate.
@@ -70,7 +70,7 @@ class AuthenticationFacade {
             }
 
         /**
-         * Authentication method that uses the JWT.
+         * Authentication method that uses a static JWT (JSON Web Token).
          * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
          *
          * @param staticJwt The already created JWT that will be used each time the SDK needs to authenticate.

--- a/core-sdk-java/src/main/java/com/ably/tracking/java/AuthenticationFacade.kt
+++ b/core-sdk-java/src/main/java/com/ably/tracking/java/AuthenticationFacade.kt
@@ -48,6 +48,16 @@ class AuthenticationFacade {
             }
 
         /**
+         * Authentication method that uses the Token Request.
+         * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
+         *
+         * @param staticTokenRequest The already created [TokenRequest] that will be used each time the SDK needs to authenticate.
+         */
+        @JvmStatic
+        fun tokenRequest(staticTokenRequest: TokenRequest): Authentication =
+            Authentication.tokenRequest(staticTokenRequest)
+
+        /**
          * Authentication method that uses the JWT. The [callback] will be called each time a new token is needed.
          * If something goes wrong while fetching the token you should throw a [TokenAuthException] in the [callback].
          *
@@ -58,5 +68,15 @@ class AuthenticationFacade {
             Authentication.jwt {
                 callback.onCreateNewToken(it).await()
             }
+
+        /**
+         * Authentication method that uses the JWT.
+         * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
+         *
+         * @param staticJwt The already created JWT that will be used each time the SDK needs to authenticate.
+         */
+        @JvmSynthetic
+        fun jwt(staticJwt: String): Authentication =
+            Authentication.jwt(staticJwt)
     }
 }

--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -86,7 +86,7 @@ sealed class Authentication(
             TokenAuthentication(null, TokenRequestConfiguration(callback, null))
 
         /**
-         * Authentication method that uses the Token Request.
+         * Authentication method that uses a static Token Request.
          * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
          *
          * @param staticTokenRequest The already created [TokenRequest] that will be used each time the SDK needs to authenticate.
@@ -121,7 +121,7 @@ sealed class Authentication(
             JwtAuthentication(null, JwtConfiguration(callback, null))
 
         /**
-         * Authentication method that uses the JWT.
+         * Authentication method that uses a static JWT (JSON Web Token).
          * This is a convenience method that accepts a static token value that will be used each time the SDK needs to authenticate.
          *
          * @param staticJwt The already created JWT that will be used each time the SDK needs to authenticate.


### PR DESCRIPTION
I added convenience auth methods that allow to easily use a static token authentication. Both token request and JWT are supported. The new static auth options are added to the Java API as well and are tested in integration tests.