### PR TITLE
Set all location updates type to ACTUAL

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -192,14 +192,12 @@ constructor(
 
             override fun onEnhancedLocationChanged(enhancedLocation: Location, intermediateLocations: List<Location>) {
                 logHandler?.v("$TAG Enhanced location received: $enhancedLocation")
-                val locationUpdateType =
-                    if (intermediateLocations.isEmpty()) LocationUpdateType.ACTUAL else LocationUpdateType.PREDICTED
                 enqueue(
                     workerFactory.createWorker(
                         WorkerParams.EnhancedLocationChanged(
                             enhancedLocation,
                             intermediateLocations,
-                            locationUpdateType
+                            LocationUpdateType.ACTUAL, // the predictions are disabled in Mapbox so all locations will be actual
                         )
                     )
                 )


### PR DESCRIPTION
We have disabled prediction in the Mapbox SDK so we will never get a `PREDICTED` location update, therefore all location updates should have the `ACTUAL` type set.