### PR TITLE
Remove `TimeoutCancellationException` from `Publisher.stop`

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,5 +1,23 @@
 # Upgrade / Migration Guide
 
+## Version 1.5.1 to 1.6.0
+
+### Removed user-specified timeout from `Publisher.stop`
+
+It is no longer possible to specify a timeout for the `Publisher.stop` operation. The `timeoutInMilliseconds` parameter has been deprecated and will be ignored.
+
+If you do not wish to wait indefinitely for this operation to complete, we recommend using [Kotlin’s `withTimeout`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout.html) to implement a timeout yourself. For example:
+
+```kotlin
+try {
+    withTimeout(timeMillis = 20_000) {
+        publisher.stop()
+    }
+} catch (e: TimeoutCancellationException) {
+    // Choose how to you want to respond to the timeout, by example for calling publisher.stop() again to retry
+}
+```
+
 ## Version 1.3.0 to 1.4.0
 
 ### Token based auth configuration

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -18,7 +18,6 @@ import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import com.google.gson.Gson
 import io.ably.lib.realtime.AblyRealtime
-import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.ChannelStateListener
 import io.ably.lib.realtime.CompletionListener
@@ -317,7 +316,7 @@ constructor(
      */
     private suspend fun enterChannelPresence(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
         try {
-            channel.enterPresenceSuspending(presenceData)
+            enterPresenceSuspending(channel, presenceData)
         } catch (connectionException: ConnectionException) {
             if (connectionException.errorInformation.code == AUTH_TOKEN_CAPABILITY_ERROR_CODE) {
                 val renewAuthResult = renewAuthSuspending()
@@ -326,8 +325,8 @@ constructor(
                     logHandler?.w("$TAG Failed to renew auth while entering the presence of channel ${channel.name}", it.toTrackingException())
                     throw it.toTrackingException()
                 }
-                channel.attachSuspending()
-                channel.enterPresenceSuspending(presenceData)
+                attachSuspending(channel)
+                enterPresenceSuspending(channel, presenceData)
             } else {
                 logHandler?.w("$TAG Failed to enter the presence of channel ${channel.name}", connectionException)
                 throw connectionException
@@ -367,7 +366,7 @@ constructor(
                 scope.launch {
                     try {
                         if (channel.isDetachedOrFailed()) {
-                            channel.attachSuspending()
+                            attachSuspending(channel)
                         }
                         enterChannelPresence(channel, presenceData)
                         callback(Result.success(Unit))
@@ -800,30 +799,30 @@ constructor(
     }
 
     /**
-     * Closes [AblySdkRealtime] and waits until it's either closed or failed.
+     * Closes [ably] and waits until it's either closed or failed.
      * If the connection is already closed it returns immediately.
      * If the connection is already failed it returns immediately as closing a failed connection should be a no-op
      * according to the Ably features spec (https://sdk.ably.com/builds/ably/specification/main/features/#state-conditions-and-operations).
      *
      * @throws ConnectionException if the [AblySdkRealtime] state changes to [ConnectionState.failed].
      */
-    private suspend fun AblySdkRealtime.closeSuspending() {
-        if (connection.state.isClosed() || connection.state.isFailed()) {
+    private suspend fun closeSuspending() {
+        if (ably.connection.state.isClosed() || ably.connection.state.isFailed()) {
             return
         }
         suspendCancellableCoroutine<Unit> { continuation ->
-            connection.on(object : ConnectionStateListener {
+            ably.connection.on(object : ConnectionStateListener {
                 override fun onConnectionStateChanged(connectionStateChange: ConnectionStateListener.ConnectionStateChange) {
                     if (connectionStateChange.current.isClosed()) {
-                        connection.off(this)
+                        ably.connection.off(this)
                         continuation.resume(Unit)
                     } else if (connectionStateChange.current.isFailed()) {
-                        connection.off(this)
+                        ably.connection.off(this)
                         continuation.resumeWithException(connectionStateChange.reason.toTrackingException())
                     }
                 }
             })
-            close()
+            ably.close()
         }
     }
 
@@ -906,13 +905,13 @@ constructor(
         errorInformation.let { it.message == "Connection resume failed" && it.code == 50000 && it.statusCode == 500 }
 
     /**
-     * Enter the presence of the [Channel] and waits for this operation to complete.
+     * Enter the presence of [channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun AblySdkRealtime.Channel.enterPresenceSuspending(presenceData: PresenceData) {
+    private suspend fun enterPresenceSuspending(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
-                presence.enter(
+                channel.presence.enter(
                     gson.toJson(presenceData.toMessage()),
                     object : CompletionListener {
                         override fun onSuccess() {
@@ -921,42 +920,42 @@ constructor(
 
                         override fun onError(reason: ErrorInfo?) {
                             val trackingException = reason?.toTrackingException()
-                                ?: ConnectionException(ErrorInformation("Unknown error when entering presence $name"))
-                            logHandler?.w("$TAG Failed to suspend enter presence for channel $name", trackingException)
+                                ?: ConnectionException(ErrorInformation("Unknown error when entering presence $channel.name"))
+                            logHandler?.w("$TAG Failed to suspend enter presence for channel $channel.name", trackingException)
                             continuation.resumeWithException(trackingException)
                         }
                     }
                 )
             } catch (ablyException: AblyException) {
                 val trackingException = ablyException.errorInfo.toTrackingException()
-                logHandler?.w("$TAG Failed to suspend enter presence for channel $name", trackingException)
+                logHandler?.w("$TAG Failed to suspend enter presence for channel $channel.name", trackingException)
                 continuation.resumeWithException(trackingException)
             }
         }
     }
 
     /**
-     * Attaches the [AblySdkRealtime.Channel] and waits for this operation to complete.
+     * Attaches [channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun AblySdkRealtime.Channel.attachSuspending() {
+    private suspend fun attachSuspending(channel: AblySdkRealtime.Channel) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
-                attach(object : CompletionListener {
+                channel.attach(object : CompletionListener {
                     override fun onSuccess() {
                         continuation.resume(Unit)
                     }
 
                     override fun onError(reason: ErrorInfo?) {
                         val trackingException = reason?.toTrackingException()
-                            ?: ConnectionException(ErrorInformation("Unknown error when attaching channel $name"))
-                        logHandler?.w("$TAG Failed to suspend attach to channel $name", trackingException)
+                            ?: ConnectionException(ErrorInformation("Unknown error when attaching channel $channel.name"))
+                        logHandler?.w("$TAG Failed to suspend attach to channel $channel.name", trackingException)
                         continuation.resumeWithException(trackingException)
                     }
                 })
             } catch (ablyException: AblyException) {
                 val trackingException = ablyException.errorInfo.toTrackingException()
-                logHandler?.w("$TAG Failed to suspend attach to channel $name", trackingException)
+                logHandler?.w("$TAG Failed to suspend attach to channel $channel.name", trackingException)
                 continuation.resumeWithException(trackingException)
             }
         }
@@ -969,7 +968,7 @@ constructor(
 
     override suspend fun startConnection(): Result<Unit> {
         return try {
-            ably.connectSuspending()
+            connectSuspending()
             Result.success(Unit)
         } catch (connectionException: ConnectionException) {
             logHandler?.w("$TAG Failed to start Ably connection", connectionException)
@@ -979,7 +978,7 @@ constructor(
 
     override suspend fun stopConnection(): Result<Unit> {
         return try {
-            ably.closeSuspending()
+            closeSuspending()
             Result.success(Unit)
         } catch (connectionException: ConnectionException) {
             logHandler?.w("$TAG Failed to stop Ably connection", connectionException)
@@ -988,7 +987,7 @@ constructor(
     }
 
     /**
-     * A suspending version of the [AblySdkRealtime.connect] method. It will begin connecting and wait until it's connected.
+     * A suspending version of the [AblySdkRealtime.connect] method. It will begin connecting [ably] and wait until it's connected.
      * If the connection enters the "failed" state it will throw a [ConnectionException].
      * If the operation doesn't complete in [timeoutInMilliseconds] it will throw a [ConnectionException].
      * If the instance is already connected it will finish immediately.
@@ -996,31 +995,31 @@ constructor(
      *
      * @throws ConnectionException if something goes wrong.
      */
-    private suspend fun AblySdkRealtime.connectSuspending(timeoutInMilliseconds: Long = 10_000L) {
-        if (connection.state.isConnected()) {
+    private suspend fun connectSuspending(timeoutInMilliseconds: Long = 10_000L) {
+        if (ably.connection.state.isConnected()) {
             return
-        } else if (connection.state.isFailed()) {
+        } else if (ably.connection.state.isFailed()) {
             // We expect connection.reason to be non-null if the connection is in a failed state
-            throw connection.reason!!.toTrackingException()
+            throw ably.connection.reason!!.toTrackingException()
         }
         try {
             withTimeout(timeoutInMilliseconds) {
                 suspendCancellableCoroutine<Unit> { continuation ->
-                    connection.on(object : ConnectionStateListener {
+                    ably.connection.on(object : ConnectionStateListener {
                         override fun onConnectionStateChanged(connectionStateChange: ConnectionStateListener.ConnectionStateChange) {
                             when {
                                 connectionStateChange.current.isConnected() -> {
-                                    connection.off(this)
+                                    ably.connection.off(this)
                                     continuation.resume(Unit)
                                 }
                                 connectionStateChange.current.isFailed() -> {
-                                    connection.off(this)
+                                    ably.connection.off(this)
                                     continuation.resumeWithException(connectionStateChange.reason.toTrackingException())
                                 }
                             }
                         }
                     })
-                    connect()
+                    ably.connect()
                 }
             }
         } catch (exception: TimeoutCancellationException) {

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -2,6 +2,10 @@ package com.ably.tracking.common
 
 import com.ably.tracking.common.helper.DefaultAblyTestEnvironment
 import io.mockk.verify
+import io.mockk.verifyOrder
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.ConnectionState
+import io.ably.lib.types.ErrorInfo
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
@@ -24,5 +28,131 @@ class DefaultAblyTests {
             testEnvironment.channelsMock.get(configuredChannel.channelName, any())
             configuredChannel.presenceMock.enter(any(), any())
         }
+    }
+
+    @Test
+    fun `close - behaviour when all presence leave calls succeed`() {
+        // Given...
+        // ...that the Realtime instance has 3 channels...
+        val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 3)
+
+        // ...and that each of these channels...
+        for (configuredChannel in testEnvironment.configuredChannels) {
+            configuredChannel.mockName()
+            // ...is in the ATTACHED state...
+            configuredChannel.mockState(ChannelState.attached)
+
+            // ...and, when asked to leave presence, does so successfully...
+            configuredChannel.mockSuccessfulPresenceLeave()
+            configuredChannel.stubUnsubscribe()
+            configuredChannel.stubPresenceUnsubscribe()
+            testEnvironment.stubRelease(configuredChannel)
+        }
+
+        testEnvironment.mockChannelsEntrySet()
+
+        // ...and the Realtime instance is in the CONNECTED state...
+        testEnvironment.mockConnectionState(ConnectionState.connected)
+        // ...and, when asked to close the connection, emits an error-free state change from CONNECTED to CLOSED,
+        testEnvironment.mockCloseToEmitStateChange(
+            previous = ConnectionState.connected,
+            current = ConnectionState.closed,
+            retryIn = 0,
+            reason = null
+        )
+        testEnvironment.stubConnectionOff()
+
+        // When...
+        runBlocking {
+            // ... we call `close` on the object under test,
+            testEnvironment.objectUnderTest.close(PresenceData("" /* arbitrary value */))
+        }
+
+        // Then...
+        verifyOrder {
+            // ...each of the channels...
+            for (configuredChannel in testEnvironment.configuredChannels) {
+                // ...is asked to leave presence....
+                configuredChannel.presenceMock.leave(any(), any())
+                // ...and then to unsubscribe from channel and presence messages...
+                configuredChannel.channelMock.unsubscribe()
+                configuredChannel.presenceMock.unsubscribe()
+                // ...and then gets released...
+                testEnvironment.channelsMock.release(configuredChannel.channelName)
+            }
+            // ...and the Realtime instance is asked to close the connection...
+            // (Note that although it's a desired behaviour, we are not here testing that the Realtime instance is only asked to close the connection _after_ the call to leave presence have finished execution. Because it seemed like it would make the test more complicated.)
+            testEnvironment.realtimeMock.close()
+        }
+
+        // ...and (implicitly from the When), the call to `close` (on the object under test) succeeds.
+    }
+
+    @Test
+    fun `close - behaviour when some presence leave calls succeed and others fail`() {
+        // Given...
+        // ...that the Realtime instance has 3 channels...
+        val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 3)
+
+        testEnvironment.configuredChannels.forEachIndexed { i, configuredChannel ->
+            configuredChannel.mockName()
+            // ...and that each of these channels is in the ATTACHED state...
+            configuredChannel.mockState(ChannelState.attached)
+
+            // ...and that, when asked to leave presence, one of the channels fails to do so and the other two do so successfully...
+            if (i == 0) {
+                configuredChannel.mockFailedPresenceLeave(
+                    ErrorInfo(
+                        "abc",
+                        500 /* both values arbitrarily chosen */
+                    )
+                )
+            } else {
+                configuredChannel.mockSuccessfulPresenceLeave()
+            }
+            configuredChannel.stubUnsubscribe()
+            configuredChannel.stubPresenceUnsubscribe()
+            testEnvironment.stubRelease(configuredChannel)
+        }
+
+        testEnvironment.mockChannelsEntrySet()
+
+        // ...and the Realtime instance is in the CONNECTED state...
+        testEnvironment.mockConnectionState(ConnectionState.connected)
+        // ...and, when asked to close the connection, emits an error-free state change from CONNECTED to CLOSED,
+        testEnvironment.mockCloseToEmitStateChange(
+            previous = ConnectionState.connected,
+            current = ConnectionState.closed,
+            retryIn = 0,
+            reason = null
+        )
+        testEnvironment.stubConnectionOff()
+
+        // When...
+        runBlocking {
+            // ... we call `close` on the object under test,
+            testEnvironment.objectUnderTest.close(PresenceData("" /* arbitrary value */))
+        }
+
+        // Then...
+        verifyOrder {
+            testEnvironment.configuredChannels.forEachIndexed { i, configuredChannel ->
+                // ...each of the channels is asked to leave presence...
+                configuredChannel.presenceMock.leave(any(), any())
+
+                if (i != 0) {
+                    // ...and each of the channels which successfully left presence is then asked to unsubscribe from channel and presence messages...
+                    configuredChannel.channelMock.unsubscribe()
+                    configuredChannel.presenceMock.unsubscribe()
+                    // ...and then gets released...
+                    testEnvironment.channelsMock.release(configuredChannel.channelName)
+                }
+            }
+            // ...and the Realtime instance is asked to close the connection...
+            // (Note that although it's a desired behaviour, we are not here testing that the Realtime instance is only asked to close the connection _after_ all of the calls to leave presence have finished execution. Because it seemed like it would make the test more complicated.)
+            testEnvironment.realtimeMock.close()
+        }
+
+        // ...and (implicitly from the When), the call to `close` (on the object under test) succeeds.
     }
 }

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -1,0 +1,142 @@
+package com.ably.tracking.common.helper
+
+import com.ably.tracking.common.AblySdkRealtime
+import com.ably.tracking.common.AblySdkRealtimeFactory
+import com.ably.tracking.common.DefaultAbly
+import com.ably.tracking.connection.Authentication
+import com.ably.tracking.connection.ConnectionConfiguration
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.CompletionListener
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+/**
+ * Provides an environment for creating and testing an instance of [DefaultAbly].
+ *
+ * It creates mock objects to represent the components of the Ably client library, and uses these to configure and create an instance of [DefaultAbly].
+ * It exposes this instance as the [objectUnderTest] property, and also exposes the configured mocks so that each test case can perform verifications on them.
+ */
+class DefaultAblyTestEnvironment private constructor(
+    /**
+     * The [DefaultAbly] object created by [create].
+     * It has been configured with an [AblySdkRealtimeFactory] mock that supplies [realtimeMock].
+     */
+    val objectUnderTest: DefaultAbly,
+    /**
+     * The [AblySdkRealtime] mock created by [create].
+     * Its [AblySdkRealtime.channels] property returns [channelsMock].
+     */
+    val realtimeMock: AblySdkRealtime,
+    /**
+     * The [AblySdkRealtime.Channels] mock which [create] has created and configured [realtimeMock]’s [AblySdkRealtime.channels] property to return.
+     * See the documentation for that method for details of how this mock is configured.
+     */
+    val channelsMock: AblySdkRealtime.Channels,
+    /**
+     * The set of [AblySdkRealtime.Channel] mocks that [create] has configured [channelsMock] to supply.
+     * See the documentation for that method for details of how these mocks are configured.
+     */
+    val configuredChannels: List<ConfiguredChannel>
+) {
+    /**
+     * The details of a an [AblySdkRealtime.Channel] mock that [create] has configured [channelsMock] to supply.
+     */
+    class ConfiguredChannel(
+        /**
+         * The ID of the trackable to which this mocked channel corresponds. This is provided as a convenience for test cases.
+         */
+        val trackableId: String,
+        /**
+         * The name of the channel to which [channelMock] corresponds.
+         */
+        val channelName: String,
+        /**
+         * The [AblySdkRealtime.Channel] mock created by [create].
+         * See the documentation for that method for details of how this mock is configured.
+         * Its [AblySdkRealtime.Channel.presence] property returns [presenceMock].
+         */
+        val channelMock: AblySdkRealtime.Channel,
+        /**
+         * The [AblySdkRealtime.Presence] mock which [create] has created and configured [channelMock]’s [AblySdkRealtime.Channel.presence] property to return.
+         */
+        val presenceMock: AblySdkRealtime.Presence
+    ) {
+        /**
+         * Mocks [presenceMock]’s [AblySdkRealtime.Presence.enter] method to immediately call its received completion listener’s [CompletionListener.onSuccess] method.
+         */
+        fun mockSuccessfulPresenceEnter() {
+            val completionListenerSlot = slot<CompletionListener>()
+            every {
+                presenceMock.enter(
+                    any(),
+                    capture(completionListenerSlot)
+                )
+            } answers { completionListenerSlot.captured.onSuccess() }
+        }
+    }
+
+    companion object {
+        /**
+         * Creates an instance of [DefaultAblyTestEnvironment], with some basic initial configuration applied to its mocks.
+         *
+         * Specifically:
+         *
+         * 1. It creates [numberOfTrackables] channel mocks, and configures each of their [AblySdkRealtime.Channel.state] properties to return [ChannelState.initialized].
+         *    It exposes these channel mocks via the [configuredChannels] property, each with a different [ConfiguredChannel.name] value, each of which have a `"tracking:"` prefix.
+         * 1. It creates a [AblySdkRealtime.Channels] mock, and configures it as follows:
+         *    1. Its [AblySdkRealtime.Channels.containsKey] method returns `false` for all inputs;
+         *    1. Its [AblySdkRealtime.Channels.get(channelName: String, channelOptions: ChannelOptions?)] method returns the mock from [configuredChannels] with the corresponding [ConfiguredChannel.channelName] property.
+         * 1. It creates a [DefaultAbly] object using the mocks described above and in the documentation for the properties of [DefaultAblyTestEnvironment].
+         *
+         *    It provides arbitrary values for required parameters that we here consider to be unimportant – namely the `connectionConfiguration` and `logHandler` parameters of [DefaultAbly]’s constructor.
+         *
+         * @param numberOfTrackables The number of channel mocks to create.
+         *
+         * @return A configured [DefaultAblyTestEnvironment] object.
+         */
+        fun create(numberOfTrackables: Int): DefaultAblyTestEnvironment {
+            val configuredChannels = (numberOfTrackables downTo 1).map { i ->
+                val trackableId = "someTrackable-$i"
+                val channelName = "tracking:$trackableId"
+
+                val presenceMock = mockk<AblySdkRealtime.Presence>()
+
+                val channelMock = mockk<AblySdkRealtime.Channel>()
+                every { channelMock.state } returns ChannelState.initialized
+                every { channelMock.presence } returns presenceMock
+
+                ConfiguredChannel(trackableId, channelName, channelMock, presenceMock)
+            }
+
+            val channelsMock = mockk<AblySdkRealtime.Channels>()
+            every { channelsMock.containsKey(any()) } returns false
+            for (configuredChannel in configuredChannels) {
+                every {
+                    channelsMock.get(
+                        configuredChannel.channelName,
+                        any()
+                    )
+                } returns configuredChannel.channelMock
+            }
+
+            val realtimeMock = mockk<AblySdkRealtime>()
+            every { realtimeMock.channels } returns channelsMock
+
+            val factory = mockk<AblySdkRealtimeFactory>()
+            every { factory.create(any()) } returns realtimeMock
+
+            val connectionConfiguration =
+                ConnectionConfiguration(Authentication.basic("", "")) // arbitrarily chosen
+            val objectUnderTest =
+                DefaultAbly(factory, connectionConfiguration, null /* arbitrarily chosen */)
+
+            return DefaultAblyTestEnvironment(
+                objectUnderTest,
+                realtimeMock,
+                channelsMock,
+                configuredChannels
+            )
+        }
+    }
+}

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -144,6 +144,13 @@ class DefaultAblyTestEnvironment private constructor(
         fun mockFailedPresenceLeave(errorInfo: ErrorInfo) {
             mockPresenceLeaveResult { it.onError(errorInfo) }
         }
+
+        /**
+         * Mocks [presenceMock]’s [AblySdkRealtime.Presence.leave] method to never call any methods on its received completion listener.
+         */
+        fun mockNonCompletingPresenceLeave() {
+            mockPresenceLeaveResult { }
+        }
     }
 
     /**

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -38,7 +38,7 @@ internal interface CorePublisher {
     fun addTrackable(trackable: Trackable, callbackFunction: ResultCallbackFunction<StateFlow<TrackableState>>)
     fun removeTrackable(trackable: Trackable, callbackFunction: ResultCallbackFunction<Boolean>)
     fun changeRoutingProfile(routingProfile: RoutingProfile)
-    fun stop(timeoutInMilliseconds: Long, callbackFunction: ResultCallbackFunction<Unit>)
+    fun stop(callbackFunction: ResultCallbackFunction<Unit>)
     val locations: SharedFlow<LocationUpdate>
     val trackables: SharedFlow<Set<Trackable>>
     val locationHistory: SharedFlow<LocationHistoryData>
@@ -252,8 +252,8 @@ constructor(
         enqueue(WorkerSpecification.ChangeRoutingProfile(routingProfile))
     }
 
-    override fun stop(timeoutInMilliseconds: Long, callbackFunction: ResultCallbackFunction<Unit>) {
-        enqueue(WorkerSpecification.Stop(callbackFunction, timeoutInMilliseconds))
+    override fun stop(callbackFunction: ResultCallbackFunction<Unit>) {
+        enqueue(WorkerSpecification.Stop(callbackFunction))
     }
 
     override fun retrySendingEnhancedLocation(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/DefaultPublisher.kt
@@ -99,17 +99,24 @@ constructor(
         }
     }
 
-    override suspend fun stop(timeoutInMilliseconds: Long) {
+    override suspend fun stop() {
         logHandler?.v("$TAG Publisher stop operation started")
         suspendCoroutine<Unit> { continuation ->
             core.stop(
-                timeoutInMilliseconds,
                 continuation.wrapInResultCallback(
                     onSuccess = { logHandler?.v("$TAG Publisher stop operation succeeded") },
                     onError = { logHandler?.w("$TAG Publisher stop operation failed", it) },
                 ),
             )
         }
+    }
+
+    @Deprecated(
+        "The timeoutInMilliseconds parameter is now ignored and should not be used.",
+        replaceWith = ReplaceWith("stop()")
+    )
+    override suspend fun stop(timeoutInMilliseconds: Long) {
+        stop()
     }
 
     override fun getTrackableState(trackableId: String): StateFlow<TrackableState>? =

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -11,7 +11,6 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -119,13 +118,24 @@ interface Publisher {
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
      *
-     * @param timeoutInMilliseconds After this duration the stopping procedure will be canceled. Default value is 30 seconds.
+     * @throws ConnectionException If something goes wrong during connection closing
+     */
+    suspend fun stop()
+
+    /**
+     * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
+     * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
+     *
+     * @param timeoutInMilliseconds This parameter will be ignored.
      *
      * @throws ConnectionException If something goes wrong during connection closing
-     * @throws TimeoutCancellationException If the operation does not complete in the [timeoutInMilliseconds] time
      */
     @JvmSynthetic
-    suspend fun stop(timeoutInMilliseconds: Long = 30_000L)
+    @Deprecated(
+        "The timeoutInMilliseconds parameter is now ignored and should not be used.",
+        replaceWith = ReplaceWith("stop()")
+    )
+    suspend fun stop(timeoutInMilliseconds: Long)
 
     /**
      * The methods implemented by builders capable of starting [Publisher] instances.

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -206,7 +206,6 @@ internal class WorkerFactory(
                 workerSpecification.callbackFunction,
                 ably,
                 publisherInteractor,
-                workerSpecification.timeoutInMilliseconds,
             )
             WorkerSpecification.StoppingConnectionFinished -> StoppingConnectionFinishedWorker()
         }
@@ -327,7 +326,6 @@ internal sealed class WorkerSpecification {
 
     data class Stop(
         val callbackFunction: ResultCallbackFunction<Unit>,
-        val timeoutInMilliseconds: Long,
     ) : WorkerSpecification()
 
     data class TrackableRemovalRequested(

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherLocationUpdatesPublishingTest.kt
@@ -187,7 +187,7 @@ class CorePublisherLocationUpdatesPublishingTest {
 
     private suspend fun stopCorePublisher(corePublisher: CorePublisher = this.corePublisher) {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop(30_000L) {
+            corePublisher.stop() {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherPresenceDataTest.kt
@@ -106,7 +106,7 @@ class CorePublisherPresenceDataTest {
 
     private suspend fun stopCorePublisher(corePublisher: CorePublisher) {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop(30_000L) {
+            corePublisher.stop() {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/CorePublisherResolutionTest.kt
@@ -179,7 +179,7 @@ class CorePublisherResolutionTest(
 
     private suspend fun stopCorePublisher() {
         suspendCoroutine<Unit> { continuation ->
-            corePublisher.stop(30_000L) {
+            corePublisher.stop() {
                 try {
                     continuation.resume(it.getOrThrow())
                 } catch (exception: Exception) {

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
@@ -9,7 +9,7 @@ import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.SubscriberStoppedException
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockCloseFailure
-import com.ably.tracking.test.common.mockCloseSuccessWithDelay
+import com.ably.tracking.test.common.mockCloseSuccess
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -37,7 +37,7 @@ internal class StopConnectionWorkerTest {
     fun `should call ably close and notify callback with success`() = runBlockingTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
-        ably.mockCloseSuccessWithDelay(10)
+        ably.mockCloseSuccess()
 
         // when
         val updatedProperties =
@@ -65,7 +65,7 @@ internal class StopConnectionWorkerTest {
     @Test
     fun `should call the callback function with a success if subscriber is already stopped`() = runBlockingTest {
         // given
-        ably.mockCloseSuccessWithDelay(10)
+        ably.mockCloseSuccess()
 
         // when
         stopConnectionWorker.doWhenStopped(SubscriberStoppedException())

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -172,8 +172,8 @@ fun Ably.mockCloseFailure(exception: ConnectionException = anyConnectionExceptio
     coEvery { close(any()) } throws exception
 }
 
-fun Ably.mockCloseSuccessWithDelay(delayInMilliseconds: Long) {
-    coEvery { close(any()) } coAnswers { delay(delayInMilliseconds) }
+fun Ably.mockCloseSuccess() {
+    coEvery { close(any()) } returns Unit
 }
 
 private fun anyConnectionException() = ConnectionException(ErrorInformation("Test"))


### PR DESCRIPTION
## Background

It’s not clear for callers of `Publisher.stop` what it means if it throws `TimeoutCancellationException`, or how they should respond to it. For example, do they need to try calling it again, or is the publisher now in some terminal broken state?

(The same questions also apply if the publisher throws `ConnectionException`; I’ve created #873 for addressing this.)

## What’s changed

This comes from the change suggested by @lmars in https://github.com/ably/ably-asset-tracking-android/issues/862#issuecomment-1366083580. 

We remove the operation-wide timeout parameter, and instead expose a parameter to give the caller control over only the presence leave operation.

We explain what will happen if this timeout elapses and how this affects the publisher’s online status from the point of view of subscribers.

## API considerations

From 944d88461cb36318032136adcf3b085c8e4da3d9:

> This is technically a breaking change to the publisher SDK API, both in terms of semantics and parameter name. I’ll start a discussion on the pull request to decide how we want to address this, and then update this commit message.

My change to `UPDATING.md` anticipates this just being a minor version bump. Do we think this warrants a major version bump?

## Reviewing

Please review commit-by-commit.

## Issues closed

Closes #862.
