### PR TITLE
Wrap `ably-java`’s `ChannelStateChange` in our own type

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -275,7 +275,7 @@ constructor(
                     )
                 }
             }
-            ably = ablySdkFactory.create(clientOptions)
+            ably = ablySdkFactory.createRealtime(clientOptions)
         } catch (exception: AblyException) {
             throw exception.errorInfo.toTrackingException().also {
                 logHandler?.w("$TAG Failed to create an Ably instance", it)

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -19,7 +19,6 @@ import com.ably.tracking.logging.LogHandler
 import com.google.gson.Gson
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.ChannelState
-import io.ably.lib.realtime.ChannelStateListener
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.realtime.ConnectionStateListener
@@ -243,17 +242,17 @@ private const val CHANNEL_NAME_PREFIX = "tracking:"
 private const val AGENT_HEADER_NAME = "ably-asset-tracking-android"
 private const val AUTH_TOKEN_CAPABILITY_ERROR_CODE = 40160
 
-class DefaultAbly
+class DefaultAbly<ChannelStateListenerType : AblySdkChannelStateListener>
 /**
  * @throws ConnectionException If connection configuration is invalid.
  */
 constructor(
-    ablySdkFactory: AblySdkFactory,
+    private val ablySdkFactory: AblySdkFactory<ChannelStateListenerType>,
     connectionConfiguration: ConnectionConfiguration,
     private val logHandler: LogHandler?,
 ) : Ably {
     private val gson = Gson()
-    private val ably: AblySdkRealtime
+    private val ably: AblySdkRealtime<ChannelStateListenerType>
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val TAG = createLoggingTag(this)
 
@@ -305,7 +304,11 @@ constructor(
                 // Initial state is launched in a fire-and-forget manner to not block this method on the listener() call
                 scope.launch { listener(ConnectionStateChange(currentChannelState, null)) }
             }
-            channel.on { listener(it.toTracking()) }
+
+            val wrappedChannelStateListener = ablySdkFactory.wrapChannelStateListener { _, stateChange ->
+                listener(stateChange.toTracking())
+            }
+            channel.on(wrappedChannelStateListener)
         }
     }
 
@@ -314,7 +317,7 @@ constructor(
      * a new auth token is requested and the operation is retried once more.
      * @throws ConnectionException if something goes wrong or the retry fails
      */
-    private suspend fun enterChannelPresence(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
+    private suspend fun enterChannelPresence(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
         try {
             enterPresenceSuspending(channel, presenceData)
         } catch (connectionException: ConnectionException) {
@@ -439,14 +442,14 @@ constructor(
         }
     }
 
-    private suspend fun tryDisconnectChannel(channelToRemove: AblySdkRealtime.Channel, presenceData: PresenceData) =
+    private suspend fun tryDisconnectChannel(channelToRemove: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) =
         try {
             disconnectChannel(channelToRemove, presenceData)
         } catch (exception: Exception) {
             // no-op
         }
 
-    private suspend fun disconnectChannel(channelToRemove: AblySdkRealtime.Channel, presenceData: PresenceData) {
+    private suspend fun disconnectChannel(channelToRemove: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
         retryChannelOperationIfConnectionResumeFails(channelToRemove) { channel ->
             leavePresence(channel, presenceData)
             channel.unsubscribe()
@@ -455,7 +458,7 @@ constructor(
         }
     }
 
-    private suspend fun failChannel(channel: AblySdkRealtime.Channel, presenceData: PresenceData, errorInfo: ErrorInfo) {
+    private suspend fun failChannel(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData, errorInfo: ErrorInfo) {
         leavePresence(channel, presenceData)
         channel.unsubscribe()
         channel.presence.unsubscribe()
@@ -464,7 +467,7 @@ constructor(
         ably.channels.release(channel.name)
     }
 
-    private suspend fun leavePresence(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
+    private suspend fun leavePresence(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.presence.leave(
@@ -549,7 +552,7 @@ constructor(
         }
     }
 
-    private fun sendMessage(channel: AblySdkRealtime.Channel, message: Message?, callback: (Result<Unit>) -> Unit) {
+    private fun sendMessage(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, message: Message?, callback: (Result<Unit>) -> Unit) {
         scope.launch {
             try {
                 retryChannelOperationIfConnectionResumeFails(channel) {
@@ -563,7 +566,7 @@ constructor(
         }
     }
 
-    private suspend fun sendMessage(channel: AblySdkRealtime.Channel, message: Message?) {
+    private suspend fun sendMessage(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, message: Message?) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.publish(
@@ -638,7 +641,7 @@ constructor(
     }
 
     private fun processReceivedLocationUpdateMessage(
-        channel: AblySdkRealtime.Channel,
+        channel: AblySdkRealtime.Channel<ChannelStateListenerType>,
         presenceData: PresenceData,
         message: Message,
         listener: (LocationUpdate) -> Unit,
@@ -698,7 +701,7 @@ constructor(
         }
     }
 
-    private fun emitAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel, listener: (PresenceMessage) -> Unit) {
+    private fun emitAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, listener: (PresenceMessage) -> Unit) {
         getAllCurrentMessagesFromPresence(channel).forEach { presenceMessage ->
             // Each message is launched in a fire-and-forget manner to not block this method on the listener() call
             scope.launch { listener(presenceMessage) }
@@ -722,7 +725,7 @@ constructor(
     /**
      * Warning: This method might block the current thread due to the presence.get(true) call.
      */
-    private fun getAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel): List<PresenceMessage> =
+    private fun getAllCurrentMessagesFromPresence(channel: AblySdkRealtime.Channel<ChannelStateListenerType>): List<PresenceMessage> =
         channel.presence.get(true).mapNotNull { presenceMessage ->
             presenceMessage.toTracking(gson).also {
                 if (it == null) {
@@ -751,7 +754,7 @@ constructor(
         }
     }
 
-    private suspend fun updatePresenceData(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
+    private suspend fun updatePresenceData(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.presence.update(
@@ -777,7 +780,7 @@ constructor(
         }
     }
 
-    private fun getChannelIfExists(trackableId: String): AblySdkRealtime.Channel? {
+    private fun getChannelIfExists(trackableId: String): AblySdkRealtime.Channel<ChannelStateListenerType>? {
         val channelName = trackableId.toChannelName()
         return if (ably.channels.containsKey(channelName)) {
             ably.channels.get(channelName)
@@ -833,8 +836,8 @@ constructor(
      * the second time the exception is rethrown no matter if it was the "connection resume" exception or not.
      */
     private suspend fun retryChannelOperationIfConnectionResumeFails(
-        channel: AblySdkRealtime.Channel,
-        operation: suspend (AblySdkRealtime.Channel) -> Unit
+        channel: AblySdkRealtime.Channel<ChannelStateListenerType>,
+        operation: suspend (AblySdkRealtime.Channel<ChannelStateListenerType>) -> Unit
     ) {
         try {
             if (channel.state == ChannelState.suspended) {
@@ -869,21 +872,22 @@ constructor(
      * If the [channel] state already is the [ChannelState.attached] state it does not wait and returns immediately.
      * If this doesn't happen during the next [timeoutInMilliseconds] milliseconds, then an exception is thrown.
      */
-    private suspend fun waitForChannelReconnection(channel: AblySdkRealtime.Channel, timeoutInMilliseconds: Long = 10_000L) {
+    private suspend fun waitForChannelReconnection(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, timeoutInMilliseconds: Long = 10_000L) {
         if (channel.state.isConnected()) {
             return
         }
         try {
             withTimeout(timeoutInMilliseconds) {
                 suspendCancellableCoroutine<Unit> { continuation ->
-                    channel.on(object : ChannelStateListener {
-                        override fun onChannelStateChanged(channelStateChange: ChannelStateListener.ChannelStateChange) {
-                            if (channelStateChange.current.isConnected()) {
-                                channel.off(this)
+                    val wrappedChannelStateListener = ablySdkFactory.wrapChannelStateListener(object : AblySdkFactory.UnderlyingChannelStateListener<ChannelStateListenerType> {
+                        override fun onChannelStateChanged(wrapper: ChannelStateListenerType, stateChange: AblySdkChannelStateListener.ChannelStateChange) {
+                            if (stateChange.current.isConnected()) {
+                                channel.off(wrapper)
                                 continuation.resume(Unit)
                             }
                         }
                     })
+                    channel.on(wrappedChannelStateListener)
                 }
             }
         } catch (exception: TimeoutCancellationException) {
@@ -908,7 +912,7 @@ constructor(
      * Enter the presence of [channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun enterPresenceSuspending(channel: AblySdkRealtime.Channel, presenceData: PresenceData) {
+    private suspend fun enterPresenceSuspending(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.presence.enter(
@@ -938,7 +942,7 @@ constructor(
      * Attaches [channel] and waits for this operation to complete.
      * If something goes wrong then it throws a [ConnectionException].
      */
-    private suspend fun attachSuspending(channel: AblySdkRealtime.Channel) {
+    private suspend fun attachSuspending(channel: AblySdkRealtime.Channel<ChannelStateListenerType>) {
         suspendCancellableCoroutine<Unit> { continuation ->
             try {
                 channel.attach(object : CompletionListener {
@@ -961,7 +965,7 @@ constructor(
         }
     }
 
-    private fun AblySdkRealtime.Channel.isDetachedOrFailed(): Boolean =
+    private fun AblySdkRealtime.Channel<ChannelStateListenerType>.isDetachedOrFailed(): Boolean =
         state == ChannelState.detached || state == ChannelState.failed
 
     private fun createMalformedMessageErrorInfo(): ErrorInfo = ErrorInfo("Received a malformed message", 100_001, 400)

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -248,7 +248,7 @@ class DefaultAbly
  * @throws ConnectionException If connection configuration is invalid.
  */
 constructor(
-    realtimeFactory: AblySdkRealtimeFactory,
+    ablySdkFactory: AblySdkFactory,
     connectionConfiguration: ConnectionConfiguration,
     private val logHandler: LogHandler?,
 ) : Ably {
@@ -275,7 +275,7 @@ constructor(
                     )
                 }
             }
-            ably = realtimeFactory.create(clientOptions)
+            ably = ablySdkFactory.create(clientOptions)
         } catch (exception: AblyException) {
             throw exception.errorInfo.toTrackingException().also {
                 logHandler?.w("$TAG Failed to create an Ably instance", it)

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -191,7 +191,7 @@ fun ChannelState.toTracking() = when (this) {
  * Extension converting Ably Realtime channel state change events to the equivalent [ConnectionStateChange] API
  * presented to users of the Ably Asset Tracking SDKs.
  */
-fun io.ably.lib.realtime.ChannelStateListener.ChannelStateChange.toTracking() =
+fun AblySdkChannelStateListener.ChannelStateChange.toTracking() =
     ConnectionStateChange(
         this.current.toTracking(),
         this.reason?.toTracking()

--- a/common/src/main/java/com/ably/tracking/common/AblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblySdk.kt
@@ -14,7 +14,7 @@ import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Message
 import io.ably.lib.types.PresenceMessage
 
-interface AblySdkRealtimeFactory {
+interface AblySdkFactory {
     fun create(clientOptions: ClientOptions): AblySdkRealtime
 }
 

--- a/common/src/main/java/com/ably/tracking/common/AblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblySdk.kt
@@ -15,7 +15,7 @@ import io.ably.lib.types.Message
 import io.ably.lib.types.PresenceMessage
 
 interface AblySdkFactory {
-    fun create(clientOptions: ClientOptions): AblySdkRealtime
+    fun createRealtime(clientOptions: ClientOptions): AblySdkRealtime
 }
 
 /**

--- a/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
@@ -19,7 +19,7 @@ import io.ably.lib.types.PresenceMessage
  * An implementation of [AblySdkFactory] which uses the `ably-java` client library.
  */
 class DefaultAblySdkFactory : AblySdkFactory {
-    override fun create(clientOptions: ClientOptions): AblySdkRealtime {
+    override fun createRealtime(clientOptions: ClientOptions): AblySdkRealtime {
         return DefaultAblySdkRealtime(clientOptions)
     }
 }

--- a/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
+++ b/common/src/main/java/com/ably/tracking/common/DefaultAblySdk.kt
@@ -16,9 +16,9 @@ import io.ably.lib.types.Message
 import io.ably.lib.types.PresenceMessage
 
 /**
- * An implementation of [AblySdkRealtimeFactory] which uses the `ably-java` client library.
+ * An implementation of [AblySdkFactory] which uses the `ably-java` client library.
  */
-class DefaultAblySdkRealtimeFactory : AblySdkRealtimeFactory {
+class DefaultAblySdkFactory : AblySdkFactory {
     override fun create(clientOptions: ClientOptions): AblySdkRealtime {
         return DefaultAblySdkRealtime(clientOptions)
     }

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -1,7 +1,7 @@
 package com.ably.tracking.common.helper
 
 import com.ably.tracking.common.AblySdkRealtime
-import com.ably.tracking.common.AblySdkRealtimeFactory
+import com.ably.tracking.common.AblySdkFactory
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.connection.Authentication
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -27,7 +27,7 @@ import io.ably.lib.types.ErrorInfo
 class DefaultAblyTestEnvironment private constructor(
     /**
      * The [DefaultAbly] object created by [create].
-     * It has been configured with an [AblySdkRealtimeFactory] mock that supplies [realtimeMock].
+     * It has been configured with an [AblySdkFactory] mock that supplies [realtimeMock].
      */
     val objectUnderTest: DefaultAbly,
     /**
@@ -389,7 +389,7 @@ class DefaultAblyTestEnvironment private constructor(
             every { realtimeMock.connection } returns connectionMock
             excludeRecords { realtimeMock.connection }
 
-            val factory = mockk<AblySdkRealtimeFactory>()
+            val factory = mockk<AblySdkFactory>()
             every { factory.create(any()) } returns realtimeMock
 
             val connectionConfiguration =

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -390,7 +390,7 @@ class DefaultAblyTestEnvironment private constructor(
             excludeRecords { realtimeMock.connection }
 
             val factory = mockk<AblySdkFactory>()
-            every { factory.create(any()) } returns realtimeMock
+            every { factory.createRealtime(any()) } returns realtimeMock
 
             val connectionConfiguration =
                 ConnectionConfiguration(Authentication.basic("", "")) // arbitrarily chosen

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -1,5 +1,6 @@
 package com.ably.tracking.common.helper
 
+import com.ably.tracking.common.AblySdkChannelStateListener
 import com.ably.tracking.common.AblySdkRealtime
 import com.ably.tracking.common.AblySdkFactory
 import com.ably.tracking.common.DefaultAbly
@@ -29,12 +30,12 @@ class DefaultAblyTestEnvironment private constructor(
      * The [DefaultAbly] object created by [create].
      * It has been configured with an [AblySdkFactory] mock that supplies [realtimeMock].
      */
-    val objectUnderTest: DefaultAbly,
+    val objectUnderTest: DefaultAbly<AblySdkChannelStateListener>,
     /**
      * The [AblySdkRealtime] mock created by [create].
      * Its [AblySdkRealtime.connection] property returns [connectionMock], and its [AblySdkRealtime.channels] property returns [channelsMock]. Calls to these property getters are ignored by MockK’s [confirmVerified] method (by use of [excludeRecords]).
      */
-    val realtimeMock: AblySdkRealtime,
+    val realtimeMock: AblySdkRealtime<AblySdkChannelStateListener>,
     /**
      * The [AblySdkRealtime.Connection] mock which [create] has created and configured [realtimeMock]’s [AblySdkRealtime.connection] property to return.
      */
@@ -43,7 +44,7 @@ class DefaultAblyTestEnvironment private constructor(
      * The [AblySdkRealtime.Channels] mock which [create] has created and configured [realtimeMock]’s [AblySdkRealtime.channels] property to return.
      * See the documentation for that method for details of how this mock is configured.
      */
-    val channelsMock: AblySdkRealtime.Channels,
+    val channelsMock: AblySdkRealtime.Channels<AblySdkChannelStateListener>,
     /**
      * The set of [AblySdkRealtime.Channel] mocks that [create] has configured [channelsMock] to supply.
      * See the documentation for that method for details of how these mocks are configured.
@@ -67,7 +68,7 @@ class DefaultAblyTestEnvironment private constructor(
          * See the documentation for that method for details of how this mock is configured.
          * Its [AblySdkRealtime.Channel.presence] property returns [presenceMock]. Calls to this property getter are ignored by MockK’s [confirmVerified] method (by use of [excludeRecords]).
          */
-        val channelMock: AblySdkRealtime.Channel,
+        val channelMock: AblySdkRealtime.Channel<AblySdkChannelStateListener>,
         /**
          * The [AblySdkRealtime.Presence] mock which [create] has created and configured [channelMock]’s [AblySdkRealtime.Channel.presence] property to return.
          */
@@ -290,7 +291,7 @@ class DefaultAblyTestEnvironment private constructor(
      */
     fun mockChannelsEntrySet() {
         val entrySet = configuredChannels.map { configuredChannel ->
-            object : Map.Entry<String, AblySdkRealtime.Channel> {
+            object : Map.Entry<String, AblySdkRealtime.Channel<AblySdkChannelStateListener>> {
                 override val key = configuredChannel.channelName
                 override val value = configuredChannel.channelMock
             }
@@ -372,7 +373,7 @@ class DefaultAblyTestEnvironment private constructor(
 
                 val presenceMock = mockk<AblySdkRealtime.Presence>()
 
-                val channelMock = mockk<AblySdkRealtime.Channel>()
+                val channelMock = mockk<AblySdkRealtime.Channel<AblySdkChannelStateListener>>()
                 every { channelMock.state } returns ChannelState.initialized
                 every { channelMock.presence } returns presenceMock
                 excludeRecords { channelMock.presence }
@@ -380,16 +381,16 @@ class DefaultAblyTestEnvironment private constructor(
                 ConfiguredChannel(trackableId, channelName, channelMock, presenceMock)
             }
 
-            val channelsMock = mockk<AblySdkRealtime.Channels>()
+            val channelsMock = mockk<AblySdkRealtime.Channels<AblySdkChannelStateListener>>()
             val connectionMock = mockk<AblySdkRealtime.Connection>()
 
-            val realtimeMock = mockk<AblySdkRealtime>()
+            val realtimeMock = mockk<AblySdkRealtime<AblySdkChannelStateListener>>()
             every { realtimeMock.channels } returns channelsMock
             excludeRecords { realtimeMock.channels }
             every { realtimeMock.connection } returns connectionMock
             excludeRecords { realtimeMock.connection }
 
-            val factory = mockk<AblySdkFactory>()
+            val factory = mockk<AblySdkFactory<AblySdkChannelStateListener>>()
             every { factory.createRealtime(any()) } returns realtimeMock
 
             val connectionConfiguration =

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -332,7 +332,7 @@ class TestResources(
         ): Publisher {
             val resolution = Resolution(Accuracy.BALANCED, 1000L, 0.0)
             val ablySdkFactory = object : AblySdkFactory {
-                override fun create(clientOptions: ClientOptions) = DefaultAblySdkRealtime(proxyClientOptions)
+                override fun createRealtime(clientOptions: ClientOptions) = DefaultAblySdkRealtime(proxyClientOptions)
             }
             val connectionConfiguration = ConnectionConfiguration(
                 Authentication.basic(

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -9,7 +9,7 @@ import com.ably.tracking.Accuracy
 import com.ably.tracking.Location
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
-import com.ably.tracking.common.AblySdkRealtimeFactory
+import com.ably.tracking.common.AblySdkFactory
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.common.DefaultAblySdkRealtime
 import com.ably.tracking.common.EventNames
@@ -331,7 +331,7 @@ class TestResources(
             locationChannelName: String
         ): Publisher {
             val resolution = Resolution(Accuracy.BALANCED, 1000L, 0.0)
-            val realtimeFactory = object : AblySdkRealtimeFactory {
+            val ablySdkFactory = object : AblySdkFactory {
                 override fun create(clientOptions: ClientOptions) = DefaultAblySdkRealtime(proxyClientOptions)
             }
             val connectionConfiguration = ConnectionConfiguration(
@@ -342,7 +342,7 @@ class TestResources(
             )
 
             return DefaultPublisher(
-                DefaultAbly(realtimeFactory, connectionConfiguration, Logging.aatDebugLogger),
+                DefaultAbly(ablySdkFactory, connectionConfiguration, Logging.aatDebugLogger),
                 DefaultMapbox(
                     context,
                     MapConfiguration(MAPBOX_ACCESS_TOKEN),

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -11,6 +11,7 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.AblySdkFactory
 import com.ably.tracking.common.DefaultAbly
+import com.ably.tracking.common.DefaultAblySdkChannelStateListener
 import com.ably.tracking.common.DefaultAblySdkRealtime
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.message.LocationGeometry
@@ -331,8 +332,12 @@ class TestResources(
             locationChannelName: String
         ): Publisher {
             val resolution = Resolution(Accuracy.BALANCED, 1000L, 0.0)
-            val ablySdkFactory = object : AblySdkFactory {
+            val ablySdkFactory = object : AblySdkFactory<DefaultAblySdkChannelStateListener> {
                 override fun createRealtime(clientOptions: ClientOptions) = DefaultAblySdkRealtime(proxyClientOptions)
+
+                override fun wrapChannelStateListener(underlyingListener: AblySdkFactory.UnderlyingChannelStateListener<DefaultAblySdkChannelStateListener>): DefaultAblySdkChannelStateListener {
+                    return DefaultAblySdkChannelStateListener(underlyingListener)
+                }
             }
             val connectionConfiguration = ConnectionConfiguration(
                 Authentication.basic(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherBuilder.kt
@@ -7,7 +7,7 @@ import androidx.annotation.RequiresPermission
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
-import com.ably.tracking.common.DefaultAblySdkRealtimeFactory
+import com.ably.tracking.common.DefaultAblySdkFactory
 import com.ably.tracking.common.logging.createLoggingTag
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -82,7 +82,7 @@ internal data class PublisherBuilder(
         logHandler?.v("$TAG Creating a publisher instance")
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultPublisher(
-            DefaultAbly(DefaultAblySdkRealtimeFactory(), connectionConfiguration!!, logHandler),
+            DefaultAbly(DefaultAblySdkFactory(), connectionConfiguration!!, logHandler),
             DefaultMapbox(
                 androidContext!!,
                 mapConfiguration!!,

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/SubscriberBuilder.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.BuilderConfigurationIncompleteException
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.DefaultAbly
-import com.ably.tracking.common.DefaultAblySdkRealtimeFactory
+import com.ably.tracking.common.DefaultAblySdkFactory
 import com.ably.tracking.common.logging.createLoggingTag
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.connection.ConnectionConfiguration
@@ -37,7 +37,7 @@ internal data class SubscriberBuilder(
         logHandler?.v("$TAG Creating a subscriber instance")
         // All below fields are required and above code checks if they are nulls, so using !! should be safe from NPE
         return DefaultSubscriber(
-            DefaultAbly(DefaultAblySdkRealtimeFactory(), connectionConfiguration!!, logHandler),
+            DefaultAbly(DefaultAblySdkFactory(), connectionConfiguration!!, logHandler),
             resolution,
             trackingId!!,
             logHandler,


### PR DESCRIPTION
I wanted to write unit tests that checked how `DefaultAbly` behaves in response to `AblySdkRealtime.Connection.on` emitting various `ChannelStateChange` values. However, I discovered that `ably-java`’s `ChannelStateChange` class does not have a public constructor. (For some reason, the analogous `ConnectionStateChange` class _does_ have a public constructor; not sure if this difference is intentional.) Furthermore, we cannot use MockK to create a useful mock of it, since its `current` etc values are implemented as Java fields as opposed to properties.

I wasn’t sure whether to modify ably-java to make `ChannelStateChange` publicly constructible. I decided not to, partly because I wasn’t very keen to go through the process of another `ably-java` release, and partly because I’m not convinced that it _should_ be publicly constructible. I’m happy to be challenged on both these points, though.

Furthermore, using a type that can be mocked by MockK gives us extra benefits, like being able to verify which fields of `ConnectionStateChange` are actually being accessed in a given test scenario.

<del>I feel a little bit out of my depth, Java/Kotlin-wise, with the code that manages the mapping of `AblySdkRealtime` listeners to `ably-java` listeners, so would appreciate a close eye on that. I'm also not sure whether the approach is a bit myopic and it would be simply better to hold a strong reference and remove it appropriately when `off` is called.</del> - new approach taken now which removes this complexity.