### PR TITLE
Add timeout on verification in WorkerQueueTest

### DIFF
--- a/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
+++ b/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
@@ -38,10 +38,9 @@ class WorkerQueueTest {
 
         // when
         workerQueue.enqueue(Unit)
-        waitForWorkerToBeProcessed()
 
         // then
-        verify(exactly = 1) { worker.doWork(any(), any(), any()) }
+        verify(exactly = 1, timeout = 5000) { worker.doWork(any(), any(), any()) }
     }
 
     @Test
@@ -51,10 +50,9 @@ class WorkerQueueTest {
 
         // when
         workerQueue.enqueue(Unit)
-        waitForWorkerToBeProcessed()
 
         // then
-        verify(exactly = 1) { worker.doWhenStopped(any()) }
+        verify(exactly = 1, timeout = 5000) { worker.doWhenStopped(any()) }
     }
 
     @Test
@@ -65,10 +63,9 @@ class WorkerQueueTest {
 
         // when
         workerQueue.enqueue(Unit)
-        waitForWorkerToBeProcessed()
 
         // then
-        verify(exactly = 1) { worker.onUnexpectedError(any(), any()) }
+        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedError(any(), any()) }
     }
 
     @Test
@@ -80,12 +77,11 @@ class WorkerQueueTest {
 
         // when
         workerQueue.enqueue(Unit)
-        waitForWorkerToBeProcessed()
         asyncWorkSlot.waitForCapture()
         asyncWorkSlot.captured { throw anyUnexpectedException() }
 
         // then
-        verify(exactly = 1) { worker.onUnexpectedAsyncError(any(), any()) }
+        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedAsyncError(any(), any()) }
     }
 
     @Test
@@ -96,10 +92,9 @@ class WorkerQueueTest {
 
         // when
         workerQueue.enqueue(Unit)
-        waitForWorkerToBeProcessed()
 
         // then
-        verify(exactly = 1) { worker.onUnexpectedError(any(), any()) }
+        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedError(any(), any()) }
     }
 
     private fun mockWorkerQueueStopped() {
@@ -111,12 +106,4 @@ class WorkerQueueTest {
     }
 
     private fun anyUnexpectedException() = java.lang.IllegalStateException("Unexpected worker exception")
-
-    /**
-     * Blocks the test to make sure that the worker is processed by the worker queue before a test case ends.
-     * If tests from this file become flaky try increasing the delay value or find a better way for waiting on workers to be processed.
-     */
-    private fun waitForWorkerToBeProcessed() {
-        runBlocking { delay(300L) }
-    }
 }

--- a/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
+++ b/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
@@ -13,8 +13,9 @@ import org.junit.Test
 
 typealias TestWorkerSpecificationType = Unit
 
+private const val ASYNC_WORK_TIMEOUT_IN_MILLISECONDS = 5000L
+
 class WorkerQueueTest {
-    private val ASYNC_WORK_TIMEOUT_IN_MILLISECONDS = 5000L
     private val properties = mockk<Properties>()
     private val scope = CoroutineScope(createSingleThreadDispatcher() + SupervisorJob())
     private val worker = mockk<Worker<Properties, TestWorkerSpecificationType>>(relaxed = true)

--- a/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
+++ b/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 typealias TestWorkerSpecificationType = Unit
 
 class WorkerQueueTest {
+    private val ASYNC_WORK_TIMEOUT_IN_MILLISECONDS = 5000L
     private val properties = mockk<Properties>()
     private val scope = CoroutineScope(createSingleThreadDispatcher() + SupervisorJob())
     private val worker = mockk<Worker<Properties, TestWorkerSpecificationType>>(relaxed = true)
@@ -38,7 +39,7 @@ class WorkerQueueTest {
         workerQueue.enqueue(Unit)
 
         // then
-        verify(exactly = 1, timeout = 5000) { worker.doWork(any(), any(), any()) }
+        verify(exactly = 1, timeout = ASYNC_WORK_TIMEOUT_IN_MILLISECONDS) { worker.doWork(any(), any(), any()) }
     }
 
     @Test
@@ -50,7 +51,7 @@ class WorkerQueueTest {
         workerQueue.enqueue(Unit)
 
         // then
-        verify(exactly = 1, timeout = 5000) { worker.doWhenStopped(any()) }
+        verify(exactly = 1, timeout = ASYNC_WORK_TIMEOUT_IN_MILLISECONDS) { worker.doWhenStopped(any()) }
     }
 
     @Test
@@ -63,7 +64,7 @@ class WorkerQueueTest {
         workerQueue.enqueue(Unit)
 
         // then
-        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedError(any(), any()) }
+        verify(exactly = 1, timeout = ASYNC_WORK_TIMEOUT_IN_MILLISECONDS) { worker.onUnexpectedError(any(), any()) }
     }
 
     @Test
@@ -79,7 +80,7 @@ class WorkerQueueTest {
         asyncWorkSlot.captured { throw anyUnexpectedException() }
 
         // then
-        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedAsyncError(any(), any()) }
+        verify(exactly = 1, timeout = ASYNC_WORK_TIMEOUT_IN_MILLISECONDS) { worker.onUnexpectedAsyncError(any(), any()) }
     }
 
     @Test
@@ -92,7 +93,7 @@ class WorkerQueueTest {
         workerQueue.enqueue(Unit)
 
         // then
-        verify(exactly = 1, timeout = 5000) { worker.onUnexpectedError(any(), any()) }
+        verify(exactly = 1, timeout = ASYNC_WORK_TIMEOUT_IN_MILLISECONDS) { worker.onUnexpectedError(any(), any()) }
     }
 
     private fun mockWorkerQueueStopped() {

--- a/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
+++ b/common/src/test/java/com/ably/tracking/common/workerqueue/WorkerQueueTest.kt
@@ -9,8 +9,6 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 typealias TestWorkerSpecificationType = Unit


### PR DESCRIPTION
The delays already present in the test weren't quite long enough to allow for the asynchronous coroutines to run. This change adds a slightly longer timeout to the verification step, to ensure that the WorkerQueue has time to run the jobs. This should hopefully fix the flakey test issue.

Fixes #888