### PR TITLE
Android Gradle Plugin version 8 readiness

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,11 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -15,8 +17,10 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,17 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
+# With Android Gradle Plugin version 7.3 we're seeing this in console output during 'Configure project' stages:
+#   WARNING: Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0.
+#            To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.
+# This was appearing for any Gradle run, including `./gradlew clean`, so was adding quite a lot of noise.
+# For now we're adding this setting, as suggested by the warning, as there appears to be no impact on build or publish to Sonatype staging.
+# Publish to Sonatype staging, validating that this change does not appear to break our release process, was tested by using close but NOT release:
+#   1. `./gradlew -PpublishTarget=MavenCentral publishToSonatype closeSonatypeStagingRepository`
+#   2. Examine contents at https://s01.oss.sonatype.org/#stagingRepositories
+# For testing DO NOT use the `closeAndReleaseSonatypeStagingRepository` task!
+android.disableAutomaticComponentCreation=true
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 


### PR DESCRIPTION
The change presented in this pull request rids our build logs of warnings that I'm guessing Google added in a recent plugin update to prepare customers for the next major release of the Android Gradle Plugin.

You can see from the commentary I've added that I did some local testing by pushing and closing (but not publishing!) a repository to Sonatype staging with this change in place. The contents of that staging repository looked normal to me but we'll only know for sure when we next perform a publish for this SDK (manually triggered as part of our [release process](https://github.com/ably/ably-asset-tracking-android/blob/main/CONTRIBUTING.md#release-process)).