### PR TITLE
Upgrade Mapbox Nav SDK to version 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Firstly, you have to exclude the notification module from Mapbox Navigation SDK 
 implementation ('com.ably.tracking:publishing-sdk:1.5.1')
 
 // The Mapbox Navigation SDK.
-implementation ('com.mapbox.navigation:android:2.8.0') {
+implementation ('com.mapbox.navigation:android:2.10.0') {
     exclude group: "com.mapbox.navigation", module: "notification"
 }
 ```

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'com.amplifyframework:aws-auth-cognito:1.4.1'
     implementation 'pub.devrel:easypermissions:3.0.0'
     // This version needs to be compatible with the "com.mapbox.navigation:core" dependency version from publishing-sdk.
-    implementation 'com.mapbox.maps:android:10.8.0'
+    implementation 'com.mapbox.maps:android:10.10.0'
 
     if (useCrashlytics) {
         // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).

--- a/publishing-sdk/build.gradle
+++ b/publishing-sdk/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // The MapBox Navigation SDK for Android.
     // We're not using the pre-built UI components, so just need the core dependency.
     // https://docs.mapbox.com/android/navigation/overview/
-    implementation('com.mapbox.navigation:core:2.8.0') {
+    implementation('com.mapbox.navigation:core:2.10.0') {
         // We provide a custom trip notification so we exclude the default one.
         // https://docs.mapbox.com/android/navigation/guides/modularization/#tripnotification
         exclude group: "com.mapbox.navigation", module: "notification"
@@ -33,11 +33,6 @@ dependencies {
     // https://docs.mapbox.com/android/navigation/guides/modularization/#replacing-a-module
     compileOnly("com.mapbox.base:annotations:0.5.0")
     kapt("com.mapbox.base:annotations-processor:0.4.0")
-
-    // Only the Core SDK portion of the MapBox Maps SDK for Android.
-    // https://docs.mapbox.com/android/maps/overview/
-    // https://docs.mapbox.com/android/core/overview/
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-core:5.0.2'
 
     // Advanced geospatial analysis - used i.e. for calculating distance between points.
     // https://docs.mapbox.com/android/java/guides/turf/


### PR DESCRIPTION
After upgrading the Nav SDK I had to remove the `mapbox-android-core` dependency, because according to [Mapbox's release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/v10.10.0):
> Remove `mapbox-android-core` dependency, it is now part of Mapbox Common library.
**NOTE:**: You need to remove any explicit dependency declaration to `com.mapbox.mapboxsdk:mapbox-android-core:<version>` from the project to avoid duplicated class definition errors related to location APIs.
