### PR TITLE
Wrap `ably-java` in a set of interfaces and add example unit test for `DefaultAbly`

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -249,11 +249,12 @@ class DefaultAbly
  * @throws ConnectionException if something goes wrong during Ably SDK initialization.
  */
 constructor(
+    realtimeFactory: AblySdkRealtimeFactory,
     connectionConfiguration: ConnectionConfiguration,
     private val logHandler: LogHandler?,
 ) : Ably {
     private val gson = Gson()
-    private val ably: AblyRealtime
+    private val ably: AblySdkRealtime
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val TAG = createLoggingTag(this)
 
@@ -275,7 +276,7 @@ constructor(
                     )
                 }
             }
-            ably = AblyRealtime(clientOptions)
+            ably = realtimeFactory.create(clientOptions)
         } catch (exception: AblyException) {
             throw exception.errorInfo.toTrackingException().also {
                 logHandler?.w("$TAG Failed to create an Ably instance", it)
@@ -314,7 +315,7 @@ constructor(
      * a new auth token is requested and the operation is retried once more.
      * @throws ConnectionException if something goes wrong or the retry fails
      */
-    private suspend fun enterChannelPresence(channel: Channel, presenceData: PresenceData) {
+    private suspend fun enterChannelPresence(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
         try {
             channel.enterPresenceSuspending(presenceData)
         } catch (connectionException: ConnectionException) {
@@ -439,14 +440,14 @@ constructor(
         }
     }
 
-    private suspend fun tryDisconnectChannel(channelToRemove: Channel, presenceData: PresenceData) =
+    private suspend fun tryDisconnectChannel(channelToRemove: AblySdkRealtime.Channel, presenceData: PresenceData) =
         try {
             disconnectChannel(channelToRemove, presenceData)
         } catch (exception: Exception) {
             // no-op
         }
 
-    private suspend fun disconnectChannel(channelToRemove: Channel, presenceData: PresenceData) {
+    private suspend fun disconnectChannel(channelToRemove: AblySdkRealtime.Channel, presenceData: PresenceData) {
         retryChannelOperationIfConnectionResumeFails(channelToRemove) { channel ->
             leavePresence(channel, presenceData)
             channel.unsubscribe()
@@ -455,7 +456,7 @@ constructor(
         }
     }
 
-    private suspend fun failChannel(channel: Channel, presenceData: PresenceData, errorInfo: ErrorInfo) {
+    private suspend fun failChannel(channel: AblySdkRealtime.Channel, presenceData: PresenceData, errorInfo: ErrorInfo) {
         leavePresence(channel, presenceData)
         channel.unsubscribe()
         channel.presence.unsubscribe()
@@ -464,7 +465,7 @@ constructor(
         ably.channels.release(channel.name)
     }
 
-    private suspend fun leavePresence(channel: Channel, presenceData: PresenceData) {
+    private suspend fun leavePresence(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.presence.leave(
@@ -549,7 +550,7 @@ constructor(
         }
     }
 
-    private fun sendMessage(channel: Channel, message: Message?, callback: (Result<Unit>) -> Unit) {
+    private fun sendMessage(channel: AblySdkRealtime.Channel, message: Message?, callback: (Result<Unit>) -> Unit) {
         scope.launch {
             try {
                 retryChannelOperationIfConnectionResumeFails(channel) {
@@ -563,7 +564,7 @@ constructor(
         }
     }
 
-    private suspend fun sendMessage(channel: Channel, message: Message?) {
+    private suspend fun sendMessage(channel: AblySdkRealtime.Channel, message: Message?) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.publish(
@@ -638,7 +639,7 @@ constructor(
     }
 
     private fun processReceivedLocationUpdateMessage(
-        channel: Channel,
+        channel: AblySdkRealtime.Channel,
         presenceData: PresenceData,
         message: Message,
         listener: (LocationUpdate) -> Unit,
@@ -698,7 +699,7 @@ constructor(
         }
     }
 
-    private fun emitAllCurrentMessagesFromPresence(channel: Channel, listener: (PresenceMessage) -> Unit) {
+    private fun emitAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel, listener: (PresenceMessage) -> Unit) {
         getAllCurrentMessagesFromPresence(channel).forEach { presenceMessage ->
             // Each message is launched in a fire-and-forget manner to not block this method on the listener() call
             scope.launch { listener(presenceMessage) }
@@ -722,7 +723,7 @@ constructor(
     /**
      * Warning: This method might block the current thread due to the presence.get(true) call.
      */
-    private fun getAllCurrentMessagesFromPresence(channel: Channel): List<PresenceMessage> =
+    private fun getAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel): List<PresenceMessage> =
         channel.presence.get(true).mapNotNull { presenceMessage ->
             presenceMessage.toTracking(gson).also {
                 if (it == null) {
@@ -751,7 +752,7 @@ constructor(
         }
     }
 
-    private suspend fun updatePresenceData(channel: Channel, presenceData: PresenceData) {
+    private suspend fun updatePresenceData(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.presence.update(
@@ -777,7 +778,7 @@ constructor(
         }
     }
 
-    private fun getChannelIfExists(trackableId: String): Channel? {
+    private fun getChannelIfExists(trackableId: String): AblySdkRealtime.Channel? {
         val channelName = trackableId.toChannelName()
         return if (ably.channels.containsKey(channelName)) {
             ably.channels.get(channelName)
@@ -799,14 +800,14 @@ constructor(
     }
 
     /**
-     * Closes [AblyRealtime] and waits until it's either closed or failed.
+     * Closes [AblySdkRealtime] and waits until it's either closed or failed.
      * If the connection is already closed it returns immediately.
      * If the connection is already failed it returns immediately as closing a failed connection should be a no-op
      * according to the Ably features spec (https://sdk.ably.com/builds/ably/specification/main/features/#state-conditions-and-operations).
      *
-     * @throws ConnectionException if the [AblyRealtime] state changes to [ConnectionState.failed].
+     * @throws ConnectionException if the [AblySdkRealtime] state changes to [ConnectionState.failed].
      */
-    private suspend fun AblyRealtime.closeSuspending() {
+    private suspend fun AblySdkRealtime.closeSuspending() {
         if (connection.state.isClosed() || connection.state.isFailed()) {
             return
         }
@@ -833,8 +834,8 @@ constructor(
      * the second time the exception is rethrown no matter if it was the "connection resume" exception or not.
      */
     private suspend fun retryChannelOperationIfConnectionResumeFails(
-        channel: Channel,
-        operation: suspend (Channel) -> Unit
+        channel: AblySdkRealtime.Channel,
+        operation: suspend (AblySdkRealtime.Channel) -> Unit
     ) {
         try {
             if (channel.state == ChannelState.suspended) {
@@ -869,7 +870,7 @@ constructor(
      * If the [channel] state already is the [ChannelState.attached] state it does not wait and returns immediately.
      * If this doesn't happen during the next [timeoutInMilliseconds] milliseconds, then an exception is thrown.
      */
-    private suspend fun waitForChannelReconnection(channel: Channel, timeoutInMilliseconds: Long = 10_000L) {
+    private suspend fun waitForChannelReconnection(channel: AblySdkRealtime.Channel, timeoutInMilliseconds: Long = 10_000L) {
         if (channel.state.isConnected()) {
             return
         }
@@ -908,7 +909,7 @@ constructor(
      * Enter the presence of the [Channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun Channel.enterPresenceSuspending(presenceData: PresenceData) {
+    private suspend fun AblySdkRealtime.Channel.enterPresenceSuspending(presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 presence.enter(
@@ -935,10 +936,10 @@ constructor(
     }
 
     /**
-     * Attaches the [Channel] and waits for this operation to complete.
+     * Attaches the [AblySdkRealtime.Channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun Channel.attachSuspending() {
+    private suspend fun AblySdkRealtime.Channel.attachSuspending() {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 attach(object : CompletionListener {
@@ -961,7 +962,7 @@ constructor(
         }
     }
 
-    private fun Channel.isDetachedOrFailed(): Boolean =
+    private fun AblySdkRealtime.Channel.isDetachedOrFailed(): Boolean =
         state == ChannelState.detached || state == ChannelState.failed
 
     private fun createMalformedMessageErrorInfo(): ErrorInfo = ErrorInfo("Received a malformed message", 100_001, 400)
@@ -987,7 +988,7 @@ constructor(
     }
 
     /**
-     * A suspending version of the [AblyRealtime.connect] method. It will begin connecting and wait until it's connected.
+     * A suspending version of the [AblySdkRealtime.connect] method. It will begin connecting and wait until it's connected.
      * If the connection enters the "failed" state it will throw a [ConnectionException].
      * If the operation doesn't complete in [timeoutInMilliseconds] it will throw a [ConnectionException].
      * If the instance is already connected it will finish immediately.
@@ -995,11 +996,12 @@ constructor(
      *
      * @throws ConnectionException if something goes wrong.
      */
-    private suspend fun AblyRealtime.connectSuspending(timeoutInMilliseconds: Long = 10_000L) {
+    private suspend fun AblySdkRealtime.connectSuspending(timeoutInMilliseconds: Long = 10_000L) {
         if (connection.state.isConnected()) {
             return
         } else if (connection.state.isFailed()) {
-            throw connection.reason.toTrackingException()
+            // We expect connection.reason to be non-null if the connection is in a failed state
+            throw connection.reason!!.toTrackingException()
         }
         try {
             withTimeout(timeoutInMilliseconds) {

--- a/common/src/main/java/com/ably/tracking/common/AblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblySdk.kt
@@ -1,0 +1,81 @@
+package com.ably.tracking.common
+
+import io.ably.lib.realtime.Channel.MessageListener
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.ChannelStateListener
+import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.realtime.ConnectionState
+import io.ably.lib.realtime.ConnectionStateListener
+import io.ably.lib.realtime.Presence.PresenceListener
+import io.ably.lib.rest.Auth.RenewAuthResult
+import io.ably.lib.types.ChannelOptions
+import io.ably.lib.types.ClientOptions
+import io.ably.lib.types.ErrorInfo
+import io.ably.lib.types.Message
+import io.ably.lib.types.PresenceMessage
+
+interface AblySdkRealtimeFactory {
+    fun create(clientOptions: ClientOptions): AblySdkRealtime
+}
+
+/**
+ * An set of interfaces that represent the parts of the Ably client library which are used by the Ably Asset Tracking SDKs.
+ *
+ * These exist so that we can mock out the Ably client library when testing the [DefaultAbly] class. The interfaces here are more or less a direct copy of the corresponding `ably-java` classes, and are expected to exhibit the same behaviour. They do remove some details that would be overkill here, such as class hierarchies and interface conformances, instead opting to add these inherited properties and methods directly on the interfaces.
+ *
+ * The aim here is _not_ to remove the usage of all `ably-java` types; we continue using types from that codebase if they are just interfaces or are easy to construct. We just intend to use interfaces to replace `ably-java` classes that would be hard to mock.
+ *
+ * `ably-java` doesn’t currently have nullability annotations (see [issue #639](https://github.com/ably/ably-java/issues/639) there), so when writing these interfaces we need to make our own judgements about nullability, based on our knowledge of the behaviour of the Ably client libraries.
+ */
+interface AblySdkRealtime {
+    val auth: Auth
+    val connection: Connection
+    val channels: Channels
+
+    fun connect()
+    fun close()
+
+    interface Auth {
+        fun renewAuth(result: RenewAuthResult)
+    }
+
+    interface Channel {
+        val name: String
+        val state: ChannelState
+        val presence: Presence
+
+        fun attach(listener: CompletionListener)
+        fun publish(message: Message?, listener: CompletionListener)
+        fun on(listener: ChannelStateListener)
+        fun off(listener: ChannelStateListener)
+        fun off()
+        fun subscribe(name: String, listener: MessageListener)
+        fun unsubscribe()
+        fun setConnectionFailed(reason: ErrorInfo)
+    }
+
+    interface Presence {
+        fun subscribe(listener: PresenceListener)
+        fun unsubscribe()
+        fun get(wait: Boolean): Array<PresenceMessage>
+        fun enter(data: Any, listener: CompletionListener)
+        fun update(data: Any, listener: CompletionListener)
+        fun leave(data: Any, listener: CompletionListener)
+    }
+
+    interface Channels {
+        fun get(channelName: String, channelOptions: ChannelOptions?): Channel
+        fun get(channelName: String): Channel
+        fun entrySet(): Iterable<Map.Entry<String, Channel>>
+        fun containsKey(key: Any): Boolean
+        fun release(channelName: String)
+    }
+
+    interface Connection {
+        val state: ConnectionState
+        val reason: ErrorInfo?
+
+        fun on(listener: ConnectionStateListener)
+        fun off(listener: ConnectionStateListener)
+    }
+}

--- a/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
@@ -1,0 +1,165 @@
+package com.ably.tracking.common
+
+import io.ably.lib.realtime.AblyRealtime
+import io.ably.lib.realtime.Channel.MessageListener
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.ChannelStateListener
+import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.realtime.ConnectionState
+import io.ably.lib.realtime.ConnectionStateListener
+import io.ably.lib.realtime.Presence.PresenceListener
+import io.ably.lib.rest.Auth.RenewAuthResult
+import io.ably.lib.types.ChannelOptions
+import io.ably.lib.types.ClientOptions
+import io.ably.lib.types.ErrorInfo
+import io.ably.lib.types.Message
+import io.ably.lib.types.PresenceMessage
+
+/**
+ * An implementation of [AblySdkRealtimeFactory] which uses the `ably-java` client library.
+ */
+class DefaultAblySdkRealtimeFactory : AblySdkRealtimeFactory {
+    override fun create(clientOptions: ClientOptions): AblySdkRealtime {
+        return DefaultAblySdkRealtime(clientOptions)
+    }
+}
+
+class DefaultAblySdkRealtime
+constructor(clientOptions: ClientOptions) : AblySdkRealtime {
+    private val realtime = AblyRealtime(clientOptions)
+
+    override val auth = Auth(realtime.auth)
+    override val connection = Connection(realtime.connection)
+    override val channels = Channels(realtime.channels)
+
+    override fun connect() {
+        realtime.connect()
+    }
+
+    override fun close() {
+        realtime.close()
+    }
+
+    class Auth
+    constructor(private val auth: io.ably.lib.rest.Auth) : AblySdkRealtime.Auth {
+        override fun renewAuth(result: RenewAuthResult) {
+            auth.renewAuth(result)
+        }
+    }
+
+    class Connection
+    constructor(private val connection: io.ably.lib.realtime.Connection) :
+        AblySdkRealtime.Connection {
+        override val state: ConnectionState
+            get() = connection.state
+        override val reason: ErrorInfo?
+            get() = connection.reason
+
+        override fun on(listener: ConnectionStateListener) {
+            connection.on(listener)
+        }
+
+        override fun off(listener: ConnectionStateListener) {
+            connection.off(listener)
+        }
+    }
+
+    class Channels
+    constructor(private val channels: AblyRealtime.Channels) : AblySdkRealtime.Channels {
+        override fun get(
+            channelName: String,
+            channelOptions: ChannelOptions?
+        ): AblySdkRealtime.Channel {
+            return Channel(channels.get(channelName, channelOptions))
+        }
+
+        override fun get(channelName: String): AblySdkRealtime.Channel {
+            return Channel(channels.get(channelName))
+        }
+
+        override fun containsKey(key: Any): Boolean {
+            return channels.containsKey(key)
+        }
+
+        override fun release(channelName: String) {
+            channels.release(channelName)
+        }
+
+        override fun entrySet(): Iterable<Map.Entry<String, AblySdkRealtime.Channel>> {
+            return channels.entrySet().map { entry ->
+                object : Map.Entry<String, AblySdkRealtime.Channel> {
+                    override val key = entry.key
+                    override val value = Channel(entry.value)
+                }
+            }
+        }
+    }
+
+    class Channel
+    constructor(private val channel: io.ably.lib.realtime.Channel) : AblySdkRealtime.Channel {
+        override val name = channel.name
+        override val state: ChannelState
+            get() = channel.state
+        override val presence = Presence(channel.presence)
+
+        override fun attach(listener: CompletionListener) {
+            channel.attach(listener)
+        }
+
+        override fun on(listener: ChannelStateListener) {
+            channel.on(listener)
+        }
+
+        override fun off(listener: ChannelStateListener) {
+            channel.off(listener)
+        }
+
+        override fun off() {
+            channel.off()
+        }
+
+        override fun publish(message: Message?, listener: CompletionListener) {
+            channel.publish(message, listener)
+        }
+
+        override fun subscribe(name: String, listener: MessageListener) {
+            channel.subscribe(name, listener)
+        }
+
+        override fun unsubscribe() {
+            channel.unsubscribe()
+        }
+
+        override fun setConnectionFailed(reason: ErrorInfo) {
+            channel.setConnectionFailed(reason)
+        }
+
+        class Presence
+        constructor(private val presence: io.ably.lib.realtime.Presence) :
+            AblySdkRealtime.Presence {
+            override fun subscribe(listener: PresenceListener) {
+                presence.subscribe(listener)
+            }
+
+            override fun unsubscribe() {
+                presence.unsubscribe()
+            }
+
+            override fun get(wait: Boolean): Array<PresenceMessage> {
+                return presence.get(wait)
+            }
+
+            override fun enter(data: Any, listener: CompletionListener) {
+                return presence.enter(data, listener)
+            }
+
+            override fun update(data: Any, listener: CompletionListener) {
+                return presence.update(data, listener)
+            }
+
+            override fun leave(data: Any, listener: CompletionListener) {
+                return presence.leave(data, listener)
+            }
+        }
+    }
+}

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -1,0 +1,48 @@
+package com.ably.tracking.common
+
+import com.ably.tracking.connection.Authentication
+import com.ably.tracking.connection.ConnectionConfiguration
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.CompletionListener
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class DefaultAblyTests {
+    // This is just an example test to check that the AblySdkRealtime mocks are working correctly. We need to add a full set of unit tests for DefaultAbly; see https://github.com/ably/ably-asset-tracking-android/issues/869
+    @Test
+    fun `connect fetches the channel and then enters presence on it, and when that succeeds the call to connect succeeds`() {
+        val presence = mockk<AblySdkRealtime.Presence>()
+        val completionListenerSlot = slot<CompletionListener>()
+        every { presence.enter(any(), capture(completionListenerSlot)) } answers { completionListenerSlot.captured.onSuccess() }
+
+        val channel = mockk<AblySdkRealtime.Channel>()
+        every { channel.state } returns ChannelState.initialized
+        every { channel.presence } returns presence
+
+        val channels = mockk<AblySdkRealtime.Channels>()
+        every { channels.containsKey(any()) } returns false
+        every { channels.get("tracking:someTrackableId", any()) } returns channel
+
+        val ably = mockk<AblySdkRealtime>()
+        every { ably.channels } returns channels
+
+        val factory = mockk<AblySdkRealtimeFactory>()
+        every { factory.create(any()) } returns ably
+
+        val configuration = ConnectionConfiguration(Authentication.basic("someClientId", "someApiKey"))
+        val client = DefaultAbly(factory, configuration, null)
+
+        runBlocking {
+            client.connect("someTrackableId", PresenceData(""))
+        }
+
+        verify {
+            channels.get("tracking:someTrackableId", any())
+            presence.enter(any(), any())
+        }
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
+import com.ably.tracking.common.DefaultAblySdkRealtimeFactory
 import com.ably.tracking.common.logging.createLoggingTag
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -81,7 +82,7 @@ internal data class PublisherBuilder(
         logHandler?.v("$TAG Creating a publisher instance")
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultPublisher(
-            DefaultAbly(connectionConfiguration!!, logHandler),
+            DefaultAbly(DefaultAblySdkRealtimeFactory(), connectionConfiguration!!, logHandler),
             DefaultMapbox(
                 androidContext!!,
                 mapConfiguration!!,

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
+import com.ably.tracking.common.DefaultAblySdkRealtimeFactory
 import com.ably.tracking.common.logging.createLoggingTag
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -36,7 +37,7 @@ internal data class SubscriberBuilder(
         logHandler?.v("$TAG Creating a subscriber instance")
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultSubscriber(
-            DefaultAbly(connectionConfiguration!!, logHandler),
+            DefaultAbly(DefaultAblySdkRealtimeFactory(), connectionConfiguration!!, logHandler),
             resolution,
             trackingId!!,
             logHandler,


### PR DESCRIPTION
This introduces a set of interfaces, `AblySDK*`, which represent all of the functionality of `ably-java` used by this SDK.

This allows us to mock out `ably-java` in unit tests and hence to write unit tests for `DefaultAbly`, which is currently untested (I've created #869 for writing tests for all the existing behaviour of that class).

I’ve also added one example unit test for `DefaultAbly`, just to confirm the new interfaces are fit for purpose.

See commit messages for more details.