### PR TITLE
Write black-box tests for `DefaultAbly.connect`

### DIFF
--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -1,7 +1,8 @@
 package com.ably.tracking.common
 
+import com.ably.tracking.ErrorInformation
 import com.ably.tracking.common.helper.DefaultAblyTestEnvironment
-import io.mockk.verify
+import com.ably.tracking.common.helper.DefaultAblyTestScenarios
 import io.mockk.verifyOrder
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.ConnectionState
@@ -13,25 +14,520 @@ import org.junit.Assert
 import org.junit.Test
 
 class DefaultAblyTests {
-    // This is just an example test to check that the AblySdkRealtime mocks are working correctly. We need to add a full set of unit tests for DefaultAbly; see https://github.com/ably/ably-asset-tracking-android/issues/869
+    /*
+    Observations from writing black-box tests for `connect`:
+
+    - When given a channel in certain states, it seems to fetch the channel’s state more than once. I have not tested what happens if a different state is returned on the second call.
+     */
+
     @Test
-    fun `connect fetches the channel and then enters presence on it, and when that succeeds the call to connect succeeds`() {
-        // Given
-        val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 1)
-        val configuredChannel = testEnvironment.configuredChannels[0]
-        testEnvironment.mockChannelsContainsKey(key = configuredChannel.channelName, result = false)
-        testEnvironment.mockChannelsGet(DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS)
-        configuredChannel.mockSuccessfulPresenceEnter()
+    fun `connect - when channel fetched is in INITIALIZED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the INITIALIZED state...
+         * ...which, when told to enter presence, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
 
-        // When
         runBlocking {
-            testEnvironment.objectUnderTest.connect(configuredChannel.trackableId, PresenceData(""))
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.initialized,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
         }
+    }
 
-        // Then
-        verify {
-            testEnvironment.channelsMock.get(configuredChannel.channelName, any())
-            configuredChannel.presenceMock.enter(any(), any())
+    @Test
+    fun `connect - when channel fetched is in ATTACHED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the ATTACHED state...
+         * ...which, when told to enter presence, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.attached,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in ATTACHING state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the ATTACHING state...
+         * ...which, when told to enter presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.attaching,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in DETACHING state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the DETACHING state...
+         * ...which, when told to enter presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.detaching,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when presence enter fails`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the (arbitrarily-chosen) INITIALIZED state...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and releases the channel...
+         * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.initialized, /* arbitrarily chosen */
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    ),
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = true,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(
+                            presenceError.code,
+                            0,
+                            presenceError.message,
+                            null,
+                            null
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in FAILED state and attach succeeds`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the FAILED state...
+         * ...which, when told to enter presence, does so successfully...
+         * ...and which, when told to attach, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to attach...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.failed,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    verifyChannelAttach = true,
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in FAILED state and attach fails`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the FAILED state...
+         * ...which, when told to attach, fails to do so with an arbitrarily-chosen error `attachError`...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to attach...
+         * ...and releases the channel...
+         * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `attachError`.
+         */
+
+        val attachError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.failed,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        attachError
+                    ),
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = false,
+                    verifyChannelAttach = true,
+                    verifyChannelRelease = true,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(attachError.code, 0, attachError.message, null, null)
+                    ),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in DETACHED state and attach succeeds`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the DETACHED state...
+         * ...which, when told to enter presence, does so successfully...
+         * ...and which, when told to attach, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to attach...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.detached,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelAttach = true,
+                    verifyPresenceEnter = true,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in DETACHED state and attach fails`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the DETACHED state...
+         * ... which, when told to attach, fails to do so with an arbitrarily-chosen error...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to attach...
+         * ...and releases the channel...
+         * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `attachError`.
+         */
+
+        val attachError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.detached,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        attachError
+                    ),
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelAttach = true,
+                    verifyPresenceEnter = false,
+                    verifyChannelRelease = true,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(attachError.code, 0, attachError.message, null, null)
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel fetched is in SUSPENDED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the SUSPENDED state...
+         * ...which, when told to enter presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state 2 times...
+         * ...and tells the channel to enter presence...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = false,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    channelState = ChannelState.suspended,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyPresenceEnter = true,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `connect - when channel already exists`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in the (arbitrarily-chosen) INITIALIZED state...
+         * ...which, when told to enter presence, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `connect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and the call to `connect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Connect.test(
+                DefaultAblyTestScenarios.Connect.GivenConfig(
+                    channelsContainsKey = true,
+                    channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS,
+                    channelState = ChannelState.initialized, /* arbitrarily chosen */
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                ),
+                DefaultAblyTestScenarios.Connect.ThenConfig(
+                    overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS,
+                    numberOfChannelStateFetchesToVerify = 0,
+                    verifyPresenceEnter = false,
+                    verifyChannelAttach = false,
+                    verifyChannelRelease = false,
+                    resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
         }
     }
 

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -19,6 +19,7 @@ class DefaultAblyTests {
         // Given
         val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 1)
         val configuredChannel = testEnvironment.configuredChannels[0]
+        testEnvironment.mockChannelsContainsKey(key = configuredChannel.channelName, result = false)
         configuredChannel.mockSuccessfulPresenceEnter()
 
         // When

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -20,6 +20,7 @@ class DefaultAblyTests {
         val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 1)
         val configuredChannel = testEnvironment.configuredChannels[0]
         testEnvironment.mockChannelsContainsKey(key = configuredChannel.channelName, result = false)
+        testEnvironment.mockChannelsGet(DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS)
         configuredChannel.mockSuccessfulPresenceEnter()
 
         // When

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -156,6 +156,16 @@ class DefaultAblyTestEnvironment private constructor(
     }
 
     /**
+     * Mocks [channelsMock]’s [AblySdkRealtime.Channels.containsKey] method to return [result] for key [key].
+     *
+     * @param result The result that [channelsMock]’s [AblySdkRealtime.Channels.containsKey] method should return for key [key].
+     * @param key The key for which [result] should be returned.
+     */
+    fun mockChannelsContainsKey(key: Any, result: Boolean) {
+        every { channelsMock.containsKey(key) } returns result
+    }
+
+    /**
      * Mocks [channelsMock]’s [AblySdkRealtime.Channels.entrySet] method to return the list of channel mocks currently contained in [configuredChannels].
      */
     fun mockChannelsEntrySet() {
@@ -226,9 +236,7 @@ class DefaultAblyTestEnvironment private constructor(
          *
          * 1. It creates [numberOfTrackables] channel mocks, and configures each of their [AblySdkRealtime.Channel.state] properties to return [ChannelState.initialized].
          *    It exposes these channel mocks via the [configuredChannels] property, each with a different [ConfiguredChannel.name] value, each of which have a `"tracking:"` prefix.
-         * 1. It creates a [AblySdkRealtime.Channels] mock, and configures it as follows:
-         *    1. Its [AblySdkRealtime.Channels.containsKey] method returns `false` for all inputs;
-         *    1. Its [AblySdkRealtime.Channels.get(channelName: String, channelOptions: ChannelOptions?)] method returns the mock from [configuredChannels] with the corresponding [ConfiguredChannel.channelName] property.
+         * 1. It creates a [AblySdkRealtime.Channels] mock, and configures it so that its [AblySdkRealtime.Channels.get] method returns the mock from [configuredChannels] with the corresponding [ConfiguredChannel.channelName] property.
          * 1. It creates a [DefaultAbly] object using the mocks described above and in the documentation for the properties of [DefaultAblyTestEnvironment].
          *
          *    It provides arbitrary values for required parameters that we here consider to be unimportant – namely the `connectionConfiguration` and `logHandler` parameters of [DefaultAbly]’s constructor.
@@ -253,7 +261,6 @@ class DefaultAblyTestEnvironment private constructor(
             }
 
             val channelsMock = mockk<AblySdkRealtime.Channels>()
-            every { channelsMock.containsKey(any()) } returns false
             for (configuredChannel in configuredChannels) {
                 every {
                     channelsMock.get(

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -10,6 +10,8 @@ import io.ably.lib.realtime.CompletionListener
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.excludeRecords
+import io.mockk.confirmVerified
 import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.realtime.ConnectionStateListener
 import io.ably.lib.types.ErrorInfo
@@ -28,7 +30,7 @@ class DefaultAblyTestEnvironment private constructor(
     val objectUnderTest: DefaultAbly,
     /**
      * The [AblySdkRealtime] mock created by [create].
-     * Its [AblySdkRealtime.connection] property returns [connectionMock], and its [AblySdkRealtime.channels] property returns [channelsMock].
+     * Its [AblySdkRealtime.connection] property returns [connectionMock], and its [AblySdkRealtime.channels] property returns [channelsMock]. Calls to these property getters are ignored by MockK’s [confirmVerified] method (by use of [excludeRecords]).
      */
     val realtimeMock: AblySdkRealtime,
     /**
@@ -61,7 +63,7 @@ class DefaultAblyTestEnvironment private constructor(
         /**
          * The [AblySdkRealtime.Channel] mock created by [create].
          * See the documentation for that method for details of how this mock is configured.
-         * Its [AblySdkRealtime.Channel.presence] property returns [presenceMock].
+         * Its [AblySdkRealtime.Channel.presence] property returns [presenceMock]. Calls to this property getter are ignored by MockK’s [confirmVerified] method (by use of [excludeRecords]).
          */
         val channelMock: AblySdkRealtime.Channel,
         /**
@@ -245,6 +247,7 @@ class DefaultAblyTestEnvironment private constructor(
                 val channelMock = mockk<AblySdkRealtime.Channel>()
                 every { channelMock.state } returns ChannelState.initialized
                 every { channelMock.presence } returns presenceMock
+                excludeRecords { channelMock.presence }
 
                 ConfiguredChannel(trackableId, channelName, channelMock, presenceMock)
             }
@@ -264,7 +267,9 @@ class DefaultAblyTestEnvironment private constructor(
 
             val realtimeMock = mockk<AblySdkRealtime>()
             every { realtimeMock.channels } returns channelsMock
+            excludeRecords { realtimeMock.channels }
             every { realtimeMock.connection } returns connectionMock
+            excludeRecords { realtimeMock.connection }
 
             val factory = mockk<AblySdkRealtimeFactory>()
             every { factory.create(any()) } returns realtimeMock

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -1,0 +1,300 @@
+package com.ably.tracking.common.helper
+
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.ErrorInformation
+import com.ably.tracking.common.DefaultAbly
+import com.ably.tracking.common.PresenceData
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.types.ErrorInfo
+import io.mockk.confirmVerified
+import io.mockk.verifyOrder
+import org.junit.Assert
+
+class DefaultAblyTestScenarios {
+    /**
+     * A collection of types which are used in the various `GivenConfig` classes used for configuring the "Given..." part of a parameterised test case.
+     */
+    class GivenTypes {
+        /**
+         * Describes how a test case mocks the behaviour of a method which uses a [CompletionListener] to communicate its result. Individual test cases should document how they interpret the values this class can take.
+         */
+        sealed class CompletionListenerMockBehaviour() {
+            object NotMocked : CompletionListenerMockBehaviour()
+            object Success : CompletionListenerMockBehaviour()
+            class Failure(val errorInfo: ErrorInfo) : CompletionListenerMockBehaviour()
+        }
+    }
+
+    /**
+     * A collection of types which are used in the various `ThenConfig` classes used for configuring the "Then..." part of a parameterised test case.
+     */
+    class ThenTypes {
+        /**
+         * Describes the expected result of an operation which returns a [Result] instance to communicate its result.
+         */
+        sealed class ExpectedResult() {
+            /**
+             * The operation succeeds.
+             */
+            object Success : ExpectedResult()
+
+            /**
+             * The operation fails with a [ConnectionException] whose [ConnectionException.errorInformation] is equal to [errorInformation].
+             */
+            class FailureWithConnectionException(val errorInformation: ErrorInformation) :
+                ExpectedResult()
+
+            /**
+             * Given [result], which represents the result of an operation `op`, this implements the following steps of the "Then..." part of a parameterised test case:
+             *
+             * ```text
+             * when ${this} is Success {
+             * ...and ${op} succeeds.
+             * }
+             *
+             * when ${this} is FailureWithConnectionException {
+             * ...and ${op} fails with a ConnectionException whose errorInformation is equal to ${this.errorInformation}.
+             * }
+             * ```
+             *
+             * @param result The result of the operation `op`.
+             */
+            fun <T> verify(result: Result<T>) {
+                when (this) {
+                    is Success -> {
+                        /* when ${this} is Success {
+                         * ...and ${op} succeeds.
+                         * }
+                         */
+                        Assert.assertTrue(result.isSuccess)
+                    }
+                    is FailureWithConnectionException -> {
+                        /* when ${this} is FailureWithConnectionException {
+                         * ...and ${op} fails with a ConnectionException whose errorInformation is equal to ${this.errorInformation}.
+                         * }
+                         */
+                        Assert.assertTrue(result.isFailure)
+                        val exception = result.exceptionOrNull()!!
+                        Assert.assertTrue(exception is ConnectionException)
+                        val connectionException = exception as ConnectionException
+                        Assert.assertEquals(
+                            this.errorInformation,
+                            connectionException.errorInformation
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Provides test scenarios for [DefaultAbly.connect]. See the [Companion.test] method.
+     */
+    class Connect {
+        /**
+         * This class provides properties for configuring the "Given..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class GivenConfig(
+            val channelsContainsKey: Boolean,
+            val channelsGetOverload: DefaultAblyTestEnvironment.ChannelsGetOverload,
+            val channelState: ChannelState,
+            val presenceEnterBehaviour: GivenTypes.CompletionListenerMockBehaviour,
+            val channelAttachBehaviour: GivenTypes.CompletionListenerMockBehaviour
+        )
+
+        /**
+         * This class provides properties for configuring the "Then..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class ThenConfig(
+            val overloadOfChannelsGetToVerify: DefaultAblyTestEnvironment.ChannelsGetOverload,
+            val numberOfChannelStateFetchesToVerify: Int,
+            val verifyPresenceEnter: Boolean,
+            val verifyChannelAttach: Boolean,
+            val verifyChannelRelease: Boolean,
+            val resultOfConnectCallOnObjectUnderTest: ThenTypes.ExpectedResult
+        )
+
+        companion object {
+            /**
+             * Implements the following parameterised test case for [DefaultAbly.connect]:
+             *
+             * ```text
+             * Given...
+             *
+             * ...that calling `containsKey` on the Channels instance returns ${givenConfig.channelsContainsKey}...
+             * ...and that calling `get` (the overload described by ${givenConfig.channelsGetOverload}) on the Channels instance returns a channel in the ${givenConfig.channelState} state...
+             *
+             * when ${givenConfig.presenceEnterBehaviour} is Success {
+             * ...which, when told to enter presence, does so successfully...
+             * }
+             *
+             * when ${givenConfig.presenceEnterBehaviour} is Failure {
+             * ...which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
+             * }
+             *
+             * when ${givenConfig.channelAttachBehaviour} is Success {
+             * ...[and] which, when told to attach, does so successfully...
+             * }
+             *
+             * when ${givenConfig.channelAttachBehaviour} is Failure {
+             * ...[and] which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
+             * }
+             *
+             * When...
+             *
+             * ...we call `connect` on the object under test,
+             *
+             * Then...
+             * ...in the following order, precisely the following things happen...
+             *
+             * ...it calls `containsKey` on the Channels instance...
+             * ...and calls `get` (the overload described by ${givenConfig.channelsGetOverload}) on the Channels instance...
+             * ...and checks the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
+             *
+             * if ${thenConfig.verifyChannelAttach} {
+             * ...and tells the channel to attach...
+             * }
+             *
+             * if ${thenConfig.verifyPresenceEnter} {
+             * ...and tells the channel to enter presence...
+             * }
+             *
+             * if ${thenConfig.verifyChannelRelease} {
+             * ...and releases the channel...
+             * }
+             *
+             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Success {
+             * ...and the call to `connect` (on the object under test) succeeds.
+             * }
+             *
+             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is FailureWithConnectionException {
+             * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInfo}.
+             * }
+             * ```
+             *
+             * @param givenConfig Parameters for the "Given..." part of the test case.
+             * @param thenConfig Parameters for the "Then..." part of the test case.
+             */
+            suspend fun test(
+                givenConfig: GivenConfig,
+                thenConfig: ThenConfig
+            ) {
+                // Given...
+                // ...that calling `containsKey` on the Channels instance returns ${givenConfig.channelsContainsKey}...
+                // ...and that calling `get` (the overload described by ${givenConfig.channelsGetOverload}) on the Channels instance returns a channel in the ${givenConfig.channelState} state...
+                val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 1)
+                val configuredChannel = testEnvironment.configuredChannels[0]
+                testEnvironment.mockChannelsContainsKey(
+                    key = configuredChannel.channelName,
+                    result = givenConfig.channelsContainsKey
+                )
+                testEnvironment.mockChannelsGet(givenConfig.channelsGetOverload)
+                configuredChannel.mockState(givenConfig.channelState)
+
+                testEnvironment.stubRelease(configuredChannel)
+
+                when (val givenPresenceEnterBehaviour = givenConfig.presenceEnterBehaviour) {
+                    is GivenTypes.CompletionListenerMockBehaviour.NotMocked -> {}
+                    /* when ${givenConfig.presenceEnterBehaviour} is Success {
+                     * ...which, when told to enter presence, does so successfully...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Success -> {
+                        configuredChannel.mockSuccessfulPresenceEnter()
+                    }
+                    /* when ${givenConfig.presenceEnterBehaviour} is Failure {
+                     * ...which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
+                        configuredChannel.mockFailedPresenceEnter(givenPresenceEnterBehaviour.errorInfo)
+                    }
+                }
+
+                when (val givenChannelAttachBehaviour = givenConfig.channelAttachBehaviour) {
+                    is GivenTypes.CompletionListenerMockBehaviour.NotMocked -> {}
+                    /* when ${givenConfig.channelAttachBehaviour} is Success {
+                     * ...[and] which, when told to attach, does so successfully...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Success -> {
+                        configuredChannel.mockSuccessfulAttach()
+                    }
+                    /* when ${givenConfig.channelAttachBehaviour} is Failure {
+                     * ...[and] which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
+                        configuredChannel.mockFailedAttach(givenChannelAttachBehaviour.errorInfo)
+                    }
+                }
+
+                // When...
+
+                // ...we call `connect` on the object under test,
+                val result = testEnvironment.objectUnderTest.connect(
+                    configuredChannel.trackableId,
+                    PresenceData("")
+                )
+
+                // Then...
+                // ...in the following order, precisely the following things happen...
+                verifyOrder {
+                    // ...it calls `containsKey` on the Channels instance...
+                    testEnvironment.channelsMock.containsKey(configuredChannel.channelName)
+
+                    // ...and calls `get` (the overload described by ${thenConfig.overloadOfChannelsGetToVerify}) on the Channels instance...
+                    when (thenConfig.overloadOfChannelsGetToVerify) {
+                        DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS -> {
+                            testEnvironment.channelsMock.get(configuredChannel.channelName)
+                        }
+                        DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS -> {
+                            testEnvironment.channelsMock.get(configuredChannel.channelName, any())
+                        }
+                    }
+
+                    // ...and checks the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
+                    repeat(thenConfig.numberOfChannelStateFetchesToVerify) {
+                        configuredChannel.channelMock.state
+                    }
+
+                    if (thenConfig.verifyChannelAttach) {
+                        /* if ${thenConfig.verifyChannelAttach} {
+                         * ...and tells the channel to attach...
+                         * }
+                         */
+                        configuredChannel.channelMock.attach(any())
+                    }
+
+                    if (thenConfig.verifyPresenceEnter) {
+                        /* if ${thenConfig.verifyPresenceEnter} {
+                         * ...and tells the channel to enter presence...
+                         * }
+                         */
+                        configuredChannel.presenceMock.enter(any(), any())
+                    }
+
+                    if (thenConfig.verifyChannelRelease) {
+                        /* if ${thenConfig.verifyChannelRelease} {
+                         * ...and releases the channel...
+                         * }
+                         */
+                        testEnvironment.channelsMock.release(configuredChannel.channelName)
+                    }
+                }
+
+                /* when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Success {
+                 * ...and the call to `connect` (on the object under test) succeeds.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is FailureWithConnectionException {
+                 * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInfo}.
+                 * }
+                 */
+                thenConfig.resultOfConnectCallOnObjectUnderTest.verify(result)
+
+                confirmVerified(*testEnvironment.allMocks)
+            }
+        }
+    }
+}


### PR DESCRIPTION
These document the current behaviour of this method.

I wrote them having only seen the `Ably` interface (which `DefaultAbly` implements), and knowing the dependencies that `DefaultAbly` has.

I intentionally did not look at the code whilst writing these tests because I wanted to limit myself to writing test cases based on scenarios that I could imagine might occur, instead of ones based on logic that I know to exist.

Once I’ve written tests like this for the whole class, then I’d like to look at its implementation and add any further test cases for logic that wasn’t clear from the public interface.

This is part of #869.