### PR TITLE
wait for publisher emissions before performing test assertion

### DIFF
--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -16,6 +16,7 @@ import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -94,6 +95,17 @@ class PublisherAndSubscriberTests {
         trackExpectation.assertSuccess()
         publisherStoppedExpectation.assertFulfilled()
         subscriberStoppedExpectation.assertFulfilled()
+
+        /*
+            Wait for everything to have been emitted onto the publisher locations channel,
+            as this happens on the same coroutine scope as, but outside of, the worker queue.
+         */
+        runBlocking {
+            while (publishedLocations.size < receivedLocations.size) {
+                delay(100);
+            }
+        }
+
         Assert.assertTrue(
             "Subscriber should receive at least half the number of events published (received: ${receivedLocations.size}, published: ${publishedLocations.size})",
             receivedLocations.size >= publishedLocations.size / 2

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -101,8 +102,10 @@ class PublisherAndSubscriberTests {
             as this happens on the same coroutine scope as, but outside of, the worker queue.
          */
         runBlocking {
-            while (publishedLocations.size < receivedLocations.size) {
-                delay(100)
+            withTimeout(10000) {
+                while (publishedLocations.size < receivedLocations.size) {
+                    delay(100)
+                }
             }
         }
 

--- a/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
+++ b/integration-testing-app/src/androidTest/java/com/ably/tracking/tests/PublisherAndSubscriberTests.kt
@@ -102,7 +102,7 @@ class PublisherAndSubscriberTests {
          */
         runBlocking {
             while (publishedLocations.size < receivedLocations.size) {
-                delay(100);
+                delay(100)
             }
         }
 


### PR DESCRIPTION
Emitting events on the publishers location channel is done on the same coroutine scope as, but outside of the worker queue. It's also initiated after we send the location update to any subscriber over the realtime service.

In a very specific order of events, this could cause the test to fail as the publisher will have sent the events to the subscriber, but not emitted them onto its location channel.

This change fixes the problem by ensuring that the publisher has emitted at least as many events as received by the subscriber before allowing test assertions to made.

Fixes #899