### PR TITLE
901 simplify transition assertions

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.test.android.common
 
 import com.ably.tracking.TrackableState
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
 import kotlin.reflect.KClass
 
 /**
@@ -160,8 +163,6 @@ class TrackableStateReceiver(
     private val expectedStates: Set<KClass<out TrackableState>>,
     private val failureStates: Set<KClass<out TrackableState>>
 ) {
-    val outcome = BooleanExpectation(label)
-
     companion object {
         fun onlineWithoutFail(label: String) = TrackableStateReceiver(
             label,
@@ -176,15 +177,26 @@ class TrackableStateReceiver(
         )
     }
 
-    fun receive(state: TrackableState) {
-        if (failureStates.contains((state::class))) {
-            testLogD("TrackableStateReceived (FAIL): $label - $state")
-            outcome.fulfill(false)
-        } else if (expectedStates.contains(state::class)) {
-            testLogD("TrackableStateReceived (SUCCESS): $label - $state")
-            outcome.fulfill(true)
-        } else {
-            testLogD("TrackableStateReceived (IGNORED): $label - $state")
+    suspend fun assertStateTransition(stateFlow: StateFlow<TrackableState>) {
+        val result = stateFlow.mapNotNull { receive(it) }.first()
+        if (!result) {
+            throw AssertionError("Expectation '$label' did not result in success.")
         }
     }
+
+    private fun receive(state: TrackableState): Boolean? =
+        when {
+            failureStates.contains(state::class) -> {
+                testLogD("TrackableStateReceived (FAIL): $label - $state")
+                false
+            }
+            expectedStates.contains(state::class) -> {
+                testLogD("TrackableStateReceived (SUCCESS): $label - $state")
+                true
+            }
+            else -> {
+                testLogD("TrackableStateReceived (IGNORED): $label - $state")
+                null
+            }
+        }
 }

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -44,7 +44,6 @@ import io.ably.lib.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -274,7 +273,6 @@ class NetworkConnectivityTests(private val testFault: FaultSimulation) {
  */
 class TestResources(
     val context: Context,
-    val scope: CoroutineScope,
     val locationHelper: LocationHelper,
     val fault: FaultSimulation,
     val publisher: Publisher
@@ -285,7 +283,6 @@ class TestResources(
          */
         fun setUp(faultParam: FaultSimulation): TestResources {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
-            val scope = CoroutineScope(Dispatchers.Unconfined)
             val locationHelper = LocationHelper()
             val publisher = createPublisher(context, faultParam.proxy.clientOptions, locationHelper.channelName)
 
@@ -293,7 +290,6 @@ class TestResources(
 
             return TestResources(
                 context = context,
-                scope = scope,
                 locationHelper = locationHelper,
                 fault = faultParam,
                 publisher = publisher
@@ -386,7 +382,6 @@ class TestResources(
     }
 
     fun tearDown() {
-        scope.cancel()
         val stopExpectation = shutdownPublisher(publisher)
         stopExpectation.assertSuccess()
         locationHelper.close()


### PR DESCRIPTION
I have updated `waitForStateTransition` function to use a more direct approach, namely using `map` and `first` on the flow and moving this operation to the `TrackableStateReceiver.` This allowed replacing `Expectations` with blocking calls and removing now unused coroutine scope from `TestResources.`

Resolves #901