### PR TITLE
Use different locations in test data file

### DIFF
--- a/integration-testing-app/src/main/assets/location_history_small.txt
+++ b/integration-testing-app/src/main/assets/location_history_small.txt
@@ -31,7 +31,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 5.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 1.0,
         "time": 1.607347950390277E9
       },
       "type": "Feature"
@@ -49,7 +49,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 5.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 2.0,
         "time": 1.607347950392239E9
       },
       "type": "Feature"
@@ -67,7 +67,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 0.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 3.0,
         "time": 1.607347951401546E9
       },
       "type": "Feature"
@@ -85,7 +85,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 0.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 4.0,
         "time": 1.607347951403518E9
       },
       "type": "Feature"
@@ -103,7 +103,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 0.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 5.0,
         "time": 1.607347952394775E9
       },
       "type": "Feature"
@@ -121,7 +121,7 @@
         "accuracyHorizontal": 20.0,
         "altitude": 0.0,
         "bearing": 0.0,
-        "speed": 0.0,
+        "speed": 6.0,
         "time": 1.607347952397098E9
       },
       "type": "Feature"


### PR DESCRIPTION
Prior to this change, the testing data file contained a series of the same locations (excluding timestamp). On receiving a location update, we stamp the current millisecond-precision timestamp on it.

If during tests, mapbox enhanced updates come through very quickly (<1ms), they are registered on the publisher, but may not be sent to Ably.

This may be due to resolution, or because such a quick update would make the timestamp on subsequent updates the same. As everything else is the same, this would produce the same hashcode for the location update, which is also what we use as the message id for the Ably realtime service. So the message would be rejected for reasons of idempotency.

This change therefore makes sure that each data point in the file is different, so we can never have clashing hashcodes.

Fixes https://github.com/ably/ably-asset-tracking-android/issues/259