### PR TITLE
Move definition of Android namespaces from manifest package attribute to project Gradle files

### DIFF
--- a/android-test-common/build.gradle
+++ b/android-test-common/build.gradle
@@ -8,3 +8,7 @@ dependencies {
     implementation project(':core-sdk')
     implementation "io.ably:ably-android:$ably_core_version"
 }
+
+android {
+    namespace 'com.ably.tracking.test.android.common'
+}

--- a/android-test-common/src/main/AndroidManifest.xml
+++ b/android-test-common/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.test.android.common">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,7 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-rules.pro'
     }
+    namespace 'com.ably.tracking.common'
 }
 
 ext {

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.common">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core-sdk-java/build.gradle
+++ b/core-sdk-java/build.gradle
@@ -16,4 +16,8 @@ ext {
     PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking shared code that is visible in the Java API."
 }
 
+android {
+    namespace 'com.ably.tracking.java'
+}
+
 apply from: '../publish.gradle'

--- a/core-sdk-java/src/main/AndroidManifest.xml
+++ b/core-sdk-java/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.java">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core-sdk/build.gradle
+++ b/core-sdk/build.gradle
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-rules.pro'
     }
+    namespace 'com.ably.tracking'
 }
 
 ext {

--- a/core-sdk/src/main/AndroidManifest.xml
+++ b/core-sdk/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/integration-testing-app/build.gradle
+++ b/integration-testing-app/build.gradle
@@ -15,6 +15,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.ably.tracking.tests'
 }
 
 dependencies {

--- a/integration-testing-app/src/main/AndroidManifest.xml
+++ b/integration-testing-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.tests">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -19,6 +19,7 @@ android {
         // Required to initialize Mapbox and use MapView in the layout XML files.
         resValue "string", "mapbox_access_token", findProperty('MAPBOX_ACCESS_TOKEN') ?: ""
     }
+    namespace 'com.ably.tracking.example.publisher'
 }
 
 dependencies {

--- a/publishing-example-app/src/main/AndroidManifest.xml
+++ b/publishing-example-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.example.publisher">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 

--- a/publishing-java-testing/build.gradle
+++ b/publishing-java-testing/build.gradle
@@ -6,6 +6,7 @@ android {
     defaultConfig {
         applicationId 'com.ably.tracking.example.javapublisher'
     }
+    namespace 'com.ably.tracking.example.javapublisher'
 }
 
 dependencies {

--- a/publishing-java-testing/src/main/AndroidManifest.xml
+++ b/publishing-java-testing/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.example.javapublisher">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
     android:allowBackup="true"

--- a/publishing-sdk-java/build.gradle
+++ b/publishing-sdk-java/build.gradle
@@ -17,4 +17,8 @@ ext {
     PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Publisher SDK for Java."
 }
 
+android {
+    namespace 'com.ably.tracking.publisher.java'
+}
+
 apply from: '../publish.gradle'

--- a/publishing-sdk-java/src/main/AndroidManifest.xml
+++ b/publishing-sdk-java/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.publisher.java">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -12,6 +12,7 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-rules.pro'
     }
+    namespace 'com.ably.tracking.publisher'
 }
 
 dependencies {

--- a/publishing-sdk/src/main/AndroidManifest.xml
+++ b/publishing-sdk/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.publisher">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/subscribing-example-app/build.gradle
+++ b/subscribing-example-app/build.gradle
@@ -11,6 +11,7 @@ android {
         resValue 'string', 'google_maps_api_key', "${findProperty('GOOGLE_MAPS_API_KEY') ?: ""}"
         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
+    namespace 'com.ably.tracking.example.subscriber'
 }
 
 dependencies {

--- a/subscribing-example-app/src/main/AndroidManifest.xml
+++ b/subscribing-example-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.example.subscriber">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
     android:name=".SubscribingExampleApplication"

--- a/subscribing-java-testing/build.gradle
+++ b/subscribing-java-testing/build.gradle
@@ -6,6 +6,7 @@ android {
     defaultConfig {
         applicationId 'com.ably.tracking.example.javasubscriber'
     }
+    namespace 'com.ably.tracking.example.javasubscriber'
 }
 
 dependencies {

--- a/subscribing-java-testing/src/main/AndroidManifest.xml
+++ b/subscribing-java-testing/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.example.javasubscriber">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
     android:allowBackup="true"

--- a/subscribing-sdk-java/build.gradle
+++ b/subscribing-sdk-java/build.gradle
@@ -17,4 +17,8 @@ ext {
     PUBLISH_POM_DESCRIPTION = "Ably Asset Tracking Subscriber SDK for Java."
 }
 
+android {
+    namespace 'com.ably.tracking.subscriber.java'
+}
+
 apply from: '../publish.gradle'

--- a/subscribing-sdk-java/src/main/AndroidManifest.xml
+++ b/subscribing-sdk-java/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.subscriber.java">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/subscribing-sdk/build.gradle
+++ b/subscribing-sdk/build.gradle
@@ -11,6 +11,7 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-rules.pro'
     }
+    namespace 'com.ably.tracking.subscriber'
 }
 
 dependencies {

--- a/subscribing-sdk/src/main/AndroidManifest.xml
+++ b/subscribing-sdk/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.subscriber">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -16,3 +16,7 @@ dependencies {
 configurations.all {
     resolutionStrategy.force 'org.objenesis:objenesis:2.6'
 }
+
+android {
+    namespace 'com.ably.tracking.test.common'
+}

--- a/test-common/src/main/AndroidManifest.xml
+++ b/test-common/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.test.common">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/ui-sdk-java/build.gradle
+++ b/ui-sdk-java/build.gradle
@@ -16,3 +16,7 @@ dependencies {
 
 apply from: '../jacoco.gradle'
 apply from: '../publish.gradle'
+
+android {
+    namespace 'com.ably.tracking.ui.java'
+}

--- a/ui-sdk-java/src/main/AndroidManifest.xml
+++ b/ui-sdk-java/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ably.tracking.ui.java">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/ui-sdk/build.gradle
+++ b/ui-sdk/build.gradle
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-rules.pro'
     }
+    namespace 'com.ably.tracking.ui'
 }
 
 ext {

--- a/ui-sdk/src/main/AndroidManifest.xml
+++ b/ui-sdk/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ably.tracking.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
Closes #837.

This change was performed for me by Android Studio. See: https://developer.android.com/studio/build/configure-app-module#set-namespace https://developer.android.com/studio/build/agp-upgrade-assistant