### PR TITLE
Upload build reports as artifacts for all connected checks

### DIFF
--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -78,3 +78,24 @@ jobs:
         with:
           name: api-level-${{ matrix.api-level }}-core-sdk-build-reports
           path: core-sdk/build/reports
+
+      - uses: actions/upload-artifact@v2
+        name: Build Reports for publishing-sdk
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
+          path: publishing-sdk/build/reports
+
+      - uses: actions/upload-artifact@v2
+        name: Build Reports for subscribing-example-app
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
+          path: subscribing-example-app/build/reports
+
+      - uses: actions/upload-artifact@v2
+        name: Build Reports for publishing-example-app
+        if: always()
+        with:
+          name: api-level-${{ matrix.api-level }}-publishing-example-app-build-reports
+          path: publishing-example-app/build/reports

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -85,17 +85,3 @@ jobs:
         with:
           name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
           path: publishing-sdk/build/reports
-
-      - uses: actions/upload-artifact@v2
-        name: Build Reports for subscribing-example-app
-        if: always()
-        with:
-          name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
-          path: subscribing-example-app/build/reports
-
-      - uses: actions/upload-artifact@v2
-        name: Build Reports for publishing-example-app
-        if: always()
-        with:
-          name: api-level-${{ matrix.api-level }}-publishing-example-app-build-reports
-          path: publishing-example-app/build/reports


### PR DESCRIPTION
For [a check run](https://github.com/ably/ably-asset-tracking-android/actions/runs/3693590988/jobs/6253753993#step:4:665) I had this log output:

```
> Task :publishing-sdk:connectedDebugAndroidTest
Starting 4 tests on test(AVD) - 7.0

com.ably.tracking.publisher.RequestingNewTokenTest > shouldAddTrackableWhenRenewedTokenHasCapabilityForTrackableId[test(AVD) - 7.0] FAILED 
	java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
Tests on test(AVD) - 7.0 failed: There was 1 failure(s).

> Task :publishing-sdk:connectedDebugAndroidTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':publishing-sdk:connectedDebugAndroidTest'.
> There were failing tests. See the report at: file:///Users/runner/work/ably-asset-tracking-android/ably-asset-tracking-android/publishing-sdk/build/reports/androidTests/connected/index.html
```

But discovered that we weren't uploading build reports for `publishing-sdk` project, so this change addresses that, ~~plus adds upload of reports for other projects containing an `androidTest/` folder that weren't included yet~~ (**EDIT**: nope, I reverted that bit in https://github.com/ably/ably-asset-tracking-android/pull/848/commits/7ee1a653948b77253619ac61c41880a45e0401aa because it added new warnings in the GitHub job summary 😞).

I suspect there may be some build reports that we're uploading from this workflow where the projects aren't running any tests for `connectedCheck`, however I've not invested the time right now into looking at that further (relates to #841). For the time being it's better to have all/more rather than none! 😁 