### PR TITLE
Upgrade core Ably SDK dependency to version `1.2.23`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.22'
+    ext.ably_core_version = '1.2.23'
 
     repositories {
         google()


### PR DESCRIPTION
This brings in the fix for https://github.com/ably/ably-java/issues/885, being part of the solution for https://github.com/ably/ably-asset-tracking-android/issues/863 (see [this comment](https://github.com/ably/ably-asset-tracking-android/issues/863#issuecomment-1370831055)).

https://github.com/ably/ably-java/issues/884 is yet to be worked upon and will be fixed here with a subsequent core SDK dependency bump for the release that includes it.