### PR TITLE
Replace deprecated GitHub actions

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -71,7 +71,7 @@ jobs:
           name: publishing-example-app-debug
           path: publishing-example-app/build/outputs/apk/debug/publishing-example-app-debug.apk
           if-no-files-found: error
- 
+
       - uses: actions/upload-artifact@v2
         with:
           name: publishing-example-app-release-unsigned

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -30,49 +30,49 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: publishing-sdk-debug
           path: publishing-sdk/build/outputs/aar/publishing-sdk-debug.aar
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: publishing-sdk-release
           path: publishing-sdk/build/outputs/aar/publishing-sdk-release.aar
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: subscribing-sdk-debug
           path: subscribing-sdk/build/outputs/aar/subscribing-sdk-debug.aar
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: subscribing-sdk-release
           path: subscribing-sdk/build/outputs/aar/subscribing-sdk-release.aar
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: subscribing-example-app-debug
           path: subscribing-example-app/build/outputs/apk/debug/subscribing-example-app-debug.apk
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: subscribing-example-app-release-unsigned
           path: subscribing-example-app/build/outputs/apk/release/subscribing-example-app-release-unsigned.apk
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: publishing-example-app-debug
           path: publishing-example-app/build/outputs/apk/debug/publishing-example-app-debug.apk
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: publishing-example-app-release-unsigned
           path: publishing-example-app/build/outputs/apk/release/publishing-example-app-release-unsigned.apk

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,56 +29,56 @@ jobs:
       - run: find . -name "index.html"
         if: always()
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for common
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-common-build-reports
           path: common/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for integration-testing-app
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for publishing-example-app
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-publishing-example-app-build-reports
           path: publishing-example-app/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for publishing-java-testing
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-publishing-java-testing-build-reports
           path: publishing-java-testing/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for publishing-sdk
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-publishing-sdk-build-reports
           path: publishing-sdk/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for subscribing-example-app
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-subscribing-example-app-build-reports
           path: subscribing-example-app/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for subscribing-java-testing
         if: always()
         with:
           name: java-version-${{ matrix.java-version }}-subscribing-java-testing-build-reports
           path: subscribing-java-testing/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for subscribing-sdk
         if: always()
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
         # Java 11 is the minimum for Gradle 7, Java 16 is the maximum for Gradle 7
         java-version: [ 11, 16 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-java@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -15,7 +15,7 @@ jobs:
           - api: 21
             excludeModules: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
       - uses: actions/setup-java@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -44,56 +44,56 @@ jobs:
       - run: find . -name "index.html"
         if: always()
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for integration-testing-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-integration-testing-app-build-reports
           path: integration-testing-app/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for core-sdk-java
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-core-sdk-java-build-reports
           path: core-sdk-java/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for common
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-common-build-reports
           path: common/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for android-test-common
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-android-test-common-build-reports
           path: android-test-common/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for core-sdk
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-core-sdk-build-reports
           path: core-sdk/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for publishing-sdk
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-publishing-sdk-build-reports
           path: publishing-sdk/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for subscribing-example-app
         if: always()
         with:
           name: api-level-${{ matrix.api-level }}-subscribing-example-app-build-reports
           path: subscribing-example-app/build/reports
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Build Reports for publishing-example-app
         if: always()
         with:

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Gradle 7 requires Java 11 to run
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: v${{ github.event.inputs.version }}
 

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -22,7 +22,7 @@ jobs:
         ref: v${{ github.event.inputs.version }}
 
     # Gradle 7 requires Java 11 to run
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: '11'

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: v${{ github.event.inputs.version }}
 

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -22,7 +22,7 @@ jobs:
         ref: v${{ github.event.inputs.version }}
 
     # Gradle 7 requires Java 11 to run
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: '11'


### PR DESCRIPTION
We've been seeing warnings like this in CI summaries for a while:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v2, actions/upload-artifact@v2

We've also been seeing warnings like this:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Which I suspect are a side effect of the Node.js-12-based actions using the older `@actions/core` dependency. We'll see for sure once this pull request has run in CI and presented a summary. 🤞 