### PR TITLE
Publisher and Subscriber builders start method throws exception descr…

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -245,7 +245,7 @@ private const val AUTH_TOKEN_CAPABILITY_ERROR_CODE = 40160
 
 class DefaultAbly
 /**
- * @throws ConnectionException if something goes wrong during Ably SDK initialization.
+ * @throws ConnectionException If connection configuration is invalid.
  */
 constructor(
     realtimeFactory: AblySdkRealtimeFactory,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -280,8 +280,8 @@ interface Publisher {
          * In order to detect device's location ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permission must be granted.
          *
          * @return A new publisher instance.
-         * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set
-         * @throws ConnectionException If something goes wrong during connection initialization
+         * @throws com.ably.tracking.BuilderConfigurationIncompleteException If all required params aren't set.
+         * @throws ConnectionException If connection configuration is invalid.
          */
         @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
         @Throws(BuilderConfigurationIncompleteException::class, ConnectionException::class)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -141,7 +141,7 @@ interface Subscriber {
          *
          * @return A new subscriber instance.
          * @throws BuilderConfigurationIncompleteException If all required params aren't set
-         * @throws ConnectionException If something goes wrong during connection initialization
+         * @throws ConnectionException If connection configuration is invalid.
          */
         @JvmSynthetic
         suspend fun start(): Subscriber


### PR DESCRIPTION
…iption updated
The investigation of #876 concluded that the `ConnectionException` thrown by the start functions of subscriber and publisher builders could only be caused by invalid configuration. This PR updates comments on those methods to better convey it to the user.

Resolves #876 