### PR TITLE
Fix swapped error codes when creating the malformed message exception

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -968,7 +968,7 @@ constructor(
     private fun AblySdkRealtime.Channel<ChannelStateListenerType>.isDetachedOrFailed(): Boolean =
         state == ChannelState.detached || state == ChannelState.failed
 
-    private fun createMalformedMessageErrorInfo(): ErrorInfo = ErrorInfo("Received a malformed message", 100_001, 400)
+    private fun createMalformedMessageErrorInfo(): ErrorInfo = ErrorInfo("Received a malformed message", 400, 100_001)
 
     override suspend fun startConnection(): Result<Unit> {
         return try {


### PR DESCRIPTION
When looking through the codebase I've noticed that we have swapped the `code` and `statusCode` values when creating a malformed message exception. The `statusCode` should correspond to the HTTP code and is specified as the first integer parameter. The `code` is AAT specific in this case and is the last parameter of the `ErrorInfo` constructor.