### PR TITLE
Write further unit tests for `DefaultAbly`

### DIFF
--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -2994,6 +2994,675 @@ class DefaultAblyTests {
         }
     }
 
+    /*
+    Observations from writing black-box tests for `sendRawLocation`:
+
+    - When given a channel in certain states, it seems to fetch the channel’s state more than once. I have not tested what happens if a different state is returned on the second call.
+     */
+
+    @Test
+    fun `sendRawLocation - when channel is in INITIALIZED state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the INITIALIZED state...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...it calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.initialized,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in ATTACHING state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the ATTACHING state...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in ATTACHED state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the ATTACHED state...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in DETACHING state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the DETACHING state...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in DETACHED state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the DETACHED state...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in FAILED state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the FAILED state...
+         * ...which, when told to publish a message, fails to do so with arbitrarily-chosen error `publishError`...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) fails with a ConnectionException whose `code` and `message` are equal to those of `publishError`.
+         */
+
+        /* A note on this test:
+         *
+         * RTL6c4 tells us that a publish attempt on a channel in the FAILED state will fail.
+         */
+
+        val publishError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.failed,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        publishError
+                    )
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                publishError.code,
+                                0,
+                                publishError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in SUSPENDED state and does not subsequently change state`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the SUSPENDED state...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and the call to `sendRawLocation` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = false,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in SUSPENDED state and then changes state to FAILED`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the SUSPENDED state...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is FAILED...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and the call to `sendRawLocation` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.failed
+                    ),
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPublish = false,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in SUSPENDED state and then changes state to DETACHED`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the SUSPENDED state...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is DETACHED...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and the call to `sendRawLocation` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.detached
+                    ),
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPublish = false,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel is in SUSPENDED state and then changes state to ATTACHED`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the SUSPENDED state...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ATTACHED...
+         * ...which, when told to publish a message, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and calls `off` on the channel...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.attached
+                    ),
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = true,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when publish fails`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the (arbitrarily-chosen) ATTACHED state...
+         * ...which, when told to publish a message, fails to do so with arbitrarily-chosen error `publishError`...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) fails with a ConnectionException whose `code` and `message` are equal to those of `publishError`.
+         */
+
+        val publishError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, /* arbitrarily chosen */
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        publishError
+                    )
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                publishError.code,
+                                0,
+                                publishError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when publish doesn't complete`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns true...
+         * ...and that the Channels instance’s `get` method (the overload that does not accept a ChannelOptions object) returns a channel in the (arbitrarily chosen) ATTACHED state...
+         * ...which, when told to publish a message, never finishes doing so...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to publish a message whose `name` property is "raw"...
+         * ...and the call to `sendRawLocation` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, /* arbitrarily chosen */
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = true,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.DoesNotTerminate(
+                        timeoutInMilliseconds = noTimeoutDemonstrationWaitingTimeInMilliseconds
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendRawLocation - when channel doesn't exist`() {
+        /* Given...
+         *
+         * ...that the Channels instance’s `containsKey` method returns false...
+         *
+         * When...
+         *
+         * ...we call `sendRawLocation` on the object under test (with an arbitrarily-chosen LocationUpdate argument),
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and the call to `sendRawLocation` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.SendRawLocation.test(
+                DefaultAblyTestScenarios.SendRawLocation.GivenConfig(
+                    channelsContainsKey = false,
+                    mockChannelsGet = false,
+                    initialChannelState = null,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    publishBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.SendRawLocation.ThenConfig(
+                    verifyChannelsGet = false,
+                    numberOfChannelStateFetchesToVerify = 0,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPublish = false,
+                    resultOfSendRawLocationCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
     @Test
     fun `close - behaviour when all presence leave calls succeed`() {
         // Given...

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -701,6 +701,714 @@ class DefaultAblyTests {
         }
     }
 
+    /*
+    Observations from writing black-box tests for `updatePresenceData`:
+
+    - When given a channel in certain states, it seems to fetch the channel’s state more than once. I have not tested what happens if a different state is returned on the second call.
+     */
+
+    @Test
+    fun `updatePresenceData - when channel is in INITIALIZED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state INITIALIZED...
+         * ...which, when told to update presence data, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.initialized,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in ATTACHING state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHING...
+         * ...which, when told to update presence data, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in ATTACHED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHED...
+         * ...which, when told to update presence data, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in DETACHING state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHING...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the DETACHING state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in DETACHED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHED...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the DETACHED state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in FAILED state`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state FAILED...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the FAILED state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.failed,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in SUSPENDED state and does not subsequently transition`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = false,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in SUSPENDED state and then transitions to ATTACHED`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ATTACHED...
+         * ...and which, when told to update presence data, does so successfully,
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the state change’s `current` property...
+         * ...and calls `off` on the channel...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.attached
+                    ),
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = true,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in SUSPENDED state and then transitions to FAILED`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is FAILED...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.failed
+                    ),
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = false,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel is in SUSPENDED state and then transitions to DETACHED`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is DETACHED...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.detached
+                    ),
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = false,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when presence update fails`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in the arbitrarily-chosen ATTACHED state...
+         * ...which, when told to update presence data, fails to do so with arbitrarily-chosen error `presenceError`,
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, // arbitrarily chosen
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when presence update doesn't complete`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in (arbitrarily chosen) state ATTACHED...
+         * ...which, when told to update presence data, never finishes doing so...
+         *
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+         * ...and checks the channel’s state once...
+         * ...and tells the channel to update presence data...
+         * ...and the call to `updatePresenceData` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, // arbitrarily chosen
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = true,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.DoesNotTerminate(
+                        timeoutInMilliseconds = noTimeoutDemonstrationWaitingTimeInMilliseconds
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `updatePresenceData - when channel doesn't exist`() {
+        /* Given...
+         *
+         * ...that calling `containsKey` on the Channels instance returns false...
+         *
+         * When...
+         *
+         * ...we call `updatePresenceData` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.UpdatePresenceData.test(
+                DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
+                    channelsContainsKey = false,
+                    mockChannelsGet = false,
+                    initialChannelState = null,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
+                    verifyChannelsGet = false,
+                    numberOfChannelStateFetchesToVerify = 0,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceUpdate = false,
+                    resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
     @Test
     fun `close - behaviour when all presence leave calls succeed`() {
         // Given...

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -177,7 +177,7 @@ class DefaultAblyTests {
          *
          * ...that calling `containsKey` on the Channels instance returns false...
          * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the DETACHING state...
-         * ...which, when told to enter presence, does so successfully...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
          *
          * When...
          *
@@ -190,8 +190,19 @@ class DefaultAblyTests {
          * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
          * ...and checks the channel’s state 2 times...
          * ...and tells the channel to enter presence...
-         * ...and the call to `connect` (on the object under test) succeeds.
+         * ...and releases the channel...
+         * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
          */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the DETACHING state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
 
         runBlocking {
             DefaultAblyTestScenarios.Connect.test(
@@ -200,16 +211,26 @@ class DefaultAblyTests {
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.detaching,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    ),
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     numberOfChannelStateFetchesToVerify = 2,
                     verifyPresenceEnter = true,
                     verifyChannelAttach = false,
-                    verifyChannelRelease = false,
+                    verifyChannelRelease = true,
                     resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
                     )
                 )
             )
@@ -532,7 +553,7 @@ class DefaultAblyTests {
          *
          * ...that calling `containsKey` on the Channels instance returns false...
          * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the SUSPENDED state...
-         * ...which, when told to enter presence, does so successfully...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
          *
          * When...
          *
@@ -545,8 +566,19 @@ class DefaultAblyTests {
          * ...and calls `get` (the overload that accepts a ChannelOptions object) on the Channels instance...
          * ...and checks the channel’s state 2 times...
          * ...and tells the channel to enter presence...
-         * ...and the call to `connect` (on the object under test) succeeds.
+         * ...and releases the channel...
+         * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
          */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the SUSPENDED state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
 
         runBlocking {
             DefaultAblyTestScenarios.Connect.test(
@@ -555,16 +587,26 @@ class DefaultAblyTests {
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.suspended,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    ),
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     numberOfChannelStateFetchesToVerify = 2,
                     verifyPresenceEnter = true,
                     verifyChannelAttach = false,
-                    verifyChannelRelease = false,
+                    verifyChannelRelease = true,
                     resultOfConnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
                     )
                 )
             )

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -2139,6 +2139,475 @@ class DefaultAblyTests {
         }
     }
 
+    /*
+    Observations from writing black-box tests for `startConnection`:
+
+    - When given a connection in certain states, it seems to fetch the connection’s state more than once. I have not tested what happens if a different state is returned on the second call.
+     */
+
+    @Test
+    fun `startConnection - when connection is in INITIALIZED state, and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns INITIALIZED...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is INITIALIZED, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.initialized,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.initialized,
+                        current = ConnectionState.connected,
+                        retryIn = 0, /* arbitrarily-chosen */
+                        reason = null /* arbitrarily-chosen */
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in CONNECTING state and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CONNECTING...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CONNECTING, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.connecting,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.connecting,
+                        current = ConnectionState.connected,
+                        retryIn = 0, /* arbitrarily-chosen */
+                        reason = null /* arbitrarily-chosen */
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in DISCONNECTED state and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns DISCONNECTED...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is DISCONNECTED, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.disconnected,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.disconnected,
+                        current = ConnectionState.connected,
+                        retryIn = 0,
+                        reason = null
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in SUSPENDED state and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns SUSPENDED...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is SUSPENDED, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.suspended,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.suspended,
+                        current = ConnectionState.connected,
+                        retryIn = 0,
+                        reason = null
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in CLOSING state and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CLOSING...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CLOSING, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.closing,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.closing,
+                        current = ConnectionState.connected,
+                        retryIn = 0,
+                        reason = null
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in CLOSED state and, after connect called, changes to CONNECTED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CLOSED...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CLOSED, `current` is CONNECTED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.closed,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.closed,
+                        current = ConnectionState.connected,
+                        retryIn = 0,
+                        reason = null
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in FAILED state`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns FAILED...
+         * ...and that the connection’s `reason` property returns the arbitrarily-chosen error `connectionReason`...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and fetches the connection’s `reason`...
+         * ...and the call to `startConnection` (on the object under test) fails with a ConnectionException whose `code` and `message` are equal to those of `connectionReason`.
+         */
+
+        val connectionReason = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.failed,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.Mocked(
+                        connectionReason
+                    ),
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = true,
+                    verifyConnectionOn = false,
+                    verifyConnect = false,
+                    verifyConnectionOff = false,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(
+                            connectionReason.code,
+                            0,
+                            connectionReason.message,
+                            null,
+                            null
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when connection is in CONNECTED state`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CONNECTED...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state once...
+         * ...and the call to `startConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.connected,
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour,
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 1,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = false,
+                    verifyConnect = false,
+                    verifyConnectionOff = false,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when, after connect called, connection changes to FAILED state`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns (arbitrarily chosen) INITIALIZED...
+         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is INITIALIZED, `current` is FAILED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is the arbitrarily-chosen error `connectionError`...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `startConnection` (on the object under test) fails with a ConnectionException whose `code` and `message` are equal to those of `connectionError`.
+         */
+
+        val connectionError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.initialized, /* arbitrarily-chosen */
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.initialized,
+                        current = ConnectionState.failed,
+                        retryIn = 0,
+                        reason = connectionError
+                    ),
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = true,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(
+                            connectionError.code,
+                            0,
+                            connectionError.message,
+                            null,
+                            null
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `startConnection - when, after connect is called, no connection state change occurs`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns (arbitrarily chosen) INITIALIZED...
+         *
+         * When...
+         *
+         * ...the `startConnection` method is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to connect...
+         * ...and the call to `startConnection` (on the object under test) fails with a ConnectionException whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for Ably to connect".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StartConnection.test(
+                DefaultAblyTestScenarios.StartConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.initialized, /* arbitrarily-chosen */
+                    connectionReasonBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionReasonMockBehaviour.NotMocked,
+                    connectBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour,
+                ),
+                DefaultAblyTestScenarios.StartConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionReasonFetch = false,
+                    verifyConnectionOn = true,
+                    verifyConnect = true,
+                    verifyConnectionOff = false,
+                    resultOfStartConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                        ErrorInformation(
+                            code = 100000,
+                            statusCode = 0,
+                            message = "Timeout was thrown when waiting for Ably to connect",
+                            href = null,
+                            cause = null
+                        )
+                    )
+                )
+            )
+        }
+    }
+
     @Test
     fun `close - behaviour when all presence leave calls succeed`() {
         // Given...

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -64,8 +64,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.initialized,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -109,8 +109,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.attached,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -154,8 +154,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.attaching,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -199,8 +199,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.detaching,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -250,10 +250,10 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.initialized, /* arbitrarily chosen */
+                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                     presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
                         presenceError
                     ),
-                    channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -305,8 +305,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.initialized, /* arbitrarily chosen */
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -328,8 +328,8 @@ class DefaultAblyTests {
          *
          * ...that calling `containsKey` on the Channels instance returns false...
          * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the FAILED state...
-         * ...which, when told to enter presence, does so successfully...
-         * ...and which, when told to attach, does so successfully...
+         * ...which, when told to attach, does so successfully...
+         * ...and which, when told to enter presence, does so successfully...
          *
          * When...
          *
@@ -352,8 +352,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.failed,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     verifyChannelAttach = true,
@@ -403,10 +403,10 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.failed,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
                         attachError
                     ),
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -430,8 +430,8 @@ class DefaultAblyTests {
          *
          * ...that calling `containsKey` on the Channels instance returns false...
          * ...and that calling `get` (the overload that accepts a ChannelOptions object) on the Channels instance returns a channel in the DETACHED state...
-         * ...which, when told to enter presence, does so successfully...
-         * ...and which, when told to attach, does so successfully...
+         * ...which, when told to attach, does so successfully...
+         * ...and which, when told to enter presence, does so successfully...
          *
          * When...
          *
@@ -454,8 +454,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.detached,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -554,8 +554,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.suspended,
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -599,8 +599,8 @@ class DefaultAblyTests {
                     channelsContainsKey = false,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
                     channelState = ChannelState.detached, /* arbitrarily chosen */
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITH_CHANNEL_OPTIONS,
@@ -642,8 +642,8 @@ class DefaultAblyTests {
                     channelsContainsKey = true,
                     channelsGetOverload = DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS,
                     channelState = ChannelState.initialized, /* arbitrarily chosen */
-                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                     channelAttachBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked,
+                    presenceEnterBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success,
                 ),
                 DefaultAblyTestScenarios.Connect.ThenConfig(
                     overloadOfChannelsGetToVerify = DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS,

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -1409,6 +1409,736 @@ class DefaultAblyTests {
         }
     }
 
+    /*
+    Observations from writing black-box tests for `disconnect`:
+
+    - When given a channel in certain states, it seems to fetch the channel’s state more than once. I have not tested what happens if a different state is returned on the second call.
+     */
+
+    @Test
+    fun `disconnect - when channel is in INITIALIZED state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state INITIALIZED...
+         * ...which, when told to leave presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.initialized,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = true,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in ATTACHING state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHING...
+         * ...which, when told to leave presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = true,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in ATTACHED state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHED...
+         * ...which, when told to leave presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = true,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in DETACHING state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHING...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and the call to `disconnect` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the DETACHING state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detaching,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in DETACHED state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHED...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and the call to `disconnect` (on the object under test) fails with a `ConnectionException` whose `errorInformation` has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the DETACHED state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.detached,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in FAILED state`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state FAILED...
+         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
+         */
+
+        /* A note on this test:
+         *
+         * RTP16c tells us that a presence operation on a channel in the FAILED state will fail.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.failed,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in SUSPENDED state with no subsequent state change`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = false,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to ATTACHED`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ATTACHED...
+         * ...and which, when told to leave presence, does so successfully...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and calls `off` on the channel...
+         * ...and tells the channel to leave presence...
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.attached
+                    ),
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = true,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = true,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to FAILED`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is FAILED...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.failed
+                    ),
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = false,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to DETACHED`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
+         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is DETACHED...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state twice...
+         * ...and calls `on` on the channel...
+         * ...and checks the `current` property of the emitted channel state change...
+         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.suspended,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
+                        current = ChannelState.detached
+                    ),
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 2,
+                    verifyChannelOn = true,
+                    verifyChannelStateChangeCurrent = true,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = false,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                code = 100000,
+                                statusCode = 0,
+                                message = "Timeout was thrown when waiting for channel to attach",
+                                href = null,
+                                cause = null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when presence leave fails`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in the arbitrarily-chosen ATTACHED state...
+         * ...which, when told to leave presence, fails to do so with an arbitrarily-chosen error `presenceError`...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
+         */
+
+        val presenceError = ErrorInfo(
+            "example of an error message", /* arbitrarily chosen */
+            123 /* arbitrarily chosen */
+        )
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, // arbitrarily chosen
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
+                        presenceError
+                    )
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
+                            ErrorInformation(
+                                presenceError.code,
+                                0,
+                                presenceError.message,
+                                null,
+                                null
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when presence leave does not complete`() {
+        /*
+         * Given...
+         *
+         * ...that calling containsKey on the Channels instance returns true...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in (arbitrarily chosen) state ATTACHED...
+         * ...which, when told to leave presence, never finishes doing so...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and calls `get` on the Channels instance...
+         * ...and fetches the channel’s state once...
+         * ...and tells the channel to leave presence...
+         * ...and the call to `disconnect` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = true,
+                    mockChannelsGet = true,
+                    initialChannelState = ChannelState.attached, // arbitrarily chosen
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = true,
+                    numberOfChannelStateFetchesToVerify = 1,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = true,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.DoesNotTerminate(
+                        timeoutInMilliseconds = noTimeoutDemonstrationWaitingTimeInMilliseconds
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `disconnect - when channel doesn't exist`() {
+        /* Given...
+         *
+         * ...that calling containsKey on the Channels instance returns false...
+         *
+         * When...
+         *
+         * ...we call `disconnect` on the object under test,
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         * ...it calls `containsKey` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.Disconnect.test(
+                DefaultAblyTestScenarios.Disconnect.GivenConfig(
+                    channelsContainsKey = false,
+                    mockChannelsGet = false,
+                    initialChannelState = null,
+                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
+                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
+                ),
+                DefaultAblyTestScenarios.Disconnect.ThenConfig(
+                    verifyChannelsGet = false,
+                    numberOfChannelStateFetchesToVerify = 0,
+                    verifyChannelOn = false,
+                    verifyChannelStateChangeCurrent = false,
+                    verifyChannelOff = false,
+                    verifyPresenceLeave = false,
+                    verifyChannelUnsubscribeAndRelease = false,
+                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                )
+            )
+        }
+    }
+
     @Test
     fun `close - behaviour when all presence leave calls succeed`() {
         // Given...

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -2608,6 +2608,392 @@ class DefaultAblyTests {
         }
     }
 
+    /*
+    Observations from writing black-box tests for `stopConnection`:
+
+    - When given a connection in certain states, it seems to fetch the connection’s state more than once. I have not tested what happens if a different state is returned on the second call.
+    */
+
+    @Test
+    fun `stopConnection - when connection is in INITIALIZED state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns INITIALIZED...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is INITIALIZED, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.initialized,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.initialized,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in CONNECTING state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CONNECTING...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CONNECTING, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.connecting,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.connecting,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in CONNECTED state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CONNECTED...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CONNECTED, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.connected,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.connected,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in DISCONNECTED state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns DISCONNECTED...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is DISCONNECTED, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.disconnected,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.disconnected,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in SUSPENDED state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns SUSPENDED...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is SUSPENDED, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.suspended,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.suspended,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in CLOSING state and, after close called, changes to CLOSED`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CLOSING...
+         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous` is CLOSING, `current` is CLOSED, `retryIn` is (arbitrarily-chosen) 0 and `reason` is (arbitrarily-chosen) null...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and removes a listener from the connection using `off`...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.closing,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange(
+                        previous = ConnectionState.closing,
+                        current = ConnectionState.closed,
+                        retryIn = 0,
+                        reason = null
+                    )
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = true,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in CLOSED state`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CLOSED...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state once...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.closed,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour,
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 1,
+                    verifyConnectionOn = false,
+                    verifyClose = false,
+                    verifyConnectionOff = false,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when connection is in FAILED state`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns FAILED...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and the call to `stopConnection` (on the object under test) succeeds.
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.failed,
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = false,
+                    verifyClose = false,
+                    verifyConnectionOff = false,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
+                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stopConnection - when, after close is called, no connection state change occurs`() {
+        /* Given...
+         *
+         * ...that the connection’s `state` property returns CONNECTED (arbitrarily chosen)...
+         *
+         * When...
+         *
+         * ...`stopConnection` is called on the object under test...
+         *
+         * Then...
+         * ...in the following order, precisely the following things happen...
+         *
+         * ...it fetches the connection’s state 2 times...
+         * ...and adds a listener to the connection using `on`...
+         * ...and tells the Realtime instance to close...
+         * ...and the call to `stopConnection` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
+         */
+
+        runBlocking {
+            DefaultAblyTestScenarios.StopConnection.test(
+                DefaultAblyTestScenarios.StopConnection.GivenConfig(
+                    initialConnectionState = ConnectionState.connected, // arbitrarily chosen
+                    closeBehaviour = DefaultAblyTestScenarios.GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour
+                ),
+                DefaultAblyTestScenarios.StopConnection.ThenConfig(
+                    numberOfConnectionStateFetchesToVerify = 2,
+                    verifyConnectionOn = true,
+                    verifyClose = true,
+                    verifyConnectionOff = false,
+                    resultOfStopConnectionCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.DoesNotTerminate(
+                        timeoutInMilliseconds = noTimeoutDemonstrationWaitingTimeInMilliseconds
+                    )
+                )
+            )
+        }
+    }
+
     @Test
     fun `close - behaviour when all presence leave calls succeed`() {
         // Given...

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -488,6 +488,13 @@ class DefaultAblyTestEnvironment private constructor(
         every { realtimeMock.connect() } returns Unit
     }
 
+    /**
+     * Stubs [realtimeMock]’s [AblySdkRealtime.close] method.
+     */
+    fun stubClose() {
+        every { realtimeMock.close() } returns Unit
+    }
+
     companion object {
         /**
          * Creates an instance of [DefaultAblyTestEnvironment], with some basic initial configuration applied to its mocks.

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -272,6 +272,41 @@ class DefaultAblyTestEnvironment private constructor(
         }
 
         /**
+         * Mocks [channelMock]’s [AblySdkRealtime.Channel.Publish] method to immediately pass its received completion listener to [handler].
+         *
+         * @param handler The function that should receive the completion listener passed to [channelMock]’s [AblySdkRealtime.Channel.publish] method.
+         */
+        private fun mockPublishResult(handler: (CompletionListener) -> Unit) {
+            val completionListenerSlot = slot<CompletionListener>()
+            every {
+                channelMock.publish(any(), capture(completionListenerSlot))
+            } answers { handler(completionListenerSlot.captured) }
+        }
+
+        /**
+         * Mocks [channelMock]’s [AblySdkRealtime.Channel.publish] method to immediately call its received completion listener’s [CompletionListener.onSuccess] method.
+         */
+        fun mockSuccessfulPublish() {
+            mockPublishResult { it.onSuccess() }
+        }
+
+        /**
+         * Mocks [channelMock]’s [AblySdkRealtime.Channel.publish] method to immediately call its received completion listener’s [CompletionListener.onError] method.
+         *
+         * @param errorInfo The error that should be passed to the completion listener’s [CompletionListener.onError] method.
+         */
+        fun mockFailedPublish(errorInfo: ErrorInfo) {
+            mockPublishResult { it.onError(errorInfo) }
+        }
+
+        /**
+         * Mocks [channelMock]’s [AblySdkRealtime.Channel.publish] method to never call any methods on its received completion listener.
+         */
+        fun mockNonCompletingPublish() {
+            mockPublishResult { }
+        }
+
+        /**
          * Stubs [channelMock]’s [AblySdkRealtime.Channel.on] method.
          */
         fun stubOn() {

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -413,6 +413,10 @@ class DefaultAblyTestEnvironment private constructor(
         every { connectionMock.state } returns state
     }
 
+    fun mockConnectionReason(reason: ErrorInfo?) {
+        every { connectionMock.reason } returns reason
+    }
+
     /**
      * Mocks [connectionMock]’s [AblySdkRealtime.Connection.on] method to capture the received [ConnectionStateListener], and mocks [realtimeMock]’s [AblySdkRealtime.close] method to immediately call this listener with a [ConnectionStateListener.ConnectionStateChange] object constructed from the [previous], [current], [retryIn] and [reason] arguments.
      *
@@ -439,10 +443,49 @@ class DefaultAblyTestEnvironment private constructor(
     }
 
     /**
+     * Mocks [connectionMock]’s [AblySdkRealtime.Connection.on] method to capture the received [ConnectionStateListener], and mocks [realtimeMock]’s [AblySdkRealtime.connect] method to immediately call this listener with a [ConnectionStateListener.ConnectionStateChange] object constructed from the [previous], [current], [retryIn] and [reason] arguments.
+     *
+     * @param previous The value to be used as the `previous` parameter of [ConnectionStateListener.ConnectionStateChange]’s constructor.
+     * @param current The value to be used as the `current` parameter of [ConnectionStateListener.ConnectionStateChange]’s constructor.
+     * @param retryIn The value to be used as the `retryIn` parameter of [ConnectionStateListener.ConnectionStateChange]’s constructor.
+     * @param reason The value to be used as the `reason` parameter of [ConnectionStateListener.ConnectionStateChange]’s constructor.
+     */
+    fun mockConnectToEmitStateChange(
+        previous: ConnectionState,
+        current: ConnectionState,
+        retryIn: Long,
+        reason: ErrorInfo?
+    ) {
+        val connectionStateListenerSlot = slot<ConnectionStateListener>()
+        every { connectionMock.on(capture(connectionStateListenerSlot)) } returns Unit
+
+        every { realtimeMock.connect() } answers {
+            val connectionStateChange = ConnectionStateListener.ConnectionStateChange(
+                previous, current, retryIn, reason
+            )
+            connectionStateListenerSlot.captured.onConnectionStateChanged(connectionStateChange)
+        }
+    }
+
+    /**
+     * Stubs [connectionMock]’s [AblySdkRealtime.Connection.on] method.
+     */
+    fun stubConnectionOn() {
+        every { connectionMock.on(any()) } returns Unit
+    }
+
+    /**
      * Stubs [connectionMock]’s [AblySdkRealtime.Connection.off] method.
      */
     fun stubConnectionOff() {
         every { connectionMock.off(any()) } returns Unit
+    }
+
+    /**
+     * Stubs [realtimeMock]’s [AblySdkRealtime.connect] method.
+     */
+    fun stubConnect() {
+        every { realtimeMock.connect() } returns Unit
     }
 
     companion object {

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestEnvironment.kt
@@ -136,6 +136,13 @@ class DefaultAblyTestEnvironment private constructor(
         }
 
         /**
+         * Mocks [presenceMock]’s [AblySdkRealtime.Presence.enter] method to never call any methods on its received completion listener.
+         */
+        fun mockNonCompletingPresenceEnter() {
+            mockPresenceEnterResult { }
+        }
+
+        /**
          * Mocks [presenceMock]’s [AblySdkRealtime.Presence.leave] method to immediately pass its received completion listener to [handler].
          *
          * @param handler The function that should receive the completion listener passed to [presenceMock]’s [AblySdkRealtime.Presence.leave] method.
@@ -203,6 +210,13 @@ class DefaultAblyTestEnvironment private constructor(
          */
         fun mockFailedAttach(errorInfo: ErrorInfo) {
             mockAttachResult { it.onError(errorInfo) }
+        }
+
+        /**
+         * Mocks [channelMock]’s [AblySdkRealtime.Channel.attach] method to never call any methods on its received completion listener.
+         */
+        fun mockNonCompletingAttach() {
+            mockAttachResult { }
         }
     }
 

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -2,8 +2,10 @@ package com.ably.tracking.common.helper
 
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.ErrorInformation
+import com.ably.tracking.common.AblySdkChannelStateListener
 import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.AblySdkRealtime
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.types.ErrorInfo
 import io.mockk.confirmVerified
@@ -27,6 +29,14 @@ class DefaultAblyTestScenarios {
             object Success : CompletionListenerMockBehaviour()
             class Failure(val errorInfo: ErrorInfo) : CompletionListenerMockBehaviour()
             object DoesNotComplete : CompletionListenerMockBehaviour()
+        }
+
+        /**
+         * Describes how a test case should interact with the [AblySdkChannelStateListener] instances added to a channel using [AblySdkRealtime.Channel.on]. Individual test cases should document how they interpret the values this class can take.
+         */
+        sealed class ChannelStateChangeBehaviour() {
+            object NoBehaviour : ChannelStateChangeBehaviour()
+            class EmitStateChange(val current: ChannelState) : ChannelStateChangeBehaviour()
         }
     }
 
@@ -152,6 +162,11 @@ class DefaultAblyTestScenarios {
             }
         }
     }
+
+    /**
+     * This exception is thrown when a test scenario is executed with an invalid configuration due to programmer error.
+     */
+    class InvalidTestConfigurationException(message: String) : Exception(message)
 
     companion object {
         /**
@@ -428,6 +443,332 @@ class DefaultAblyTestScenarios {
                  * }
                  */
                 thenConfig.resultOfConnectCallOnObjectUnderTest.verify(result)
+
+                confirmVerified(*testEnvironment.allMocks)
+            }
+        }
+    }
+
+    /**
+     * Provides test scenarios for [DefaultAbly.updatePresenceData]. See the [Companion.test] method.
+     */
+    class UpdatePresenceData {
+        /**
+         * This class provides properties for configuring the "Given..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class GivenConfig(
+            val channelsContainsKey: Boolean,
+            val mockChannelsGet: Boolean,
+            /**
+             * This must be `null` if and only if [mockChannelsGet] is `false`.
+             */
+            val initialChannelState: ChannelState?,
+            /**
+             * If [mockChannelsGet] is `false` then this must be [GivenTypes.ChannelStateChangeBehaviour.NoBehaviour].
+             */
+            val channelStateChangeBehaviour: GivenTypes.ChannelStateChangeBehaviour,
+            /**
+             * If [mockChannelsGet] is `false` then this must be [GivenTypes.CompletionListenerMockBehaviour.NotMocked].
+             */
+            val presenceUpdateBehaviour: GivenTypes.CompletionListenerMockBehaviour
+        ) {
+            /**
+             * Checks that this object represents a valid test configuration.
+             *
+             * @throws InvalidTestConfigurationException If this object does not represent a valid test configuration.
+             */
+            fun validate() {
+                if (mockChannelsGet) {
+                    if (initialChannelState == null) {
+                        throw InvalidTestConfigurationException("initialChannelState must be non-null when mockChannelsGet is true")
+                    }
+                } else {
+                    if (initialChannelState != null) {
+                        throw InvalidTestConfigurationException("initialChannelState must be null when mockChannelsGet is false")
+                    }
+                    if (channelStateChangeBehaviour !is GivenTypes.ChannelStateChangeBehaviour.NoBehaviour) {
+                        throw InvalidTestConfigurationException("channelStateChangeBehaviour must be NoBehaviour when mockChannelsGet is false")
+                    }
+                    if (presenceUpdateBehaviour !is GivenTypes.CompletionListenerMockBehaviour.NotMocked) {
+                        throw InvalidTestConfigurationException("presenceUpdateBehaviour must be NotMocked when mockChannelsGet is false")
+                    }
+                }
+            }
+        }
+
+        /**
+         * This class provides properties for configuring the "Then..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class ThenConfig(
+            val verifyChannelsGet: Boolean,
+            /**
+             * If [GivenConfig.mockChannelsGet] is `false` then this must be zero.
+             */
+            val numberOfChannelStateFetchesToVerify: Int,
+            /**
+             * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
+             */
+            val verifyChannelOn: Boolean,
+            /**
+             * If [GivenConfig.channelStateChangeBehaviour] is not [GivenTypes.ChannelStateChangeBehaviour.EmitStateChange] then this must be `false`.
+             */
+            val verifyChannelStateChangeCurrent: Boolean,
+            /**
+             * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
+             */
+            val verifyChannelOff: Boolean,
+            /**
+             * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
+             */
+            val verifyPresenceUpdate: Boolean,
+            val resultOfUpdatePresenceCallOnObjectUnderTest: ThenTypes.ExpectedAsyncResult
+        ) {
+            /**
+             * Checks that this object represents a valid test configuration to be used with [givenConfig].
+             *
+             * @param givenConfig The configuration that `this` is intended to be used with.
+             * @throws InvalidTestConfigurationException If this object does not represent a valid test configuration.
+             */
+            fun validate(givenConfig: GivenConfig) {
+                if (!givenConfig.mockChannelsGet) {
+                    if (numberOfChannelStateFetchesToVerify != 0) {
+                        throw InvalidTestConfigurationException("numberOfChannelStateFetchesToVerify must be zero when mockChannelsGet is false")
+                    }
+                    if (verifyChannelOn) {
+                        throw InvalidTestConfigurationException("verifyChannelOn must be false when mockChannelsGet is false")
+                    }
+                    if (verifyChannelOff) {
+                        throw InvalidTestConfigurationException("verifyChannelOn must be false when mockChannelsGet is false")
+                    }
+                    if (verifyPresenceUpdate) {
+                        throw InvalidTestConfigurationException("verifyPresenceUpdate must be false when mockChannelsGet is false")
+                    }
+                }
+                if (givenConfig.channelStateChangeBehaviour !is GivenTypes.ChannelStateChangeBehaviour.EmitStateChange) {
+                    if (verifyChannelStateChangeCurrent) {
+                        throw InvalidTestConfigurationException("verifyChannelStateChangeCurrent must be false when channelStateChangeBehaviour is not EmitStateChange")
+                    }
+                }
+            }
+        }
+
+        companion object {
+            /**
+             * Implements the following parameterised test case for [DefaultAbly.updatePresenceData]:
+             *
+             * ```text
+             * Given...
+             *
+             * ...that calling `containsKey` on the Channels instance returns ${givenConfig.channelsContainsKey}...
+             *
+             * if ${givenConfig.mockChannelsGet} {
+             * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ${givenConfig.initialChannelState}...
+             * }
+             *
+             * when ${givenConfig.channelStateChangeBehaviour} is EmitStateChange {
+             * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ${givenConfig.channelStateChangeBehaviour.current}...
+             * }
+             *
+             * when ${givenConfig.presenceUpdateBehaviour} is Success {
+             * ...[and] which, when told to update presence data, does so successfully...
+             * }
+             *
+             * when ${givenConfig.presenceUpdateBehaviour} is Failure {
+             * ...[and] which, when told to update presence data, fails to do so with error ${givenConfig.presenceUpdateBehaviour.errorInfo}...
+             * }
+             *
+             * when ${givenConfig.presenceUpdateBehaviour} is DoesNotComplete {
+             * ...[and] which, when told to update presence data, never finishes doing so...
+             * }
+             *
+             *
+             * When...
+             *
+             * ...we call `updatePresenceData` on the object under test,
+             *
+             * Then...
+             * ...in the following order, precisely the following things happen...
+             *
+             * ...it calls `containsKey` on the Channels instance...
+             *
+             * if ${thenConfig.verifyChannelsGet} {
+             * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+             * }
+             *
+             * ...and checks the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
+             *
+             * if ${thenConfig.verifyChannelOn} {
+             * ...and calls `on` on the channel...
+             * }
+             *
+             * if ${thenConfig.verifyChannelStateChangeCurrent}
+             * ...and checks the state change’s `current` property...
+             * }
+             *
+             * if ${thenConfig.verifyChannelOff} {
+             * ...and calls `off` on the channel...
+             * }
+             *
+             * if ${thenConfig.verifyPresenceUpdate} {
+             * ...and tells the channel to update presence data...
+             * }
+             *
+             * when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.expectedResult} is Success {
+             * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+             * }
+             *
+             * when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+             * ...and the call to `updatePresenceData` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.errorInformation}.
+             * }
+             *
+             * when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is DoesNotTerminate {
+             * ...and the call to `updatePresenceData` (on the object under test) does not complete within ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
+             * }
+             * ```
+             */
+            suspend fun test(givenConfig: GivenConfig, thenConfig: ThenConfig) {
+                givenConfig.validate()
+                thenConfig.validate(givenConfig)
+
+                // Given...
+
+                val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 1)
+                val configuredChannel = testEnvironment.configuredChannels[0]
+
+                // ...that calling `containsKey` on the Channels instance returns ${givenConfig.channelsContainsKey}...
+                testEnvironment.mockChannelsContainsKey(
+                    configuredChannel.channelName,
+                    givenConfig.channelsContainsKey
+                )
+
+                if (givenConfig.mockChannelsGet) {
+                    /* if ${givenConfig.mockChannelsGet} {
+                     * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ${givenConfig.initialChannelState}...
+                     * }
+                     */
+                    testEnvironment.mockChannelsGet(DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS)
+                    configuredChannel.mockState(givenConfig.initialChannelState!!)
+                }
+
+                val channelStateChangeMock: AblySdkChannelStateListener.ChannelStateChange?
+                when (
+                    val givenChannelStateChangeBehaviour =
+                        givenConfig.channelStateChangeBehaviour
+                ) {
+                    is GivenTypes.ChannelStateChangeBehaviour.NoBehaviour -> {
+                        configuredChannel.stubOn()
+                        channelStateChangeMock = null
+                    }
+                    is GivenTypes.ChannelStateChangeBehaviour.EmitStateChange -> {
+                        /* when ${givenConfig.channelStateChangeBehaviour} is EmitStateChange {
+                         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ${givenConfig.channelStateChangeBehaviour.current}...
+                         * }
+                         */
+                        channelStateChangeMock =
+                            configuredChannel.mockOnToEmitStateChange(current = givenChannelStateChangeBehaviour.current)
+                        configuredChannel.stubOff()
+                    }
+                }
+
+                when (val givenPresenceUpdateBehaviour = givenConfig.presenceUpdateBehaviour) {
+                    is GivenTypes.CompletionListenerMockBehaviour.NotMocked -> {}
+                    /* when ${givenConfig.presenceUpdateBehaviour} is Success {
+                     * ...[and] which, when told to update presence data, does so successfully...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Success -> {
+                        configuredChannel.mockSuccessfulPresenceUpdate()
+                    }
+                    /* when ${givenConfig.presenceUpdateBehaviour} is Failure {
+                     * ...[and] which, when told to update presence data, fails to do so with error ${givenConfig.presenceUpdateBehaviour.errorInfo}...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
+                        configuredChannel.mockFailedPresenceUpdate(givenPresenceUpdateBehaviour.errorInfo)
+                    }
+                    /* when ${givenConfig.presenceUpdateBehaviour} is DoesNotComplete {
+                     * ...[and] which, when told to update presence data, never finishes doing so...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete -> {
+                        configuredChannel.mockNonCompletingPresenceUpdate()
+                    }
+                }
+
+                // When...
+
+                val result = executeForVerifying(thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest) {
+                    // ...we call `updatePresenceData` on the object under test,
+                    testEnvironment.objectUnderTest.updatePresenceData(
+                        configuredChannel.trackableId,
+                        PresenceData("") /* arbitrarily chosen */
+                    )
+                }
+
+                // Then...
+                // ...in the following order, precisely the following things happen...
+                verifyOrder {
+                    // ...it calls `containsKey` on the Channels instance...
+                    testEnvironment.channelsMock.containsKey(configuredChannel.channelName)
+
+                    if (thenConfig.verifyChannelsGet) {
+                        /* if ${thenConfig.verifyChannelsGet} {
+                         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
+                         * }
+                         */
+                        testEnvironment.channelsMock.get(configuredChannel.channelName)
+                    }
+
+                    repeat(thenConfig.numberOfChannelStateFetchesToVerify) {
+                        // ...and checks the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
+                        configuredChannel.channelMock.state
+                    }
+
+                    if (thenConfig.verifyChannelOn) {
+                        /* if ${thenConfig.verifyChannelOn} {
+                         * ...and calls `on` on the channel...
+                         */
+                        configuredChannel.channelMock.on(any())
+                    }
+
+                    if (thenConfig.verifyChannelStateChangeCurrent) {
+                        /* if ${thenConfig.verifyChannelStateChangeCurrent}
+                         * ...and checks the state change’s `current` property...
+                         * }
+                         */
+                        channelStateChangeMock!!.current
+                    }
+
+                    if (thenConfig.verifyChannelOff) {
+                        /* if ${thenConfig.verifyChannelOff} {
+                         * ...and calls `off` on the channel...
+                         * }
+                         */
+                        configuredChannel.channelMock.off(any())
+                    }
+
+                    if (thenConfig.verifyPresenceUpdate) {
+                        /* if ${thenConfig.verifyPresenceUpdate} {
+                         * ...and tells the channel to update presence data...
+                         * }
+                         */
+                        configuredChannel.presenceMock.update(any(), any())
+                    }
+                }
+
+                /* when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.expectedResult} is Success {
+                 * ...and the call to `updatePresenceData` (on the object under test) succeeds.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+                 * ...and the call to `updatePresenceData` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.errorInformation}.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest} is DoesNotTerminate {
+                 * ...and the call to `updatePresenceData` (on the object under test) does not complete within ${thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
+                 * }
+                 */
+                thenConfig.resultOfUpdatePresenceCallOnObjectUnderTest.verify(result)
 
                 confirmVerified(*testEnvironment.allMocks)
             }

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -1336,4 +1336,171 @@ class DefaultAblyTestScenarios {
             }
         }
     }
+
+    /**
+     * Provides test scenarios for [DefaultAbly.stopConnection]. See the [Companion.test] method.
+     */
+    class StopConnection {
+        /**
+         * This class provides properties for configuring the "Given..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class GivenConfig(
+            val initialConnectionState: ConnectionState,
+            val closeBehaviour: GivenTypes.ConnectionStateChangeBehaviour
+        )
+
+        /**
+         * This class provides properties for configuring the "Then..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class ThenConfig(
+            val numberOfConnectionStateFetchesToVerify: Int,
+            val verifyConnectionOn: Boolean,
+            val verifyClose: Boolean,
+            val verifyConnectionOff: Boolean,
+            val resultOfStopConnectionCallOnObjectUnderTest: ThenTypes.ExpectedAsyncResult
+        ) {
+            /**
+             * Checks that this object represents a valid test configuration.
+             *
+             * @throws InvalidTestConfigurationException If this object does not represent a valid test configuration.
+             */
+            fun validate() {
+                if (resultOfStopConnectionCallOnObjectUnderTest is ThenTypes.ExpectedAsyncResult.Terminates && resultOfStopConnectionCallOnObjectUnderTest.expectedResult is ThenTypes.ExpectedResult.FailureWithConnectionException) {
+                    throw InvalidTestConfigurationException("resultOfStopConnectionCallOnObjectUnderTest.expectedResult must not be FailureWithConnectionException")
+                }
+            }
+        }
+
+        companion object {
+            /**
+             * Implements the following parameterised test case for [DefaultAbly.stopConnection]:
+             *
+             * ```text
+             * Given...
+             *
+             * ...that the connection’s `state` property returns ${givenConfig.initialConnectionState}...
+             *
+             * when ${givenConfig.closeBehaviour} is EmitStateChange {
+             * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous`, `current`, `retryIn` and `reason` are those of ${givenConfig.closeBehaviour}...
+             * }
+             *
+             * When...
+             *
+             * ...`stopConnection` is called on the object under test...
+             *
+             * Then...
+             * ...in the following order, precisely the following things happen...
+             *
+             * ...it fetches the connection’s state ${thenConfig.numberOfConnectionStateFetchesToVerify} times...
+             *
+             * if ${thenConfig.verifyConnectionOn} {
+             * ...and adds a listener to the connection using `on`...
+             * }
+             *
+             * if ${thenConfig.verifyClose} {
+             * ...and tells the Realtime instance to close...
+             * }
+             *
+             * if ${thenConfig.verifyConnectionOff} {
+             * ...and removes a listener from the connection using `off`...
+             * }
+             *
+             * when ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest.result} is Success {
+             * ...and the call to `stopConnection` (on the object under test) succeeds.
+             * }
+             *
+             * when ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} is DoesNotTerminate {
+             * ...and the call to `stopConnection` (on the object under test) does not complete within ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} milliseconds.
+             * }
+             * ```
+             */
+            suspend fun test(
+                givenConfig: GivenConfig,
+                thenConfig: ThenConfig
+            ) {
+                thenConfig.validate()
+
+                val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 0)
+
+                // Given...
+
+                // ...that the connection’s `state` property returns ${givenConfig.initialConnectionState}...
+                testEnvironment.mockConnectionState(givenConfig.initialConnectionState)
+
+                when (val givenCloseBehaviour = givenConfig.closeBehaviour) {
+                    is GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour -> {
+                        testEnvironment.stubConnectionOn()
+                        testEnvironment.stubClose()
+                    }
+                    is GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange -> {
+                        /* when ${givenConfig.closeBehaviour} is EmitStateChange {
+                         * ...and that when the Realtime instance’s `close` method is called, its connection’s `on` method immediately emits a connection state change whose `previous`, `current`, `retryIn` and `reason` are those of ${givenConfig.closeBehaviour}...
+                         * }
+                         */
+                        testEnvironment.mockCloseToEmitStateChange(
+                            previous = givenCloseBehaviour.previous,
+                            current = givenCloseBehaviour.current,
+                            retryIn = givenCloseBehaviour.retryIn,
+                            reason = givenCloseBehaviour.reason
+                        )
+                    }
+                }
+
+                testEnvironment.stubConnectionOff()
+
+                // When...
+
+                val result = executeForVerifying(thenConfig.resultOfStopConnectionCallOnObjectUnderTest) {
+                    // ...`stopConnection` is called on the object under test...
+                    testEnvironment.objectUnderTest.stopConnection()
+                }
+
+                // Then...
+                // ...in the following order, precisely the following things happen...
+
+                verifyOrder {
+                    // ...it fetches the connection’s state ${thenConfig.numberOfConnectionStateFetchesToVerify} times...
+                    repeat(thenConfig.numberOfConnectionStateFetchesToVerify) {
+                        testEnvironment.connectionMock.state
+                    }
+
+                    if (thenConfig.verifyConnectionOn) {
+                        /* if ${thenConfig.verifyConnectionOn} {
+                         * ...and adds a listener to the connection using `on`...
+                         * }
+                         */
+                        testEnvironment.connectionMock.on(any())
+                    }
+
+                    if (thenConfig.verifyClose) {
+                        /* if ${thenConfig.verifyClose} {
+                         * ...and tells the Realtime instance to close...
+                         * }
+                         */
+                        testEnvironment.realtimeMock.close()
+                    }
+
+                    if (thenConfig.verifyConnectionOff) {
+                        /* if ${thenConfig.verifyConnectionOff} {
+                         * ...and removes a listener from the connection using `off`...
+                         * }
+                         */
+                        testEnvironment.connectionMock.off(any())
+                    }
+                }
+
+                /* when ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest.result} is Success {
+                 * ...and the call to `stopConnection` (on the object under test) succeeds.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} is DoesNotTerminate {
+                 * ...and the call to `stopConnection` (on the object under test) does not complete within ${thenConfig.resultOfStopConnectionCallOnObjectUnderTest} milliseconds.
+                 * }
+                 */
+                thenConfig.resultOfStopConnectionCallOnObjectUnderTest.verify(result)
+
+                confirmVerified(*testEnvironment.allMocks)
+            }
+        }
+    }
 }

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -8,6 +8,10 @@ import io.ably.lib.realtime.ChannelState
 import io.ably.lib.types.ErrorInfo
 import io.mockk.confirmVerified
 import io.mockk.verifyOrder
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert
 
 class DefaultAblyTestScenarios {
@@ -22,6 +26,7 @@ class DefaultAblyTestScenarios {
             object NotMocked : CompletionListenerMockBehaviour()
             object Success : CompletionListenerMockBehaviour()
             class Failure(val errorInfo: ErrorInfo) : CompletionListenerMockBehaviour()
+            object DoesNotComplete : CompletionListenerMockBehaviour()
         }
     }
 
@@ -85,6 +90,105 @@ class DefaultAblyTestScenarios {
                 }
             }
         }
+
+        /**
+         * Describes the expected result of an asynchronous operation which returns a [Result] instance to communicate its result.
+         */
+        sealed class ExpectedAsyncResult {
+            /**
+             * The operation terminates and its result is described by [expectedResult].
+             */
+            class Terminates(val expectedResult: ExpectedResult) : ExpectedAsyncResult()
+
+            /**
+             * The operation does not terminate within [timeoutInMilliseconds] milliseconds.
+             */
+            class DoesNotTerminate(val timeoutInMilliseconds: Long) : ExpectedAsyncResult()
+
+            /**
+             * Given [result], which represents the result of an asynchronous operation `op`, this implements the following steps of the "Then..." part of a parameterised test case:
+             *
+             * ```text
+             * when ${this} is Terminates and ${this.expectedResult} is Success {
+             * ...and ${op} succeeds.
+             * }
+             *
+             * when ${this} is Terminates and ${this.expectedResult} is FailureWithConnectionException {
+             * ...and ${op} fails with a ConnectionException whose errorInformation is equal to ${this.errorInformation}.
+             * }
+             *
+             * when ${this} is DoesNotTerminate {
+             * ...and ${op} does not complete within ${this.timeoutInMilliseconds} milliseconds.
+             * }
+             * ```
+             *
+             * @param result `null` if the execution of `op` lasted longer than some timeout described by `this`, else the result of `op`’s execution. For example, a value returned by executing `op` using [executeForVerifying], with `this` as the `expectedAsyncResult` argument.
+             */
+            fun <T> verify(result: Result<T>?) {
+                when (this) {
+                    is Terminates -> {
+                        /* when ${this} is Terminates and ${this.expectedResult} is Success {
+                         * ...and ${op} succeeds.
+                         * }
+                         *
+                         * when ${this} is Terminates and ${this.expectedResult} is FailureWithConnectionException {
+                         * ...and ${op} fails with a ConnectionException whose errorInformation is equal to ${this.errorInformation}.
+                         * }
+                         */
+                        Assert.assertNotNull(result)
+                        if (result != null) {
+                            expectedResult.verify(result)
+                        }
+                    }
+
+                    is DoesNotTerminate -> {
+                        /* when ${this} is DoesNotTerminate {
+                         * ...and ${op} does not complete within ${this.timeoutInMilliseconds} milliseconds.
+                         * }
+                         */
+                        Assert.assertNull(result)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Executes asynchronous operation [operation] in an environment suitable for later verifying whether its result was as described by [expectedAsyncResult].
+         *
+         * @param expectedAsyncResult The expected result of [operation].
+         * @param operation The operation to execute, whose result the caller intends to subsequently verify [expectedAsyncResult] as describing.
+         * @return `null` if the execution of [operation] lasted longer than some timeout described by [expectedAsyncResult], else the result of [operation]’s execution. You can later pass this value to [ThenTypes.ExpectedAsyncResult.verify].
+         */
+        suspend fun <T> executeForVerifying(
+            expectedAsyncResult: ThenTypes.ExpectedAsyncResult,
+            operation: suspend () -> T
+        ): T? {
+            return when (expectedAsyncResult) {
+                is ThenTypes.ExpectedAsyncResult.Terminates -> {
+                    operation()
+                }
+                is ThenTypes.ExpectedAsyncResult.DoesNotTerminate -> {
+                    try {
+                        withTimeout(timeMillis = expectedAsyncResult.timeoutInMilliseconds) {
+                            /* This usage of runInterruptible is intended to ensure that even if `operation` is not cancellable — that is, even if it does not cooperate with cancellation (https://kotlinlang.org/docs/cancellation-and-timeouts.html#cancellation-is-cooperative) — the withTimeout method call will return after the timeout elapses. We have some methods in DefaultAbly that are not cancellable – see https://github.com/ably/ably-asset-tracking-android/issues/908.
+                             *
+                             * Perhaps there’s a better way to do this — to create a coroutine that’s cancellable even if it calls a non-cancellable one — that doesn’t involve making a trip from coroutines land to synchronous land and back again. I’m not familiar enough with the coroutines APIs to know.
+                             */
+
+                            runInterruptible {
+                                runBlocking {
+                                    operation()
+                                }
+                            }
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        null
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -111,7 +215,7 @@ class DefaultAblyTestScenarios {
             val verifyPresenceEnter: Boolean,
             val verifyChannelAttach: Boolean,
             val verifyChannelRelease: Boolean,
-            val resultOfConnectCallOnObjectUnderTest: ThenTypes.ExpectedResult
+            val resultOfConnectCallOnObjectUnderTest: ThenTypes.ExpectedAsyncResult
         )
 
         companion object {
@@ -132,12 +236,20 @@ class DefaultAblyTestScenarios {
              * ...which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
              * }
              *
-             * when ${givenConfig.channelAttachBehaviour} is Success {
-             * ...[and] which, when told to attach, does so successfully...
+             * when ${givenConfig.presenceEnterBehaviour} is DoesNotComplete {
+             * ...which, when told to enter presence, never finishes doing so...
+             * }
+             *
+             * when ${givenConfig.presenceEnterBehaviour} is Success {
+             * ...[and] which, when told to enter presence, does so successfully...
              * }
              *
              * when ${givenConfig.channelAttachBehaviour} is Failure {
              * ...[and] which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
+             * }
+             *
+             * when ${givenConfig.channelAttachBehaviour} is DoesNotComplete {
+             * ...[and] which, when told to attach, never finishes doing so...
              * }
              *
              * When...
@@ -163,12 +275,16 @@ class DefaultAblyTestScenarios {
              * ...and releases the channel...
              * }
              *
-             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Success {
+             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfConnectCallOnObjectUnderTest.expectedResult} is Success {
              * ...and the call to `connect` (on the object under test) succeeds.
              * }
              *
-             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is FailureWithConnectionException {
-             * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInfo}.
+             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfConnectCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+             * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInformation}.
+             * }
+             *
+             * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is DoesNotTerminate {
+             * ...and the call to `connect` (on the object under test) does not complete within ${thenConfig.resultOfConnectCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
              * }
              * ```
              *
@@ -209,6 +325,13 @@ class DefaultAblyTestScenarios {
                     is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
                         configuredChannel.mockFailedPresenceEnter(givenPresenceEnterBehaviour.errorInfo)
                     }
+                    /* when ${givenConfig.channelAttachBehaviour} is DoesNotComplete {
+                     * ...which, when told to attach, never finishes doing so...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete -> {
+                        configuredChannel.mockNonCompletingAttach()
+                    }
                 }
 
                 when (val givenChannelAttachBehaviour = givenConfig.channelAttachBehaviour) {
@@ -227,15 +350,24 @@ class DefaultAblyTestScenarios {
                     is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
                         configuredChannel.mockFailedAttach(givenChannelAttachBehaviour.errorInfo)
                     }
+                    /* when ${givenConfig.presenceEnterBehaviour} is DoesNotComplete {
+                     * ...[and] which, when told to enter presence, never finishes doing so...
+                     * }
+                     */
+                    is GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete -> {
+                        configuredChannel.mockNonCompletingPresenceEnter()
+                    }
                 }
 
                 // When...
 
-                // ...we call `connect` on the object under test,
-                val result = testEnvironment.objectUnderTest.connect(
-                    configuredChannel.trackableId,
-                    PresenceData("")
-                )
+                val result = executeForVerifying(thenConfig.resultOfConnectCallOnObjectUnderTest) {
+                    // ...we call `connect` on the object under test,
+                    testEnvironment.objectUnderTest.connect(
+                        configuredChannel.trackableId,
+                        PresenceData("")
+                    )
+                }
 
                 // Then...
                 // ...in the following order, precisely the following things happen...
@@ -283,12 +415,16 @@ class DefaultAblyTestScenarios {
                     }
                 }
 
-                /* when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Success {
+                /* when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfConnectCallOnObjectUnderTest.expectedResult} is Success {
                  * ...and the call to `connect` (on the object under test) succeeds.
                  * }
                  *
-                 * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is FailureWithConnectionException {
-                 * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInfo}.
+                 * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfConnectCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+                 * ...and the call to `connect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfConnectCallOnObjectUnderTest.errorInformation}.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfConnectCallOnObjectUnderTest} is DoesNotTerminate {
+                 * ...and the call to `connect` (on the object under test) does not complete within ${thenConfig.resultOfConnectCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
                  * }
                  */
                 thenConfig.resultOfConnectCallOnObjectUnderTest.verify(result)

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -202,8 +202,8 @@ class DefaultAblyTestScenarios {
             val channelsContainsKey: Boolean,
             val channelsGetOverload: DefaultAblyTestEnvironment.ChannelsGetOverload,
             val channelState: ChannelState,
-            val presenceEnterBehaviour: GivenTypes.CompletionListenerMockBehaviour,
-            val channelAttachBehaviour: GivenTypes.CompletionListenerMockBehaviour
+            val channelAttachBehaviour: GivenTypes.CompletionListenerMockBehaviour,
+            val presenceEnterBehaviour: GivenTypes.CompletionListenerMockBehaviour
         )
 
         /**
@@ -228,28 +228,28 @@ class DefaultAblyTestScenarios {
              * ...that calling `containsKey` on the Channels instance returns ${givenConfig.channelsContainsKey}...
              * ...and that calling `get` (the overload described by ${givenConfig.channelsGetOverload}) on the Channels instance returns a channel in the ${givenConfig.channelState} state...
              *
-             * when ${givenConfig.presenceEnterBehaviour} is Success {
-             * ...which, when told to enter presence, does so successfully...
+             * when ${givenConfig.channelAttachBehaviour} is Success {
+             * ...which, when told to attach, does so successfully...
              * }
              *
-             * when ${givenConfig.presenceEnterBehaviour} is Failure {
-             * ...which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
+             * when ${givenConfig.channelAttachBehaviour} is Failure {
+             * ...which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
              * }
              *
-             * when ${givenConfig.presenceEnterBehaviour} is DoesNotComplete {
-             * ...which, when told to enter presence, never finishes doing so...
+             * when ${givenConfig.channelAttachBehaviour} is DoesNotComplete {
+             * ...which, when told to attach, never finishes doing so...
              * }
              *
              * when ${givenConfig.presenceEnterBehaviour} is Success {
              * ...[and] which, when told to enter presence, does so successfully...
              * }
              *
-             * when ${givenConfig.channelAttachBehaviour} is Failure {
-             * ...[and] which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
+             * when ${givenConfig.presenceEnterBehaviour} is Failure {
+             * ...[and] which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
              * }
              *
-             * when ${givenConfig.channelAttachBehaviour} is DoesNotComplete {
-             * ...[and] which, when told to attach, never finishes doing so...
+             * when ${givenConfig.presenceEnterBehaviour} is DoesNotComplete {
+             * ...[and] which, when told to enter presence, never finishes doing so...
              * }
              *
              * When...
@@ -309,21 +309,21 @@ class DefaultAblyTestScenarios {
 
                 testEnvironment.stubRelease(configuredChannel)
 
-                when (val givenPresenceEnterBehaviour = givenConfig.presenceEnterBehaviour) {
+                when (val givenChannelAttachBehaviour = givenConfig.channelAttachBehaviour) {
                     is GivenTypes.CompletionListenerMockBehaviour.NotMocked -> {}
-                    /* when ${givenConfig.presenceEnterBehaviour} is Success {
-                     * ...which, when told to enter presence, does so successfully...
+                    /* when ${givenConfig.channelAttachBehaviour} is Success {
+                     * ...which, when told to attach, does so successfully...
                      * }
                      */
                     is GivenTypes.CompletionListenerMockBehaviour.Success -> {
-                        configuredChannel.mockSuccessfulPresenceEnter()
+                        configuredChannel.mockSuccessfulAttach()
                     }
-                    /* when ${givenConfig.presenceEnterBehaviour} is Failure {
-                     * ...which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
+                    /* when ${givenConfig.channelAttachBehaviour} is Failure {
+                     * ...which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
                      * }
                      */
                     is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
-                        configuredChannel.mockFailedPresenceEnter(givenPresenceEnterBehaviour.errorInfo)
+                        configuredChannel.mockFailedAttach(givenChannelAttachBehaviour.errorInfo)
                     }
                     /* when ${givenConfig.channelAttachBehaviour} is DoesNotComplete {
                      * ...which, when told to attach, never finishes doing so...
@@ -334,21 +334,21 @@ class DefaultAblyTestScenarios {
                     }
                 }
 
-                when (val givenChannelAttachBehaviour = givenConfig.channelAttachBehaviour) {
+                when (val givenPresenceEnterBehaviour = givenConfig.presenceEnterBehaviour) {
                     is GivenTypes.CompletionListenerMockBehaviour.NotMocked -> {}
-                    /* when ${givenConfig.channelAttachBehaviour} is Success {
-                     * ...[and] which, when told to attach, does so successfully...
+                    /* when ${givenConfig.presenceEnterBehaviour} is Success {
+                     * ...[and] which, when told to enter presence, does so successfully...
                      * }
                      */
                     is GivenTypes.CompletionListenerMockBehaviour.Success -> {
-                        configuredChannel.mockSuccessfulAttach()
+                        configuredChannel.mockSuccessfulPresenceEnter()
                     }
-                    /* when ${givenConfig.channelAttachBehaviour} is Failure {
-                     * ...[and] which, when told to attach, fails to do so with error ${givenConfig.channelAttachBehaviour.errorInfo}...
+                    /* when ${givenConfig.presenceEnterBehaviour} is Failure {
+                     * ...[and] which, when told to enter presence, fails to do so with error ${givenConfig.presenceEnterBehaviour.errorInfo}...
                      * }
                      */
                     is GivenTypes.CompletionListenerMockBehaviour.Failure -> {
-                        configuredChannel.mockFailedAttach(givenChannelAttachBehaviour.errorInfo)
+                        configuredChannel.mockFailedPresenceEnter(givenPresenceEnterBehaviour.errorInfo)
                     }
                     /* when ${givenConfig.presenceEnterBehaviour} is DoesNotComplete {
                      * ...[and] which, when told to enter presence, never finishes doing so...

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -7,6 +7,8 @@ import com.ably.tracking.common.DefaultAbly
 import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.AblySdkRealtime
 import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.ConnectionState
+import io.ably.lib.realtime.ConnectionStateListener
 import io.ably.lib.types.ErrorInfo
 import io.mockk.confirmVerified
 import io.mockk.verifyOrder
@@ -37,6 +39,27 @@ class DefaultAblyTestScenarios {
         sealed class ChannelStateChangeBehaviour() {
             object NoBehaviour : ChannelStateChangeBehaviour()
             class EmitStateChange(val current: ChannelState) : ChannelStateChangeBehaviour()
+        }
+
+        /**
+         * Describes how a test case should interact with the [ConnectionStateListener] instances added to a connection using [AblySdkRealtime.Connection.on]. Individual test cases should document how they interpret the values this class can take.
+         */
+        sealed class ConnectionStateChangeBehaviour() {
+            object NoBehaviour : ConnectionStateChangeBehaviour()
+            class EmitStateChange(
+                val previous: ConnectionState,
+                val current: ConnectionState,
+                val retryIn: Long,
+                val reason: ErrorInfo?
+            ) : ConnectionStateChangeBehaviour()
+        }
+
+        /**
+         * Describes how a test case mocks the return value of an [AblySdkRealtime.Connection] object’s [AblySdkRealtime.Connection.reason] property. Individual test cases should document how they interpret the values this class can take.
+         */
+        sealed class ConnectionReasonMockBehaviour() {
+            object NotMocked : ConnectionReasonMockBehaviour()
+            class Mocked(val reason: ErrorInfo?) : ConnectionReasonMockBehaviour()
         }
     }
 
@@ -1122,6 +1145,192 @@ class DefaultAblyTestScenarios {
                  * }
                  */
                 thenConfig.resultOfDisconnectCallOnObjectUnderTest.verify(result)
+
+                confirmVerified(*testEnvironment.allMocks)
+            }
+        }
+    }
+
+    /**
+     * Provides test scenarios for [DefaultAbly.startConnection]. See the [Companion.test] method.
+     */
+    class StartConnection {
+        /**
+         * This class provides properties for configuring the "Given..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class GivenConfig(
+            val initialConnectionState: ConnectionState,
+            val connectionReasonBehaviour: GivenTypes.ConnectionReasonMockBehaviour,
+            val connectBehaviour: GivenTypes.ConnectionStateChangeBehaviour
+        )
+
+        /**
+         * This class provides properties for configuring the "Then..." part of the parameterised test case described by [Companion.test]. See that method’s documentation for information about the effect of this class’s properties.
+         */
+        class ThenConfig(
+            val numberOfConnectionStateFetchesToVerify: Int,
+            val verifyConnectionReasonFetch: Boolean,
+            val verifyConnectionOn: Boolean,
+            val verifyConnect: Boolean,
+            val verifyConnectionOff: Boolean,
+            val resultOfStartConnectionCallOnObjectUnderTest: ThenTypes.ExpectedResult
+        )
+
+        companion object {
+            /**
+             * Implements the following parameterised test case for [DefaultAbly.startConnection]:
+             *
+             * ```text
+             * Given...
+             *
+             * ...that the connection’s `state` property returns ${givenConfig.initialConnectionState}...
+             *
+             * when ${givenConfig.connectionReasonBehaviour} is Mocked {
+             * ...and that the connection’s `reason` property returns ${givenConfig.connectionReasonBehaviour}...
+             * }
+             *
+             * when ${givenConfig.connectBehaviour} is EmitStateChange {
+             * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous`, `current`, `retryIn` and `reason` are those of ${givenConfig.connectBehaviour}...
+             * }
+             *
+             * When...
+             *
+             * ...the `startConnection` method is called on the object under test...
+             *
+             * Then...
+             * ...in the following order, precisely the following things happen...
+             *
+             * ...it fetches the connection’s state ${thenConfig.numberOfConnectionStateFetchesToVerify} times...
+             *
+             * if ${thenConfig.verifyConnectionReasonFetch} {
+             * ...and fetches the connection’s `reason`...
+             * }
+             *
+             * if ${thenConfig.verifyConnectionOn} {
+             * ...and adds a listener to the connection using `on`...
+             * }
+             *
+             * if ${thenConfig.verifyConnect} {
+             * ...and tells the Realtime instance to connect...
+             * }
+             *
+             * if ${thenConfig.verifyConnectionOff} {
+             * ...and removes a listener from the connection using `off`...
+             * }
+             *
+             * when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.expectedResult} is Success {
+             * ...and the call to `startConnection` (on the object under test) succeeds.
+             * }
+             *
+             * when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+             * ...and the call to `startConnection` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.errorInformation}.
+             * }
+             *
+             * when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is DoesNotTerminate {
+             * ...and the call to `startConnection` (on the object under test) does not complete within ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
+             * }
+             * ```
+             */
+            suspend fun test(givenConfig: GivenConfig, thenConfig: ThenConfig) {
+                val testEnvironment = DefaultAblyTestEnvironment.create(numberOfTrackables = 0)
+
+                // Given...
+
+                // ...that the connection’s `state` property returns ${givenConfig.initialConnectionState}...
+                testEnvironment.mockConnectionState(givenConfig.initialConnectionState)
+
+                when (val givenConnectionReasonBehaviour = givenConfig.connectionReasonBehaviour) {
+                    is GivenTypes.ConnectionReasonMockBehaviour.NotMocked -> {}
+                    is GivenTypes.ConnectionReasonMockBehaviour.Mocked -> {
+                        /* when ${givenConfig.connectionReasonBehaviour} is Mocked {
+                         * ...and that the connection’s `reason` property returns ${givenConfig.connectionReasonBehaviour}...
+                         * }
+                         */
+                        testEnvironment.mockConnectionReason(givenConnectionReasonBehaviour.reason)
+                    }
+                }
+
+                when (val givenConnectBehaviour = givenConfig.connectBehaviour) {
+                    is GivenTypes.ConnectionStateChangeBehaviour.NoBehaviour -> {
+                        testEnvironment.stubConnectionOn()
+                        testEnvironment.stubConnect()
+                    }
+                    is GivenTypes.ConnectionStateChangeBehaviour.EmitStateChange -> {
+                        /* when ${givenConfig.connectBehaviour} is EmitStateChange {
+                         * ...and that when the Realtime instance’s `connect` method is called, its connection’s `on` method immediately emits a connection state change whose `previous`, `current`, `retryIn` and `reason` are those of ${givenConfig.connectBehaviour}...
+                         * }
+                         */
+                        testEnvironment.mockConnectToEmitStateChange(
+                            previous = givenConnectBehaviour.previous,
+                            current = givenConnectBehaviour.current,
+                            retryIn = givenConnectBehaviour.retryIn,
+                            reason = givenConnectBehaviour.reason
+                        )
+                    }
+                }
+
+                testEnvironment.stubConnectionOff()
+
+                // When...
+
+                // ...the `startConnection` method is called on the object under test...
+                val result = testEnvironment.objectUnderTest.startConnection()
+
+                // Then...
+                // ...in the following order, precisely the following things happen...
+
+                verifyOrder {
+                    // ...it fetches the connection’s state ${thenConfig.numberOfConnectionStateFetchesToVerify} times...
+                    repeat(thenConfig.numberOfConnectionStateFetchesToVerify) {
+                        testEnvironment.connectionMock.state
+                    }
+
+                    if (thenConfig.verifyConnectionReasonFetch) {
+                        /* if ${thenConfig.verifyConnectionReasonFetch} {
+                         * ...and fetches the connection’s `reason`...
+                         * }
+                         */
+                        testEnvironment.connectionMock.reason
+                    }
+
+                    if (thenConfig.verifyConnectionOn) {
+                        /* if ${thenConfig.verifyConnectionOn} {
+                         * ...and adds a listener to the connection using `on`...
+                         * }
+                         */
+                        testEnvironment.connectionMock.on(any())
+                    }
+
+                    if (thenConfig.verifyConnect) {
+                        /* if ${thenConfig.verifyConnect} {
+                         * ...and tells the Realtime instance to connect...
+                         * }
+                         */
+                        testEnvironment.realtimeMock.connect()
+                    }
+
+                    if (thenConfig.verifyConnectionOff) {
+                        /* if ${thenConfig.verifyConnectionOff} {
+                         * ...and removes a listener from the connection using `off`...
+                         * }
+                         */
+                        testEnvironment.connectionMock.off(any())
+                    }
+                }
+
+                /* when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.expectedResult} is Success {
+                 * ...and the call to `startConnection` (on the object under test) succeeds.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
+                 * ...and the call to `startConnection` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.errorInformation}.
+                 * }
+                 *
+                 * when ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest} is DoesNotTerminate {
+                 * ...and the call to `startConnection` (on the object under test) does not complete within ${thenConfig.resultOfStartConnectionCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
+                 * }
+                 */
+                thenConfig.resultOfStartConnectionCallOnObjectUnderTest.verify(result)
 
                 confirmVerified(*testEnvironment.allMocks)
             }


### PR DESCRIPTION
This builds on the tests added for `DefaultAbly` in #878. It does the following:

- adds further tests for `connect`
- changes some of the existing tests for `connect` to reflect specified client library behaviour
- adds tests for `updatePresenceData`, `disconnect`, `startConnection`, `stopConnection`, and `sendRawLocation`

I opened the following issues as a result of working on these tests:

- #908 
- #909
- #912