### PR TITLE
Add methods for detecting retriable and fatal Ably exceptions

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -227,7 +227,7 @@ private fun TokenAuthException.toAblyException(): AblyException =
  * Fatal errors have status codes like 4xx (e.g. 400).
  */
 fun ConnectionException.isFatal(): Boolean {
-    return (400 .. 499).contains(errorInformation.statusCode)
+    return (400..499).contains(errorInformation.statusCode)
 }
 
 /**
@@ -235,5 +235,5 @@ fun ConnectionException.isFatal(): Boolean {
  * Non-fatal errors have status codes in range 500-504.
  */
 fun ConnectionException.isRetriable(): Boolean {
-    return (500 .. 504).contains(errorInformation.statusCode)
+    return (500..504).contains(errorInformation.statusCode)
 }

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -224,18 +224,16 @@ private fun TokenAuthException.toAblyException(): AblyException =
 
 /**
  * Indicates whether the exception from Ably is fatal and we should not attempt to retry it.
- * Fatal errors have codes like 4xx (e.g. 400).
+ * Fatal errors have status codes like 4xx (e.g. 400).
  */
 fun ConnectionException.isFatal(): Boolean {
-    val firstErrorCodeDigit = errorInformation.code.toString().first()
-    return firstErrorCodeDigit == '4'
+    return (400 .. 499).contains(errorInformation.statusCode)
 }
 
 /**
  * Indicates whether the exception from Ably is retriable and we can attempt to retry it.
- * Non-fatal errors have codes like 5xx (e.g. 500).
+ * Non-fatal errors have status codes in range 500-504.
  */
 fun ConnectionException.isRetriable(): Boolean {
-    val firstErrorCodeDigit = errorInformation.code.toString().first()
-    return firstErrorCodeDigit == '5'
+    return (500 .. 504).contains(errorInformation.statusCode)
 }

--- a/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
+++ b/common/src/main/java/com/ably/tracking/common/AblyHelpers.kt
@@ -221,3 +221,21 @@ private fun TokenAuthException.toAblyException(): AblyException =
         is CouldNotFetchTokenException ->
             AblyException.fromErrorInfo(ErrorInfo(message, 401, 100_002))
     }
+
+/**
+ * Indicates whether the exception from Ably is fatal and we should not attempt to retry it.
+ * Fatal errors have codes like 4xx (e.g. 400).
+ */
+fun ConnectionException.isFatal(): Boolean {
+    val firstErrorCodeDigit = errorInformation.code.toString().first()
+    return firstErrorCodeDigit == '4'
+}
+
+/**
+ * Indicates whether the exception from Ably is retriable and we can attempt to retry it.
+ * Non-fatal errors have codes like 5xx (e.g. 500).
+ */
+fun ConnectionException.isRetriable(): Boolean {
+    val firstErrorCodeDigit = errorInformation.code.toString().first()
+    return firstErrorCodeDigit == '5'
+}

--- a/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
@@ -14,7 +14,7 @@ class ConnectionExceptionTests(
     private val isRetriable: Boolean,
 ) {
 
-    companion object{
+    companion object {
         @JvmStatic
         @Parameterized.Parameters(
             name = "Status code: {0} | Is fatal: {1} | Is retriable: {2}"

--- a/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
@@ -4,56 +4,82 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.ErrorInformation
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class ConnectionExceptionTests {
+@RunWith(Parameterized::class)
+class ConnectionExceptionTests(
+    private val statusCode: Int,
+    private val isFatal: Boolean,
+    private val isRetriable: Boolean,
+) {
+
+    companion object{
+        @JvmStatic
+        @Parameterized.Parameters(
+            name = "Status code: {0} | Is fatal: {1} | Is retriable: {2}"
+        )
+        fun data() = listOf(
+            params(
+                statusCode = 399,
+                isFatal = false,
+                isRetriable = false,
+            ),
+            params(
+                statusCode = 400,
+                isFatal = true,
+                isRetriable = false,
+            ),
+            params(
+                statusCode = 499,
+                isFatal = true,
+                isRetriable = false,
+            ),
+            params(
+                statusCode = 500,
+                isFatal = false,
+                isRetriable = true,
+            ),
+            params(
+                statusCode = 504,
+                isFatal = false,
+                isRetriable = true,
+            ),
+            params(
+                statusCode = 505,
+                isFatal = false,
+                isRetriable = false,
+            ),
+        )
+
+        private fun params(statusCode: Int, isFatal: Boolean, isRetriable: Boolean) =
+            arrayOf(statusCode, isFatal, isRetriable)
+    }
+
     @Test
-    fun `exception with error code starting with 4 should be treated as fatal`() {
+    fun `exception should be treated as fatal if its status code is between 400 and 499`() {
         // given
-        val exception = createConnectionException(400, 40000, "Fatal error")
+        val exception = createConnectionException(statusCode)
 
         // when
         val result = exception.isFatal()
 
         // then
-        Assert.assertTrue(result)
+        Assert.assertEquals(isFatal, result)
     }
 
     @Test
-    fun `exception with error code starting with 4 should not be treated as retriable`() {
+    fun `exception should be treated as retriable if its status code is between 500 and 504`() {
         // given
-        val exception = createConnectionException(400, 40000, "Fatal error")
+        val exception = createConnectionException(statusCode)
 
         // when
         val result = exception.isRetriable()
 
         // then
-        Assert.assertFalse(result)
+        Assert.assertEquals(isRetriable, result)
     }
 
-    @Test
-    fun `exception with error code starting with 5 should not be treated as fatal`() {
-        // given
-        val exception = createConnectionException(500, 50000, "Retriable error")
-
-        // when
-        val result = exception.isFatal()
-
-        // then
-        Assert.assertFalse(result)
-    }
-
-    @Test
-    fun `exception with error code starting with 5 should be treated as retriable`() {
-        // given
-        val exception = createConnectionException(500, 50000, "Retriable error")
-
-        // when
-        val result = exception.isRetriable()
-
-        // then
-        Assert.assertTrue(result)
-    }
-
-    private fun createConnectionException(code: Int, statusCode: Int, message: String): ConnectionException =
-        ConnectionException(ErrorInformation(code, statusCode, message, null, null))
+    private fun createConnectionException(statusCode: Int): ConnectionException =
+        ConnectionException(ErrorInformation(0, statusCode, "Test exception", null, null))
 }

--- a/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/ConnectionExceptionTests.kt
@@ -1,0 +1,59 @@
+package com.ably.tracking.common
+
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.ErrorInformation
+import org.junit.Assert
+import org.junit.Test
+
+class ConnectionExceptionTests {
+    @Test
+    fun `exception with error code starting with 4 should be treated as fatal`() {
+        // given
+        val exception = createConnectionException(400, 40000, "Fatal error")
+
+        // when
+        val result = exception.isFatal()
+
+        // then
+        Assert.assertTrue(result)
+    }
+
+    @Test
+    fun `exception with error code starting with 4 should not be treated as retriable`() {
+        // given
+        val exception = createConnectionException(400, 40000, "Fatal error")
+
+        // when
+        val result = exception.isRetriable()
+
+        // then
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun `exception with error code starting with 5 should not be treated as fatal`() {
+        // given
+        val exception = createConnectionException(500, 50000, "Retriable error")
+
+        // when
+        val result = exception.isFatal()
+
+        // then
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun `exception with error code starting with 5 should be treated as retriable`() {
+        // given
+        val exception = createConnectionException(500, 50000, "Retriable error")
+
+        // when
+        val result = exception.isRetriable()
+
+        // then
+        Assert.assertTrue(result)
+    }
+
+    private fun createConnectionException(code: Int, statusCode: Int, message: String): ConnectionException =
+        ConnectionException(ErrorInformation(code, statusCode, message, null, null))
+}


### PR DESCRIPTION
Added helper methods that will enable us to detect fatal and retriable errors. This should allow us to implement appropriate retry mechanisms for certain Ably operations (like presence enter and leave).

Open questions:
- should we only look at the `code` property or maybe also at the `statusCode`?
- how should we classify exceptions that have codes that doesn't start with either `4` or `5`?