### PR TITLE
Source the copyright information used by Dokka from our `COPYRIGHT` file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.copyright_message = 'Copyright 2020-2021 Ably Real-time Ltd (ably.com)'
+    ext.copyright_message = (new File('COPYRIGHT')).readLines().get(0)
+
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.


### PR DESCRIPTION
I noticed the copyright range emitted to the rendered Dokka output was only extending to 2021, whereas we had updated the canonical `COPYRIGHT` file earlier this year in https://github.com/ably/ably-asset-tracking-android/pull/601 to extend into 2022.

We're going to need to update that into 2023 very soon, so this change will make that change smaller when it comes.

For those curious as to where the `readLines()` method comes from (it's not in [the `File` API](https://docs.oracle.com/javase/8/docs/api/java/io/File.html)), I initially discovered it via [this Stackoverflow answer](https://stackoverflow.com/a/50051161), but suspected that it was being added by Gradle and/or Groovy. That is, indeed [the case](https://docs.groovy-lang.org/latest/html/groovy-jdk/java/io/File.html#readLines()).