### PR TITLE
setting log level for test location source AblyRealtime instance

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -460,6 +460,9 @@ private val LOCATION_SOURCE_OPTS = ClientOptions().apply {
     this.clientId = "IntegTests_NoProxy"
     this.key = BuildConfig.ABLY_API_KEY
     this.logHandler = Logging.ablyJavaDebugLogger
+    // Setting log level only to prevent overwriting it in the AblyRealtime instance that we care about
+    // can be removed once underlying ably-java issue is fixed - https://github.com/ably/ably-java/issues/901
+    this.logLevel = Log.VERBOSE
 }
 
 /**


### PR DESCRIPTION
Setting `log level` in `LocationSource` ably client to prevent overwriting the `VERBOSE` log level specified in the client under test options, and some messages were not logged. Can be reverted once [underlying ably-java issue](https://github.com/ably/ably-java/issues/901) is fixed.