### PR TITLE
Upgrade to the latest Gradle build tools for Crashlytics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
 
         // Firebase Crashlytics
         // see: https://firebase.google.com/docs/crashlytics/get-started?platform=android
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.google.gms:google-services:4.3.14'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
I'm not sure why we were not seeing this in CI, but locally (before this change) when I tried to run `./gradlew check assemble` then it was failing with:

```
> Task :publishing-example-app:mapDebugSourceSetPaths FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':publishing-example-app:mapDebugSourceSetPaths'.
> Error while evaluating property 'extraGeneratedResDir' of task ':publishing-example-app:mapDebugSourceSetPaths'
   > Failed to calculate the value of task ':publishing-example-app:mapDebugSourceSetPaths' property 'extraGeneratedResDir'.
      > Querying the mapped value of provider(interface java.util.Set) before task ':publishing-example-app:processDebugGoogleServices' has completed is not supported
```

For which I found [this Stackoverflow answer](https://stackoverflow.com/a/73774667):

> This issue started after updating the `com.android.tools.build:gradle` to version `7.3.0` and was fixed for me after updating the `com.google.gms:google-services` to version `4.3.14`.

 which strongly suggests that I broke this in https://github.com/ably/ably-asset-tracking-android/pull/838. 🤦 I hadn't locally set myself up for MapBox when I pushed that pull request, so had only verified it in CI, hence why I'm not too surprised that I've only discovered this knock-on effect now.