### PR TITLE
Add dedicated unexpected error handling to certain workers

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -22,6 +22,11 @@ internal class ConnectionCreatedWorker(
     private val presenceUpdateListener: ((presenceMessage: PresenceMessage) -> Unit),
     private val channelStateChangeListener: ((connectionStateChange: ConnectionStateChange) -> Unit),
 ) : Worker<PublisherProperties, WorkerSpecification> {
+    /**
+     * Whether the trackable is being removed.
+     * Used to properly handle unexpected exceptions in [onUnexpectedAsyncError].
+     */
+    private var isBeingRemoved = false
 
     override fun doWork(
         properties: PublisherProperties,
@@ -35,6 +40,7 @@ internal class ConnectionCreatedWorker(
         if (properties.trackableRemovalGuard.isMarkedForRemoval(trackable)) {
             // Leave Ably channel.
             doAsyncWork {
+                isBeingRemoved = true
                 val result = ably.disconnect(trackable.id, properties.presenceData)
                 postWork(WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, result))
             }
@@ -89,6 +95,13 @@ internal class ConnectionCreatedWorker(
     }
 
     override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
-        callbackFunction(Result.failure(exception))
+        if (isBeingRemoved) {
+            postWork(
+                WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, Result.failure(exception))
+            )
+        } else {
+            // If the async work fails we carry on as if it failed with a regular exception
+            postWork(createConnectionReadyWorkerSpecification(isSubscribedToPresence = false))
+        }
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -16,6 +16,12 @@ internal class DisconnectSuccessWorker(
     private val shouldRecalculateResolutionCallback: () -> Unit,
     private val ably: Ably,
 ) : CallbackWorker<PublisherProperties, WorkerSpecification>(callbackFunction) {
+    /**
+     * Whether the worker is also performing disconnecting.
+     * Used to properly handle unexpected exceptions in [onUnexpectedAsyncError].
+     */
+    private var isDisconnecting: Boolean = false
+
     override fun doWork(
         properties: PublisherProperties,
         doAsyncWork: (suspend () -> Unit) -> Unit,
@@ -38,6 +44,7 @@ internal class DisconnectSuccessWorker(
         if (removedTheLastTrackable) {
             properties.state = PublisherState.DISCONNECTING
             doAsyncWork {
+                isDisconnecting = true
                 ably.stopConnection()
                 postWork(WorkerSpecification.StoppingConnectionFinished)
             }
@@ -100,5 +107,13 @@ internal class DisconnectSuccessWorker(
 
     private fun notifyRemoveOperationFinished() {
         callbackFunction(Result.success(Unit))
+    }
+
+    override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
+        // Async work is an optional step that happens after the callback was called so it should not call the callback
+        if (isDisconnecting) {
+            // When async work fails we should make sure that the SDK state is not stuck in DISCONNECTING so we post a new worker
+            postWork(WorkerSpecification.StoppingConnectionFinished)
+        }
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
@@ -17,6 +17,12 @@ internal class TrackableRemovalRequestedWorker(
     private val ably: Ably,
     private val result: Result<Unit>
 ) : Worker<PublisherProperties, WorkerSpecification> {
+    /**
+     * Whether the worker is also performing disconnecting.
+     * Used to properly handle unexpected exceptions in [onUnexpectedAsyncError].
+     */
+    private var isDisconnecting: Boolean = false
+
     override fun doWork(
         properties: PublisherProperties,
         doAsyncWork: (suspend () -> Unit) -> Unit,
@@ -36,6 +42,7 @@ internal class TrackableRemovalRequestedWorker(
         if (removedTheLastTrackable) {
             properties.state = PublisherState.DISCONNECTING
             doAsyncWork {
+                isDisconnecting = true
                 ably.stopConnection()
                 postWork(WorkerSpecification.StoppingConnectionFinished)
             }
@@ -52,6 +59,10 @@ internal class TrackableRemovalRequestedWorker(
     }
 
     override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
-        callbackFunction(Result.failure(exception))
+        // Async work is an optional step that happens after the callback was called so it should not call the callback
+        if (isDisconnecting) {
+            // When async work fails we should make sure that the SDK state is not stuck in DISCONNECTING so we post a new worker
+            postWork(WorkerSpecification.StoppingConnectionFinished)
+        }
     }
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorker.kt
@@ -49,4 +49,10 @@ internal class SubscribeForPresenceMessagesWorker(
             }
         )
     }
+
+    override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
+        // All error paths for the async work end in posting the disconnect worker so it feels right to do the same on
+        // unexpected errors
+        postDisconnectWork(postWork, Result.failure(exception))
+    }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
@@ -127,6 +127,20 @@ internal class SubscribeForPresenceMessagesWorkerTest {
         Assert.assertTrue(postedWorks[0] is WorkerSpecification.Disconnect)
     }
 
+    @Test
+    fun `should post disconnect work when async work throw an unexpected exception`() = runBlockingTest {
+        // given
+
+        // when
+        subscribeForPresenceMessagesWorker.onUnexpectedAsyncError(
+            Exception("Unexpected exception"),
+            postedWorks.appendSpecification(),
+        )
+
+        // then
+        Assert.assertTrue(postedWorks[0] is WorkerSpecification.Disconnect)
+    }
+
     private fun anyPresenceMessage() =
         PresenceMessage(PresenceAction.PRESENT_OR_ENTER, PresenceData(ClientTypes.PUBLISHER), "any-client-id")
 }


### PR DESCRIPTION
I checked all publisher and subscriber workers and tried to find paths in which an unexpected exception might break the SDK state (e.g. make it stay in the `CONNECTING` state indefinitely). Then I applied the simplest fixes to those paths that make sure the SDK is working properly. 

This is the next iteration of the unexpected exceptions handling that added a generic, default handling for all workers https://github.com/ably/ably-asset-tracking-android/pull/872.