### PR TITLE
Include API version 33 in tests

### DIFF
--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          arch: x86_64
           target: google_apis
           #Github's default -no-snapshot option causes check workflow failing.It is likely because it has to cold boot
           #emulator which might be taking long and causing a timeout issue or a freeze.

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 21, 24, 27, 29, 33 ]
+        api-level: [ 29, 30, 31, 32, 33 ]
         include:
           - api: 21
             excludeModules: true

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
+          arch: x86_64
           #Github's default -no-snapshot option causes check workflow failing.It is likely because it has to cold boot
           #emulator which might be taking long and causing a timeout issue or a freeze.
           #Adding -no-snapshot-save will enable quick

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
+          target: google_apis
           #Github's default -no-snapshot option causes check workflow failing.It is likely because it has to cold boot
           #emulator which might be taking long and causing a timeout issue or a freeze.
           #Adding -no-snapshot-save will enable quick

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 21, 24, 27, 29 ]
+        api-level: [ 21, 24, 27, 29, 33 ]
         include:
           - api: 21
             excludeModules: true

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86_64
           #Github's default -no-snapshot option causes check workflow failing.It is likely because it has to cold boot
           #emulator which might be taking long and causing a timeout issue or a freeze.
           #Adding -no-snapshot-save will enable quick


### PR DESCRIPTION
This change brings the Android versions we test against to:

5, 7, 8.1, 10 and 13.