### PR TITLE
Switch to CIO ktor engine

### DIFF
--- a/android-test-common/build.gradle
+++ b/android-test-common/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     // Ktor dependencies for Layer 7 proxy in NetworkConnectivityTest
     implementation "io.ktor:ktor-server-websockets:$ktor_version"
-    implementation "io.ktor:ktor-server-netty:$ktor_version"
+    implementation "io.ktor:ktor-server-cio:$ktor_version"
     implementation "io.ktor:ktor-server-call-logging:$ktor_version"
     implementation "io.ktor:ktor-client-cio:$ktor_version"
     implementation "io.ktor:ktor-client-websockets:$ktor_version"

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/AblyProxy.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/AblyProxy.kt
@@ -3,7 +3,6 @@ package com.ably.tracking.test.android.common
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.util.Log
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -13,9 +12,8 @@ import io.ktor.http.Parameters
 import io.ktor.http.ParametersBuilder
 import io.ktor.http.Url
 import io.ktor.server.application.install
+import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
-import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
@@ -35,6 +33,8 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
 import javax.net.ssl.SSLSocketFactory
+import io.ktor.client.engine.cio.CIO as ClientCIO
+import io.ktor.server.cio.CIO as ServerCIO
 
 private const val AGENT_HEADER_NAME = "ably-asset-tracking-android-publisher-tests"
 
@@ -283,13 +283,13 @@ class Layer7Proxy(
         const val tag = "Layer7Proxy"
     }
 
-    private var server: NettyApplicationEngine? = null
+    private var server: ApplicationEngine? = null
     var interceptor: Layer7Interceptor = PassThroughInterceptor()
 
     override fun start() {
         testLogD("$tag: starting...")
         server = embeddedServer(
-            Netty,
+            ServerCIO,
             port = listenPort,
             host = listenHost
         ) {
@@ -412,7 +412,7 @@ fun Route.wsProxy(path: String, target: Url, parent: Layer7Proxy) {
  * we can see in logcat
  */
 fun configureWsClient() =
-    HttpClient(CIO).config {
+    HttpClient(ClientCIO).config {
         install(io.ktor.client.plugins.websocket.WebSockets) {
         }
         install(Logging) {


### PR DESCRIPTION
We're seeing random crashes from the Netty backend currently used as a websocket server in the Layer 7 proxy implementation. These seem to be related to [KTOR-2762](https://youtrack.jetbrains.com/issue/KTOR-2762) and [KTOR-3928](https://youtrack.jetbrains.com/issue/KTOR-3928), neither of which seem to have a quick resolution in sight.

Ktor has different backend options, however. CIO is a pure Kotlin, coroutine-based alternative, which aims to be free of heavyweight JVM dependencies. This seems to be more stable for our purposes, testing on Android. Let's see if CI agrees...