### PR TITLE
coroutines and coroutines-test dependency updated to 1.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.6.21'
+    ext.kotlin_coroutines_version = '1.6.4'
     ext.copyright_message = (new File('COPYRIGHT')).readLines().get(0)
 
     // The version of Ably's client library for Java that we're using.
@@ -242,11 +243,12 @@ subprojects {
                 // Projects that use our SDK projects will crash when dispatching to the Main thread on
                 // the Android runtime unless we include this dependency. See:
                 // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html
-                implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
-                testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
+                testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
                 testImplementation 'io.mockk:mockk:1.12.2'
             } else {
                 testImplementation 'org.mockito:mockito-core:3.6.28'
+                testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:$kotlin_coroutines_version"
             }
 
             if (evaluatedSubProjectIsAnApp) {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableFailedWorkerTest.kt
@@ -11,7 +11,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -95,7 +95,7 @@ class AddTrackableFailedWorkerTest {
     }
 
     @Test
-    fun `should post StoppingConnectionFinished work after performing async work`() = runBlockingTest {
+    fun `should post StoppingConnectionFinished work after performing async work`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackables.clear()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -14,7 +14,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -32,7 +32,7 @@ class ConnectionCreatedWorkerTest {
 
     @Test
     fun `should return presence success result when executing normally and presence enter was successful`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             ably.mockSubscribeToPresenceSuccess(trackable.id)
@@ -59,7 +59,7 @@ class ConnectionCreatedWorkerTest {
 
     @Test
     fun `should return presence failure result when executing normally and presence enter failed`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             ably.mockSubscribeToPresenceError(trackable.id)
@@ -85,7 +85,7 @@ class ConnectionCreatedWorkerTest {
         }
 
     @Test
-    fun `should post TrackableRemovalRequested work when trackable removal was requested`() = runBlockingTest {
+    fun `should post TrackableRemovalRequested work when trackable removal was requested`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
@@ -112,7 +112,7 @@ class ConnectionCreatedWorkerTest {
     }
 
     @Test
-    fun `should disconnect from Ably when trackable removal was requested`() = runBlockingTest {
+    fun `should disconnect from Ably when trackable removal was requested`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -20,7 +20,7 @@ import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -331,7 +331,7 @@ class ConnectionReadyWorkerTest {
     }
 
     @Test
-    fun `should return trackable removal work result when trackable removal was requested`() = runBlockingTest {
+    fun `should return trackable removal work result when trackable removal was requested`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
@@ -360,7 +360,7 @@ class ConnectionReadyWorkerTest {
     }
 
     @Test
-    fun `should disconnect from Ably when trackable removal was requested`() = runBlockingTest {
+    fun `should disconnect from Ably when trackable removal was requested`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
@@ -383,7 +383,7 @@ class ConnectionReadyWorkerTest {
     }
 
     @Test
-    fun `should not perform any of the normal operations when trackable removal was requested`() = runBlockingTest {
+    fun `should not perform any of the normal operations when trackable removal was requested`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -25,7 +25,7 @@ import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -668,7 +668,7 @@ class DisconnectSuccessWorkerTest {
 
     @Test
     fun `should stop ably and post StoppingConnectionFinished work if the removed trackable was the last one`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherPropertiesWithMultipleTrackables()
             initialProperties.trackables.remove(otherTrackable)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RawLocationChangedWorkerTest.kt
@@ -13,7 +13,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -27,7 +27,7 @@ class RawLocationChangedWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should set the last publisher known location`() = runBlockingTest {
+    fun `should set the last publisher known location`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
@@ -9,7 +9,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -24,7 +24,7 @@ class RemoveTrackableWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `when removing trackable that is not present should invoke callback with Success(false)`() = runBlockingTest {
+    fun `when removing trackable that is not present should invoke callback with Success(false)`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
 
@@ -47,7 +47,7 @@ class RemoveTrackableWorkerTest {
 
     @Test
     fun `when removing trackable that is currently added should add it to trackableRemovalGuard`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.duplicateTrackableGuard.startAddingTrackable(trackable)
@@ -68,7 +68,7 @@ class RemoveTrackableWorkerTest {
 
     @Test
     fun `when removing trackable that is present succeeded should invoke callback with exception`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)
@@ -91,7 +91,7 @@ class RemoveTrackableWorkerTest {
 
     @Test
     fun `when removing trackable that is present fails should invoke callback with exception`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
@@ -14,7 +14,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -46,7 +46,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
     }
 
     @Test
-    fun `should post no other works if the channel went to the failed state`() = runBlockingTest {
+    fun `should post no other works if the channel went to the failed state`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         initialProperties.trackables.add(trackable)
@@ -67,7 +67,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
     }
 
     @Test
-    fun `should not try to subscribe to presence if the channel went to the failed state`() = runBlockingTest {
+    fun `should not try to subscribe to presence if the channel went to the failed state`() = runTest {
         // given
         val initialProperties = createPublisherProperties()
         mockChannelStateChange(ConnectionState.FAILED)
@@ -89,7 +89,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
 
     @Test
     fun `should post RetrySubscribeToPresenceSuccess if the channel went to the online state and subscribe to presence was successful`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)
@@ -113,7 +113,7 @@ internal class RetrySubscribeToPresenceWorkerTest {
 
     @Test
     fun `should return failure if the channel went to the online state but subscribe to presence has failed`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorkerTest.kt
@@ -20,7 +20,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -143,7 +143,7 @@ class TrackableRemovalRequestedWorkerTest {
     }
 
     @Test
-    fun `should stop ably connection after removing last trackable`() = runBlockingTest {
+    fun `should stop ably connection after removing last trackable`() = runTest {
         // given
         val initialProperties = createPublisherPropertiesWithMultipleTrackables()
         initialProperties.trackables.clear()

--- a/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -39,6 +39,9 @@ public class UsageExamples {
     Subscriber.Builder nativeSubscriberBuilder;
     SubscriberFacade.Builder subscriberFacadeBuilder;
 
+    // We need to inject a different coroutine dispatcher in place of the Main dispatcher,
+    // because DefaultSubscriberFacade is directly accessing it.
+    // Otherwise, tests fail with RuntimeException: Stub!
     @Rule
     public ReplaceMainCoroutineDispatcherRule replaceMainCoroutineDispatcherRule = new ReplaceMainCoroutineDispatcherRule();
 

--- a/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
+++ b/subscribing-java-testing/src/test/java/com/ably/tracking/example/javasubscriber/UsageExamples.java
@@ -16,23 +16,31 @@ import com.ably.tracking.connection.ConnectionConfiguration;
 import com.ably.tracking.java.AuthenticationFacade;
 import com.ably.tracking.subscriber.Subscriber;
 import com.ably.tracking.subscriber.java.SubscriberFacade;
+import com.ably.tracking.test.common.ReplaceMainCoroutineDispatcherRule;
 import com.ably.tracking.ui.animation.CoreLocationAnimator;
 import com.ably.tracking.ui.animation.LocationAnimator;
 import com.ably.tracking.ui.java.animation.CoreLocationAnimatorFacade;
 import com.ably.tracking.ui.java.animation.LocationAnimatorFacade;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi;
+
+@ExperimentalCoroutinesApi
 public class UsageExamples {
     SubscriberFacade subscriberFacade;
     Subscriber nativeSubscriber;
     Subscriber.Builder nativeSubscriberBuilder;
     SubscriberFacade.Builder subscriberFacadeBuilder;
+
+    @Rule
+    public ReplaceMainCoroutineDispatcherRule replaceMainCoroutineDispatcherRule = new ReplaceMainCoroutineDispatcherRule();
 
     @Before
     public void beforeEach() {

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorkerTest.kt
@@ -9,7 +9,7 @@ import com.ably.tracking.test.common.mockUpdatePresenceDataSuccess
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -25,7 +25,7 @@ internal class ChangeResolutionWorkerTest {
     private val asyncWorks = mutableListOf<suspend () -> Unit>()
 
     @Test
-    fun `should return Properties with updated resolution and notify callback`() = runBlockingTest {
+    fun `should return Properties with updated resolution and notify callback`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockUpdatePresenceDataSuccess(trackableId)

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
@@ -9,7 +9,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -24,7 +24,7 @@ internal class DisconnectWorkerTest {
     private val asyncWorks = mutableListOf<suspend () -> Unit>()
 
     @Test
-    fun `should call ably disconnect and notify callback`() = runBlockingTest {
+    fun `should call ably disconnect and notify callback`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockDisconnectSuccess(trackableId)

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/ProcessInitialPresenceMessagesWorkerTest.kt
@@ -13,7 +13,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -25,7 +25,7 @@ internal class ProcessInitialPresenceMessagesWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should process all presence messages`() = runBlockingTest {
+    fun `should process all presence messages`() = runTest {
         // given
         val presenceMessages = listOf(anyPresenceMessage(), anyPresenceMessage(), anyPresenceMessage())
         val worker = ProcessInitialPresenceMessagesWorker(presenceMessages) {}
@@ -45,7 +45,7 @@ internal class ProcessInitialPresenceMessagesWorkerTest {
     }
 
     @Test
-    fun `should post subscribe to channel work after processing presence messages`() = runBlockingTest {
+    fun `should post subscribe to channel work after processing presence messages`() = runTest {
         // given
         val callbackFunction: ResultCallbackFunction<Unit> = {}
         val presenceMessages = emptyList<PresenceMessage>()

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -5,8 +5,8 @@ import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
-import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockConnectFailure
+import com.ably.tracking.test.common.mockConnectSuccess
 import com.ably.tracking.test.common.mockStartConnectionFailure
 import com.ably.tracking.test.common.mockStartConnectionSuccess
 import io.mockk.Runs
@@ -16,7 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -34,7 +34,7 @@ internal class StartConnectionWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call ably connect and post update trackable worker specification on success`() = runBlockingTest {
+    fun `should call ably connect and post update trackable worker specification on success`() = runTest {
         // given
         ably.mockStartConnectionSuccess()
         ably.mockConnectSuccess(trackableId)
@@ -65,7 +65,7 @@ internal class StartConnectionWorkerTest {
     }
 
     @Test
-    fun `should call ably connect and notify callback on failure`() = runBlockingTest {
+    fun `should call ably connect and notify callback on failure`() = runTest {
         // given
         ably.mockStartConnectionSuccess()
         ably.mockConnectFailure(trackableId)
@@ -97,7 +97,7 @@ internal class StartConnectionWorkerTest {
     }
 
     @Test
-    fun `should notify callback about failure when starting Ably connection fails`() = runBlockingTest {
+    fun `should notify callback about failure when starting Ably connection fails`() = runTest {
         // given
         ably.mockStartConnectionFailure()
         ably.mockConnectSuccess(trackableId)

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
@@ -4,8 +4,8 @@ import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
-import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberStoppedException
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockCloseFailure
@@ -16,7 +16,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -34,7 +34,7 @@ internal class StopConnectionWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call ably close and notify callback with success`() = runBlockingTest {
+    fun `should call ably close and notify callback with success`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockCloseSuccessWithDelay(10)
@@ -50,7 +50,7 @@ internal class StopConnectionWorkerTest {
     }
 
     @Test
-    fun `should call ably close and notify callback with failure when it fails`() = runBlockingTest {
+    fun `should call ably close and notify callback with failure when it fails`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockCloseFailure()
@@ -63,7 +63,7 @@ internal class StopConnectionWorkerTest {
     }
 
     @Test
-    fun `should call the callback function with a success if subscriber is already stopped`() = runBlockingTest {
+    fun `should call the callback function with a success if subscriber is already stopped`() = runTest {
         // given
         ably.mockCloseSuccessWithDelay(10)
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeForPresenceMessagesWorkerTest.kt
@@ -18,7 +18,7 @@ import io.mockk.CapturingSlot
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 
@@ -35,7 +35,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should post update presence work when presence listener is called`() = runBlockingTest {
+    fun `should post update presence work when presence listener is called`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         val presenceListenerSlot: CapturingSlot<(PresenceMessage) -> Unit> = slot()
@@ -64,7 +64,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
 
     @Test
     fun `should post process initial presence messages work when both get current presence and subscribe to presence return success`() =
-        runBlockingTest {
+        runTest {
             // given
             val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
             val initialPresenceMessages = listOf(anyPresenceMessage())
@@ -90,7 +90,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
         }
 
     @Test
-    fun `should post disconnect work when subscribe to presence returns failure`() = runBlockingTest {
+    fun `should post disconnect work when subscribe to presence returns failure`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockGetCurrentPresenceSuccess(trackableId)
@@ -109,7 +109,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
     }
 
     @Test
-    fun `should post disconnect work when get current presence returns failure`() = runBlockingTest {
+    fun `should post disconnect work when get current presence returns failure`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
         ably.mockGetCurrentPresenceError(trackableId)
@@ -128,7 +128,7 @@ internal class SubscribeForPresenceMessagesWorkerTest {
     }
 
     @Test
-    fun `should post disconnect work when async work throw an unexpected exception`() = runBlockingTest {
+    fun `should post disconnect work when async work throw an unexpected exception`() = runTest {
         // given
 
         // when

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeToChannelWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/SubscribeToChannelWorkerTest.kt
@@ -3,8 +3,8 @@ package com.ably.tracking.subscriber.workerqueue.workers
 import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.ResultCallbackFunction
-import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 import io.mockk.every
 import io.mockk.just
@@ -12,7 +12,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -31,7 +31,7 @@ internal class SubscribeToChannelWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should notify callback after calling subscriberInteractor`() = runBlockingTest {
+    fun `should notify callback after calling subscriberInteractor`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateChannelConnectionStateWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateChannelConnectionStateWorkerTest.kt
@@ -9,7 +9,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -24,7 +24,7 @@ internal class UpdateChannelConnectionStateWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call updateForChannelConnectionStateChangeAndThenEmitStateEventsIfRequired`() = runBlockingTest {
+    fun `should call updateForChannelConnectionStateChangeAndThenEmitStateEventsIfRequired`() = runTest {
         // given
         every { subscriberProperties.updateForChannelConnectionStateChangeAndThenEmitStateEventsIfRequired(any()) } just Runs
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdateConnectionStateWorkerTest.kt
@@ -9,7 +9,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -24,7 +24,7 @@ internal class UpdateConnectionStateWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call updateForConnectionStateChangeAndThenEmitStateEventsIfRequired`() = runBlockingTest {
+    fun `should call updateForConnectionStateChangeAndThenEmitStateEventsIfRequired`() = runTest {
         // given
         every { subscriberProperties.updateForConnectionStateChangeAndThenEmitStateEventsIfRequired(any()) } just Runs
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/UpdatePublisherPresenceWorkerTest.kt
@@ -9,7 +9,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -21,7 +21,7 @@ internal class UpdatePublisherPresenceWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call updateForPresenceMessagesAndThenEmitStateEventsIfRequired`() = runBlockingTest {
+    fun `should call updateForPresenceMessagesAndThenEmitStateEventsIfRequired`() = runTest {
         // given
         val worker = UpdatePublisherPresenceWorker(presenceMessage)
         every { subscriberProperties.updateForPresenceMessagesAndThenEmitStateEventsIfRequired(any()) } just Runs

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     implementation project(':core-sdk')
     implementation project(':common')
     implementation 'io.mockk:mockk:1.10.2'
+    implementation 'junit:junit:4.13.2'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
 }
 
 // The mockk library depends on the objenesis library in version 3. This forces using minSdkLevel to 26 or above.

--- a/test-common/src/main/java/com/ably/tracking/test/common/ReplaceMainCoroutineDispatcherRule.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/ReplaceMainCoroutineDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.ably.tracking.test.common
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class ReplaceMainCoroutineDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/test-common/src/main/java/com/ably/tracking/test/common/ReplaceMainCoroutineDispatcherRule.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/ReplaceMainCoroutineDispatcherRule.kt
@@ -9,6 +9,10 @@ import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
+/**
+ * This junit rule is replacing the Main dispatcher with TestDispatcher
+ * to allow unit testing code that directly accesses the Main dispatcher
+ */
 @ExperimentalCoroutinesApi
 class ReplaceMainCoroutineDispatcherRule(
     private val dispatcher: TestDispatcher = StandardTestDispatcher()


### PR DESCRIPTION
Updating test coroutines dependency to use `runTest` for better handling of async calls in the test code, as we are currently adding lots of them.
`runTest` can be used to provide async context for the whole tests instead of local `runBlocking` blocks.
The biggest gain from using `runTest` is virtual time manipulation - a test with 10 seconds delay won't be executing 10 seconds