### PR TITLE
Static token auth flakey test

### DIFF
--- a/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
+++ b/core-sdk/src/main/java/com/ably/tracking/connection/ConnectionConfigurationModels.kt
@@ -143,7 +143,7 @@ private class JwtAuthentication(clientId: String?, configuration: JwtConfigurati
 
 interface TokenParams {
     /**
-     * Time to live of the token.
+     * Time to live of the token, in milliseconds.
      * If set to 0 then the default value will be used.
      */
     val ttl: Long

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
@@ -102,7 +102,8 @@ class AuthenticationTests {
         val keyParts = ABLY_API_KEY.split(":")
         val keyName = keyParts[0]
         val keySecret = keyParts[1]
-        val tokenValidityInSeconds = if (tokenParams != null && tokenParams.ttl > 0L) tokenParams.ttl else 3600L
+        val tokenValidityInSeconds =
+            if (tokenParams != null && tokenParams.ttl > 0L) (tokenParams.ttl / 1000L) else 3600L
         val currentTimestampInSeconds = (Date().time / 1000L)
         val tokenExpirationTimestampInSeconds = currentTimestampInSeconds + tokenValidityInSeconds
         val tokenCapability =

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/AuthenticationTests.kt
@@ -69,7 +69,7 @@ class AuthenticationTests {
     private fun createTokenRequest(ably: AblyRealtime, requestParameters: TokenParams? = null): TokenRequest {
         val ablyTokenRequest = ably.auth.createTokenRequest(
             Auth.TokenParams().apply {
-                ttl = requestParameters?.ttl ?: 3600L
+                ttl = requestParameters?.ttl ?: (60L * 60L * 1000L) // default to one hour
                 capability = requestParameters?.capability ?: "{\"*\":[\"*\"]}"
                 clientId = CLIENT_ID
                 timestamp = requestParameters?.timestamp ?: Date().time


### PR DESCRIPTION
So much of the code was shared with other tests that the only obvious discrepancy I could find was specification of millisecond TTL value with what looked like seconds. I'm quietly confident this'll prevent the `staticTokenAuthenticationShouldCreateWorkingConnectionBetweenPublisherAndSubscriber ` test from flaking out 'randomly'.

Fixes #844.