### PR TITLE
Improve `NetworkingConnectivityTest` assertions

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/AblyProxy.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/AblyProxy.kt
@@ -34,7 +34,6 @@ import org.slf4j.event.Level
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
-import java.util.UUID
 import javax.net.ssl.SSLSocketFactory
 
 private const val AGENT_HEADER_NAME = "ably-asset-tracking-android-publisher-tests"
@@ -43,6 +42,8 @@ private const val PROXY_HOST = "localhost"
 private const val PROXY_PORT = 13579
 private const val REALTIME_HOST = "realtime.ably.io"
 private const val REALTIME_PORT = 443
+
+const val PUBLISHER_CLIENT_ID = "AatNetworkConnectivityTests_Publisher"
 
 /**
  * A local proxy that can be used to intercept Realtime traffic for testing
@@ -87,7 +88,7 @@ abstract class AatProxy(
      * this proxy. Note that TLS is disabled, so that the proxy can act as a man in the middle.
      */
     override fun clientOptions() = ClientOptions().apply {
-        this.clientId = "AatTestProxy_${UUID.randomUUID()}"
+        this.clientId = PUBLISHER_CLIENT_ID
         this.agents = mapOf(AGENT_HEADER_NAME to BuildConfig.VERSION_NAME)
         this.idempotentRestPublishing = true
         this.autoConnect = false

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -1,14 +1,9 @@
 package com.ably.tracking.test.android.common
 
-import com.ably.tracking.TrackableState
 import io.ktor.websocket.Frame
 import io.ktor.websocket.FrameType
 import java.util.Timer
 import kotlin.concurrent.timerTask
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.mapNotNull
-import kotlin.reflect.KClass
 
 /**
  * Abstract interface definition for specific instances of connectivity
@@ -24,6 +19,12 @@ abstract class FaultSimulation {
      * A human-readable name for this type of fault
      */
     abstract val name: String
+
+    /**
+     * The type of fault this simulates - used to validate the state of trackables
+     * and channel activity during and after the fault.
+     */
+    abstract val type: FaultType
 
     /**
      * Subclasses can override this value to `true` in order to skip test that use this fault.
@@ -49,30 +50,45 @@ abstract class FaultSimulation {
      */
     abstract fun resolve()
 
-    /**
-     * Provide a TrackableStateReceiver describing the acceptable state transitions
-     * during the given fault stage.
-     */
-    abstract fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ): TrackableStateReceiver
-
     override fun toString() = name
 }
 
 /**
- * Steps during a fault simulation test:
- *   - FaultActiveBeforeTracking - fault.enable() has been called but trackables
- *     have not yet been tracked, so attempts to track will follow
- *   - FaultActiveDuringTracking - fault.enable() has been called while trackables
- *     were already online
- *   - FaultResolved - fault.enable() was called earlier, now fault.resolve()
- *     has also been called.
+ * Describes the nature of a given fault simulation, and specifically the impact that it
+ * should have on any Trackables or channel activity during and after resolution.
  */
-enum class FaultSimulationStage {
-    FaultActiveBeforeTracking,
-    FaultActiveDuringTracking,
-    FaultResolved
+sealed class FaultType {
+    /**
+     * AAT and/or Ably Java should handle this fault seamlessly Trackable state should be
+     * online and publisher should be present within [resolvedWithinMillis]. It's possible
+     * the fault will cause a brief Offline blip, but tests should expect to see Trackables
+     * Online again before [resolvedWithinMillis] expires regardless.
+     */
+    data class Nonfatal(
+        val resolvedWithinMillis: Long,
+    ) : FaultType()
+
+    /**
+     * This is a non-fatal error, but will persist until the [FaultSimulation.resolve]
+     * method has been called. Trackable states should be offline during the fault within
+     * [offlineWithinMillis] maximum. When the fault is resolved, Trackables should return
+     * online within [onlineWithinMillis] maximum.
+     *
+     */
+    data class NonfatalWhenResolved(
+        val offlineWithinMillis: Long,
+        val onlineWithinMillis: Long,
+    ) : FaultType()
+
+    /**
+     * This is a fatal error and should permanently move Trackables to the Failed state.
+     * The publisher should not be present in the corresponding channel any more and no
+     * further location updates will be published. Tests should check that Trackables reach
+     * the Failed state within [failedWithinMillis]
+     */
+    data class Fatal(
+        val failedWithinMillis: Long,
+    ) : FaultType()
 }
 
 /**
@@ -88,11 +104,18 @@ abstract class TransportLayerFault(apiKey: String) : FaultSimulation() {
  * test code works under normal proxy functionality.
  */
 class NullTransportFault(apiKey: String) : TransportLayerFault(apiKey) {
+
     override val name = "NullTransportFault"
-    override fun enable() {}
-    override fun resolve() {}
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
+
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 10_000L
+    )
+
+    override fun enable() {
+    }
+
+    override fun resolve() {
+    }
 }
 
 /**
@@ -101,6 +124,11 @@ class NullTransportFault(apiKey: String) : TransportLayerFault(apiKey) {
 class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
 
     override val name = "TcpConnectionRefused"
+
+    override val type = FaultType.NonfatalWhenResolved(
+        offlineWithinMillis = 30_000,
+        onlineWithinMillis = 60_000
+    )
 
     /**
      * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
@@ -117,16 +145,6 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
     override fun resolve() {
         tcpProxy.start()
     }
-
-    override fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ) = when (stage) {
-        FaultSimulationStage.FaultActiveBeforeTracking,
-        FaultSimulationStage.FaultActiveDuringTracking ->
-            TrackableStateReceiver.offlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultResolved ->
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
-    }
 }
 
 /**
@@ -136,6 +154,11 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
 class TcpConnectionUnresponsive(apiKey: String) : TransportLayerFault(apiKey) {
 
     override val name = "TcpConnectionUnresponsive"
+
+    override val type = FaultType.NonfatalWhenResolved(
+        offlineWithinMillis = 120_000,
+        onlineWithinMillis = 60_000
+    )
 
     /**
      * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
@@ -151,16 +174,6 @@ class TcpConnectionUnresponsive(apiKey: String) : TransportLayerFault(apiKey) {
 
     override fun resolve() {
         tcpProxy.isForwarding = true
-    }
-
-    override fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ) = when (stage) {
-        FaultSimulationStage.FaultActiveBeforeTracking,
-        FaultSimulationStage.FaultActiveDuringTracking ->
-            TrackableStateReceiver.offlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultResolved ->
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
     }
 }
 
@@ -183,6 +196,10 @@ class DisconnectAndSuspend(apiKey: String) : TransportLayerFault(apiKey) {
 
     override val name = "DisconnectAndSuspend"
 
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 150_000L
+    )
+
     override fun enable() {
         tcpProxy.stop()
         timer.schedule(
@@ -197,11 +214,6 @@ class DisconnectAndSuspend(apiKey: String) : TransportLayerFault(apiKey) {
         timer.cancel()
         tcpProxy.start()
     }
-
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        // After two minutes, trackables should always return to online state
-        // with no fatal error
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
 }
 
 /**
@@ -218,11 +230,18 @@ abstract class ApplicationLayerFault(apiKey: String) : FaultSimulation() {
  * functionality is working with no interventions
  */
 class NullApplicationLayerFault(apiKey: String) : ApplicationLayerFault(apiKey) {
+
     override val name = "NullApplicationLayerFault"
-    override fun enable() { }
-    override fun resolve() { }
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
+
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 10_000L
+    )
+
+    override fun enable() {
+    }
+
+    override fun resolve() {
+    }
 }
 
 /**
@@ -235,11 +254,17 @@ abstract class DropAction(
     private val action: Message.Action
 ) : ApplicationLayerFault(apiKey) {
 
+    // TODO: This fault needs a limit!
+
     companion object {
         private const val tag = "DropAction"
     }
 
     private var initialConnection = true
+
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 120_000L
+    )
 
     override fun enable() {
         applicationProxy.interceptor = object : Layer7Interceptor {
@@ -269,17 +294,6 @@ abstract class DropAction(
     override fun resolve() {
         applicationProxy.interceptor = PassThroughInterceptor()
         initialConnection = true
-    }
-
-    override fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ) = when (stage) {
-        FaultSimulationStage.FaultActiveDuringTracking ->
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultActiveBeforeTracking ->
-            TrackableStateReceiver.offlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultResolved ->
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
     }
 
     /**
@@ -341,6 +355,10 @@ abstract class UnresponsiveAfterAction(
     private var nConnections = 0
     private var isTriggered = false
 
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 120_000L
+    )
+
     override fun enable() {
         applicationProxy.interceptor = object : Layer7Interceptor {
 
@@ -383,8 +401,8 @@ abstract class UnresponsiveAfterAction(
 }
 
 /**
- * A DropAction fault implementation to drop PRESENCE messages,
- * simulating a presence enter failure
+ * A fault implementation makling the connection unresponsive
+ * after observing an out-going Presence message
  */
 class EnterUnresponsive(apiKey: String) : UnresponsiveAfterAction(
     apiKey = apiKey,
@@ -400,20 +418,6 @@ class EnterUnresponsive(apiKey: String) : UnresponsiveAfterAction(
     override val skipTest = true
 
     override val name = "EnterUnresponsive"
-
-    override fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ) = when (stage) {
-        FaultSimulationStage.FaultActiveDuringTracking ->
-            // There won't be a presence.enter() during tracking
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultActiveBeforeTracking ->
-            // presence.enter() when trackable added will trigger fault
-            TrackableStateReceiver.offlineWithoutFail("$name: $stage")
-        FaultSimulationStage.FaultResolved ->
-            // always return to online state when there's no fault
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
-    }
 }
 
 /**
@@ -443,6 +447,10 @@ class DisconnectWithFailedResume(apiKey: String) : ApplicationLayerFault(apiKey)
     private var state = State.AwaitingInitialConnection
 
     override val name = "DisconnectWithFailedResume"
+
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 30_000
+    )
 
     override fun enable() {
         applicationProxy.interceptor = object : Layer7Interceptor {
@@ -486,17 +494,6 @@ class DisconnectWithFailedResume(apiKey: String) : ApplicationLayerFault(apiKey)
     override fun resolve() {
         state = State.AwaitingInitialConnection
         applicationProxy.interceptor = PassThroughInterceptor()
-    }
-
-    override fun stateReceiverForStage(
-        stage: FaultSimulationStage
-    ) = when (stage) {
-        // This fault is entirely non-fatal. AAT should recover to online
-        // state eventually without failure at any stage in test
-        FaultSimulationStage.FaultActiveDuringTracking,
-        FaultSimulationStage.FaultActiveBeforeTracking,
-        FaultSimulationStage.FaultResolved ->
-            TrackableStateReceiver.onlineWithoutFail("$name: $stage")
     }
 
     /**
@@ -592,9 +589,9 @@ class EnterFailedWithNonfatalNack(apiKey: String) : PresenceNackFault(
 
     override val name = "EnterFailedWithNonfatalNack"
 
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        // Note: 5xx presence errors should always be non-fatal and recovered seamlessly
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 60_000L
+    )
 }
 
 /**
@@ -609,9 +606,9 @@ class UpdateFailedWithNonfatalNack(apiKey: String) : PresenceNackFault(
 ) {
     override val name = "UpdateFailedWithNonfatalNack"
 
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        // Note: 5xx presence errors should always be non-fatal and recovered seamlessly
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 60_000L
+    )
 }
 
 /**
@@ -632,8 +629,6 @@ class ReenterOnResumeFailed(apiKey: String) : ApplicationLayerFault(apiKey) {
      */
     override val skipTest = true
 
-    override val name = "ReenterOnResumeFailed"
-
     private var state = State.DisconnectAfterPresence
     private var presenceEnterSerial: Int? = null
 
@@ -653,6 +648,12 @@ class ReenterOnResumeFailed(apiKey: String) : ApplicationLayerFault(apiKey) {
         // Finished - return to normal pass-through
         WorkingNormally
     }
+
+    override val name = "ReenterOnResumeFailed"
+
+    override val type = FaultType.Nonfatal(
+        resolvedWithinMillis = 60_000L
+    )
 
     override fun enable() {
         applicationProxy.interceptor = object : Layer7Interceptor {
@@ -681,11 +682,6 @@ class ReenterOnResumeFailed(apiKey: String) : ApplicationLayerFault(apiKey) {
         state = State.DisconnectAfterPresence
         applicationProxy.interceptor = PassThroughInterceptor()
     }
-
-    override fun stateReceiverForStage(stage: FaultSimulationStage) =
-        // This fault should not be non-fatal, Trackables should
-        // return to online state before resolve() is called
-        TrackableStateReceiver.onlineWithoutFail("$name: $stage")
 
     /**
      * Step 1: disconnect the client to cause it to attempt a resume,
@@ -813,50 +809,3 @@ internal fun nonFatalNack(msgSerial: Int) =
         errorStatusCode = 500,
         errorMessage = "injected by proxy"
     )
-
-/**
- * Helper to capture an expected set of successful or unsuccessful TrackableState
- * transitions using the StateFlows provided by publishers.
- */
-class TrackableStateReceiver(
-    private val label: String,
-    private val expectedStates: Set<KClass<out TrackableState>>,
-    private val failureStates: Set<KClass<out TrackableState>>
-) {
-    companion object {
-        fun onlineWithoutFail(label: String) = TrackableStateReceiver(
-            label,
-            setOf(TrackableState.Online::class),
-            setOf(TrackableState.Failed::class)
-        )
-
-        fun offlineWithoutFail(label: String) = TrackableStateReceiver(
-            label,
-            setOf(TrackableState.Offline::class),
-            setOf(TrackableState.Failed::class)
-        )
-    }
-
-    suspend fun assertStateTransition(stateFlow: StateFlow<TrackableState>) {
-        val result = stateFlow.mapNotNull { receive(it) }.first()
-        if (!result) {
-            throw AssertionError("Expectation '$label' did not result in success.")
-        }
-    }
-
-    private fun receive(state: TrackableState): Boolean? =
-        when {
-            failureStates.contains(state::class) -> {
-                testLogD("TrackableStateReceived (FAIL): $label - $state")
-                false
-            }
-            expectedStates.contains(state::class) -> {
-                testLogD("TrackableStateReceived (SUCCESS): $label - $state")
-                true
-            }
-            else -> {
-                testLogD("TrackableStateReceived (IGNORED): $label - $state")
-                null
-            }
-        }
-}

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -50,6 +50,14 @@ abstract class FaultSimulation {
      */
     abstract fun resolve()
 
+    /**
+     * Called at start of test tearDown function to ensure fault doesn't interefere with test
+     * tearDown of open resources.
+     */
+    open fun cleanUp() {
+        proxy.stop()
+    }
+
     override fun toString() = name
 }
 
@@ -197,7 +205,7 @@ class DisconnectAndSuspend(apiKey: String) : TransportLayerFault(apiKey) {
     override val name = "DisconnectAndSuspend"
 
     override val type = FaultType.Nonfatal(
-        resolvedWithinMillis = 150_000L
+        resolvedWithinMillis = 180_000L
     )
 
     override fun enable() {
@@ -213,6 +221,11 @@ class DisconnectAndSuspend(apiKey: String) : TransportLayerFault(apiKey) {
     override fun resolve() {
         timer.cancel()
         tcpProxy.start()
+    }
+
+    override fun cleanUp() {
+        timer.cancel()
+        super.cleanUp()
     }
 }
 

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -16,6 +16,7 @@ import com.ably.tracking.common.DefaultAblySdkChannelStateListener
 import com.ably.tracking.common.DefaultAblySdkRealtime
 import com.ably.tracking.common.EventNames
 import com.ably.tracking.common.message.EnhancedLocationUpdateMessage
+import com.ably.tracking.common.message.GeoJsonTypes
 import com.ably.tracking.common.message.LocationGeometry
 import com.ably.tracking.common.message.LocationMessage
 import com.ably.tracking.common.message.LocationProperties
@@ -133,7 +134,7 @@ class NetworkConnectivityTests(private val testFault: FaultSimulation) {
             fault.enable()
 
             // Add an active trackable while fault active
-            val locationUpdate = locationHelper.locationUpdate(100.0, 100.0)
+            val locationUpdate = locationHelper.locationUpdate(80.0, 100.0)
             PublisherMonitor.forActiveFault(
                 label = "[fault active] publisher.track()",
                 trackable = primaryTrackable,
@@ -154,7 +155,7 @@ class NetworkConnectivityTests(private val testFault: FaultSimulation) {
                 publisher.add(secondaryTrackable).also {
                     // apparently another location update is needed for this to go online
                     locationHelper.sendUpdate(
-                        locationHelper.locationUpdate(101.0, 101.0)
+                        locationHelper.locationUpdate(81.0, 101.0)
                     )
                 }
             }.close()
@@ -193,7 +194,7 @@ class NetworkConnectivityTests(private val testFault: FaultSimulation) {
 
         withResources {
             // Add active trackable, wait for it to reach Online state
-            val locationUpdate = locationHelper.locationUpdate(102.0, 102.0)
+            val locationUpdate = locationHelper.locationUpdate(82.0, 102.0)
             PublisherMonitor.onlineWithoutFail(
                 label = "[no fault] publisher.track()",
                 trackable = primaryTrackable,
@@ -214,7 +215,7 @@ class NetworkConnectivityTests(private val testFault: FaultSimulation) {
                 publisher.add(secondaryTrackable).also {
                     // apparently another location update is needed for this to go online
                     locationHelper.sendUpdate(
-                        locationHelper.locationUpdate(103.0, 103.0)
+                        locationHelper.locationUpdate(83.0, 103.0)
                     )
                 }
             }.close()
@@ -489,8 +490,8 @@ class LocationHelper {
         LocationMessage(
             type = "Feature",
             geometry = LocationGeometry(
-                type = "Point",
-                coordinates = listOf(lat, long, 0.0)
+                type = GeoJsonTypes.POINT,
+                coordinates = listOf(long, lat, 0.0)
             ),
             properties = LocationProperties(
                 accuracyHorizontal = 5.0f,

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -492,7 +492,7 @@ class LocationHelper {
  */
 class TrackableStateReceiver(
     val label: String,
-    private val expectedStates: Set<KClass<out TrackableState>>,
+    private val expectedState: KClass<out TrackableState>,
     private val failureStates: Set<KClass<out TrackableState>>,
     val timeout: Long,
 ) {
@@ -505,10 +505,10 @@ class TrackableStateReceiver(
         fun forActiveFault(label: String, faultType: FaultType) =
             TrackableStateReceiver(
                 label = label,
-                expectedStates = when (faultType) {
-                    is FaultType.Fatal -> setOf(TrackableState.Failed::class)
-                    is FaultType.Nonfatal -> setOf(TrackableState.Online::class)
-                    is FaultType.NonfatalWhenResolved -> setOf(TrackableState.Offline::class)
+                expectedState = when (faultType) {
+                    is FaultType.Fatal -> TrackableState.Failed::class
+                    is FaultType.Nonfatal -> TrackableState.Online::class
+                    is FaultType.NonfatalWhenResolved -> TrackableState.Offline::class
                 },
                 failureStates = when (faultType) {
                     is FaultType.Fatal -> setOf(TrackableState.Offline::class)
@@ -529,10 +529,10 @@ class TrackableStateReceiver(
         fun forResolvedFault(label: String, faultType: FaultType) =
             TrackableStateReceiver(
                 label = label,
-                expectedStates = when (faultType) {
-                    is FaultType.Fatal -> setOf(TrackableState.Failed::class)
+                expectedState = when (faultType) {
+                    is FaultType.Fatal -> TrackableState.Failed::class
                     is FaultType.Nonfatal, is FaultType.NonfatalWhenResolved ->
-                        setOf(TrackableState.Online::class)
+                        TrackableState.Online::class
                 },
                 failureStates = when (faultType) {
                     is FaultType.Fatal -> setOf(
@@ -556,7 +556,7 @@ class TrackableStateReceiver(
         fun onlineWithoutFail(label: String, timeout: Long) =
             TrackableStateReceiver(
                 label = label,
-                expectedStates = setOf(TrackableState.Online::class),
+                expectedState = TrackableState.Online::class,
                 failureStates = setOf(TrackableState.Failed::class),
                 timeout = timeout
             )
@@ -600,7 +600,7 @@ class TrackableStateReceiver(
                 testLogD("TrackableStateReceived (FAIL): $label - $state")
                 false
             }
-            expectedStates.contains(state::class) -> {
+            expectedState == state::class -> {
                 testLogD("TrackableStateReceived (SUCCESS): $label - $state")
                 true
             }


### PR DESCRIPTION
I realised when looking at #928 for @lawrence-forooghian and #932 for @AndyTWF that the existing `TrackableStateReceiver` design in this test makes it quite complicated to make any assertions relating to expected behaviours during faults, because faults didn't have a way to communicate whether they're fatal, nonfatal (always) or nonfatal once you call the `resolve()` method. This PR replaces the `Fault.stateReceiverForStage()` interface with `Fault.type()`, where faults simply communicate what kind of fault they are. This also gives us an opportunity for the fault to provide sensible timeouts for the nature of the fault implemented.

The existing `TrackableStateReceiver` code has been moved into the test, as it's now just a helper that `NetworkConnectivityTest` uses to monitor for side-effects generally. As such, it's renamed to `PublisherMonitor`, to reflect what it does, but this could possibly be generalised if other tests need a way to monitor for similar side-effects.

I think this change will simplify implementation of the Subscriber test, so putting this in a draft PR and handing the baton to @AndyTWF so that I'm not blocking the team.

Some assumptions I'm slightly unsure of relating to using REST APIs rather than listening for WebSocket events to validate side-effects. This does simplify things, but worth an extra set of eyes to ensure these assumptions are valid:

* I'm using the Ably Presence API to just get a presence snapshot "now" after state transitions, as I believe this is reasonable -- state transitions to `Online` or `Failed` should only happen when we've confirmed our presence status, I think. The trickier case is `Offline`, when there's an active fault, as the Publisher won't necessarily have been able to communicate with Ably. I therefore don't bother asserting presence status for the `Offline` during `NonfatalWhenResolved` fault, as I figure this is basically just testing Ably server-side timeouts, not AAT.
* I'm also using the History API to look up the most-recently published message. Not so sure about this one... It seems OK for the initial call to `track()`, but doesn't work for the secondary `add()` call. I actually think this is because of the client implementation, not specifically a race with the Ably API state. So, I'm not sure it was actually valid to be asserting that the location update sent while adding second trackable be immediately broadcast anyway?

A few other changes to be aware of:
* Cleaned up `withResources` to pass itself as `this` to the test body, cuts down on boiler-plate.
* Moved `waitForStateTransition()` into `PublisherMonitor` (previously `TrackableStateReceiver`) as all the resources it uses are now members of that class.
* Added a `Fault.cleanUp` function with default implementation to just shutdown the proxy. `DisconnectAndSuspend` overrides this to also cancel its async timer.

State at the time of opening:
* Should be somewhat 'green' as-is, all the problematic tests are still disabled.
* I'm seeing `DisconnectAndSuspend` hang on `faultBeforeAddingTrackable`, seemingly during the `setUp()` function. Not sure what's going on here, it may be related to the new cleanup stuff in the last commit.
* Side-effects are being successfully verified. I didn't see `DetachUnresponsive` move to failing as described by @lawrence-forooghian in #928. And initial glance through the logs suggests that the only `DETACH` operation in that test occurs *after* the fault is resolved anyway. I can only assume this is because the `remove()` call completes before the channel is detached? I'm not sure this is a problem, the end result appears to be that all use cases exercised complete successfully, with the expected side-effects, despite the fault?
