### PR TITLE
Change publisher's remove operation to always succeed

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -497,14 +497,13 @@ constructor(
         try {
             leavePresence(channel, presenceData)
         } catch (connectionException: ConnectionException) {
-            if (connectionException.isRetriable()) {
-                logHandler?.w("$TAG Failed to leave presence for channel ${channel.name} due to a retriable exception, the operation will be retried in $PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS ms", connectionException)
-                delay(PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS)
-                leavePresenceRepeating(channel, presenceData)
-            } else {
+            if (!connectionException.isRetriable()) {
                 logHandler?.w("$TAG Failed to leave presence for channel ${channel.name} due to a non-retriable exception", connectionException)
                 throw connectionException
             }
+            logHandler?.w("$TAG Failed to leave presence for channel ${channel.name} due to a retriable exception, the operation will be retried in $PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS ms", connectionException)
+            delay(PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS)
+            leavePresenceRepeating(channel, presenceData)
         }
     }
 

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -205,18 +206,12 @@ interface Ably {
 
     /**
      * Removes the [trackableId] channel from the connected channels and leaves the presence of that channel.
-     * If a channel for the given [trackableId] doesn't exist then it just calls [callback] with success.
+     * If a channel for the given [trackableId] doesn't exist then it just completes.
      *
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
-     * @param callback The function that will be called when disconnecting completes. If something goes wrong it will be called with [ConnectionException].
      */
-    fun disconnect(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit)
-
-    /**
-     * A suspending version of [disconnect]
-     * */
-    suspend fun disconnect(trackableId: String, presenceData: PresenceData): Result<Unit>
+    suspend fun disconnect(trackableId: String, presenceData: PresenceData)
 
     /**
      * Cleanups and closes all the connected channels and their presence. In the end closes Ably connection.
@@ -241,6 +236,8 @@ interface Ably {
 private const val CHANNEL_NAME_PREFIX = "tracking:"
 private const val AGENT_HEADER_NAME = "ably-asset-tracking-android"
 private const val AUTH_TOKEN_CAPABILITY_ERROR_CODE = 40160
+private const val PRESENCE_LEAVE_MAXIMUM_DURATION_IN_MILLISECONDS = 30_000L
+private const val PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS = 15_000L
 
 class DefaultAbly<ChannelStateListenerType : AblySdkChannelStateListener>
 /**
@@ -425,38 +422,12 @@ constructor(
         }
     }
 
-    override fun disconnect(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
-        scope.launch {
-            val channelToRemove = getChannelIfExists(trackableId)
-            if (channelToRemove != null) {
-                try {
-                    disconnectChannel(channelToRemove, presenceData)
-                    callback(Result.success(Unit))
-                } catch (exception: ConnectionException) {
-                    logHandler?.w("$TAG Failed to disconnect for trackable $trackableId", exception)
-                    callback(Result.failure(exception))
-                }
-            } else {
-                callback(Result.success(Unit))
-            }
-        }
-    }
-
     private suspend fun tryDisconnectChannel(channelToRemove: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) =
         try {
             disconnectChannel(channelToRemove, presenceData)
         } catch (exception: Exception) {
             // no-op
         }
-
-    private suspend fun disconnectChannel(channelToRemove: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
-        retryChannelOperationIfConnectionResumeFails(channelToRemove) { channel ->
-            leavePresence(channel, presenceData)
-            channel.unsubscribe()
-            channel.presence.unsubscribe()
-            ably.channels.release(channel.name)
-        }
-    }
 
     private suspend fun failChannel(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData, errorInfo: ErrorInfo) {
         leavePresence(channel, presenceData)
@@ -493,19 +464,46 @@ constructor(
         }
     }
 
+    override suspend fun disconnect(trackableId: String, presenceData: PresenceData) {
+        logHandler?.v("$TAG Disconnect started for trackable $trackableId")
+        val channelToRemove = getChannelIfExists(trackableId)
+        if (channelToRemove != null) {
+            disconnectChannel(channelToRemove, presenceData)
+        }
+        logHandler?.v("$TAG Disconnect finished for trackable $trackableId")
+    }
+
+    private suspend fun disconnectChannel(channelToRemove: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
+        try {
+            logHandler?.v("$TAG Starting to disconnect channel ${channelToRemove.name}")
+            withTimeout(PRESENCE_LEAVE_MAXIMUM_DURATION_IN_MILLISECONDS) {
+                leavePresenceRepeating(channelToRemove, presenceData)
+            }
+        } catch (connectionException: ConnectionException) {
+            logHandler?.w("$TAG Leave presence failed but will continue disconnecting channel ${channelToRemove.name}")
+        } catch (timeoutException: TimeoutCancellationException) {
+            logHandler?.w("$TAG Leave presence timed out but will continue disconnecting channel ${channelToRemove.name}")
+        }
+        channelToRemove.unsubscribe()
+        channelToRemove.presence.unsubscribe()
+        ably.channels.release(channelToRemove.name)
+    }
+
     /**
-     * A suspend version of the [DefaultAbly.disconnect] method. It waits until disconnection is completed.
+     * Try to leave the presence of the [channel] and if it fails due to a retriable error repeat the operation
+     * after a delay. If the operation fails due to a non-retriable error then re-throw the [ConnectionException].
      */
-    override suspend fun disconnect(trackableId: String, presenceData: PresenceData): Result<Unit> {
-        return suspendCancellableCoroutine { continuation ->
-            disconnect(trackableId, presenceData) {
-                try {
-                    it.getOrThrow()
-                    continuation.resume(Result.success(Unit))
-                } catch (exception: ConnectionException) {
-                    logHandler?.w("$TAG Failed to disconnect for trackable $trackableId", exception)
-                    continuation.resume(Result.failure(exception))
-                }
+    private suspend fun leavePresenceRepeating(channel: AblySdkRealtime.Channel<ChannelStateListenerType>, presenceData: PresenceData) {
+        try {
+            leavePresence(channel, presenceData)
+        } catch (connectionException: ConnectionException) {
+            if (connectionException.isRetriable()) {
+                logHandler?.w("$TAG Failed to leave presence for channel ${channel.name} due to a retriable exception, the operation will be retried in $PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS ms", connectionException)
+                delay(PRESENCE_LEAVE_RETRY_DELAY_IN_MILLISECONDS)
+                leavePresenceRepeating(channel, presenceData)
+            } else {
+                logHandler?.w("$TAG Failed to leave presence for channel ${channel.name} due to a non-retriable exception", connectionException)
+                throw connectionException
             }
         }
     }

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -1416,11 +1416,11 @@ class DefaultAblyTests {
      */
 
     @Test
-    fun `disconnect - when channel is in INITIALIZED state`() {
+    fun `disconnect - when presence leave succeeds`() {
         /* Given...
          *
          * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state INITIALIZED...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel...
          * ...which, when told to leave presence, does so successfully...
          *
          * When...
@@ -1432,7 +1432,6 @@ class DefaultAblyTests {
          *
          * ...it calls `containsKey` on the Channels instance...
          * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
          * ...and tells the channel to leave presence...
          * ...and calls `unsubscribe` on the channel and on its Presence instance...
          * ...and fetches the channel’s name and calls `release` on the Channels instance...
@@ -1444,545 +1443,12 @@ class DefaultAblyTests {
                 DefaultAblyTestScenarios.Disconnect.GivenConfig(
                     channelsContainsKey = true,
                     mockChannelsGet = true,
-                    initialChannelState = ChannelState.initialized,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
                     presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
                 ),
                 DefaultAblyTestScenarios.Disconnect.ThenConfig(
                     verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
                     verifyPresenceLeave = true,
                     verifyChannelUnsubscribeAndRelease = true,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in ATTACHING state`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHING...
-         * ...which, when told to leave presence, does so successfully...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
-         * ...and tells the channel to leave presence...
-         * ...and calls `unsubscribe` on the channel and on its Presence instance...
-         * ...and fetches the channel’s name and calls `release` on the Channels instance...
-         * ...and the call to `disconnect` (on the object under test) succeeds.
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.attaching,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = true,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in ATTACHED state`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ATTACHED...
-         * ...which, when told to leave presence, does so successfully...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
-         * ...and tells the channel to leave presence...
-         * ...and calls `unsubscribe` on the channel and on its Presence instance...
-         * ...and fetches the channel’s name and calls `release` on the Channels instance...
-         * ...and the call to `disconnect` (on the object under test) succeeds.
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.attached,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = true,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in DETACHING state`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHING...
-         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
-         * ...and tells the channel to leave presence...
-         * ...and the call to `disconnect` (on the object under test) fails with a `ConnectionException` whose errorInformation has the same `code` and `message` as `presenceError`.
-         */
-
-        /* A note on this test:
-         *
-         * RTP16c tells us that a presence operation on a channel in the DETACHING state will fail.
-         */
-
-        val presenceError = ErrorInfo(
-            "example of an error message", /* arbitrarily chosen */
-            123 /* arbitrarily chosen */
-        )
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.detaching,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
-                        presenceError
-                    )
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                presenceError.code,
-                                0,
-                                presenceError.message,
-                                null,
-                                null
-                            )
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in DETACHED state`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state DETACHED...
-         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
-         * ...and tells the channel to leave presence...
-         * ...and the call to `disconnect` (on the object under test) fails with a `ConnectionException` whose errorInformation has the same `code` and `message` as `presenceError`.
-         */
-
-        /* A note on this test:
-         *
-         * RTP16c tells us that a presence operation on a channel in the DETACHED state will fail.
-         */
-
-        val presenceError = ErrorInfo(
-            "example of an error message", /* arbitrarily chosen */
-            123 /* arbitrarily chosen */
-        )
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.detached,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
-                        presenceError
-                    )
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                presenceError.code,
-                                0,
-                                presenceError.message,
-                                null,
-                                null
-                            )
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in FAILED state`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state FAILED...
-         * ...which, when told to enter presence, fails to do so with an arbitrarily-chosen error `presenceError`...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
-         * ...and tells the channel to leave presence...
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
-         */
-
-        /* A note on this test:
-         *
-         * RTP16c tells us that a presence operation on a channel in the FAILED state will fail.
-         */
-
-        val presenceError = ErrorInfo(
-            "example of an error message", /* arbitrarily chosen */
-            123 /* arbitrarily chosen */
-        )
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.failed,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
-                        presenceError
-                    )
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                presenceError.code,
-                                0,
-                                presenceError.message,
-                                null,
-                                null
-                            )
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in SUSPENDED state with no subsequent state change`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state twice...
-         * ...and calls `on` on the channel...
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.suspended,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 2,
-                    verifyChannelOn = true,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = false,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                code = 100000,
-                                statusCode = 0,
-                                message = "Timeout was thrown when waiting for channel to attach",
-                                href = null,
-                                cause = null
-                            )
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to ATTACHED`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
-         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ATTACHED...
-         * ...and which, when told to leave presence, does so successfully...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state twice...
-         * ...and calls `on` on the channel...
-         * ...and checks the `current` property of the emitted channel state change...
-         * ...and calls `off` on the channel...
-         * ...and tells the channel to leave presence...
-         * ...and calls `unsubscribe` on the channel and on its Presence instance...
-         * ...and fetches the channel’s name and calls `release` on the Channels instance...
-         * ...and the call to `disconnect` (on the object under test) succeeds.
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.suspended,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
-                        current = ChannelState.attached
-                    ),
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Success
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 2,
-                    verifyChannelOn = true,
-                    verifyChannelStateChangeCurrent = true,
-                    verifyChannelOff = true,
-                    verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = true,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to FAILED`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
-         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is FAILED...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state twice...
-         * ...and calls `on` on the channel...
-         * ...and checks the `current` property of the emitted channel state change...
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.suspended,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
-                        current = ChannelState.failed
-                    ),
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 2,
-                    verifyChannelOn = true,
-                    verifyChannelStateChangeCurrent = true,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = false,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                code = 100000,
-                                statusCode = 0,
-                                message = "Timeout was thrown when waiting for channel to attach",
-                                href = null,
-                                cause = null
-                            )
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `disconnect - when channel is in SUSPENDED state and subsequently transitions to DETACHED`() {
-        /* Given...
-         *
-         * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state SUSPENDED...
-         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is DETACHED...
-         *
-         * When...
-         *
-         * ...we call `disconnect` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state twice...
-         * ...and calls `on` on the channel...
-         * ...and checks the `current` property of the emitted channel state change...
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has `code` 100000 and `message` "Timeout was thrown when waiting for channel to attach".
-         */
-
-        runBlocking {
-            DefaultAblyTestScenarios.Disconnect.test(
-                DefaultAblyTestScenarios.Disconnect.GivenConfig(
-                    channelsContainsKey = true,
-                    mockChannelsGet = true,
-                    initialChannelState = ChannelState.suspended,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.EmitStateChange(
-                        current = ChannelState.detached
-                    ),
-                    presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
-                ),
-                DefaultAblyTestScenarios.Disconnect.ThenConfig(
-                    verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 2,
-                    verifyChannelOn = true,
-                    verifyChannelStateChangeCurrent = true,
-                    verifyChannelOff = false,
-                    verifyPresenceLeave = false,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                code = 100000,
-                                statusCode = 0,
-                                message = "Timeout was thrown when waiting for channel to attach",
-                                href = null,
-                                cause = null
-                            )
-                        )
-                    )
                 )
             )
         }
@@ -1993,7 +1459,7 @@ class DefaultAblyTests {
         /* Given...
          *
          * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in the arbitrarily-chosen ATTACHED state...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel...
          * ...which, when told to leave presence, fails to do so with an arbitrarily-chosen error `presenceError`...
          *
          * When...
@@ -2005,9 +1471,10 @@ class DefaultAblyTests {
          *
          * ...it calls `containsKey` on the Channels instance...
          * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
          * ...and tells the channel to leave presence...
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation has the same `code` and `message` as `presenceError`.
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds.
          */
 
         val presenceError = ErrorInfo(
@@ -2020,31 +1487,14 @@ class DefaultAblyTests {
                 DefaultAblyTestScenarios.Disconnect.GivenConfig(
                     channelsContainsKey = true,
                     mockChannelsGet = true,
-                    initialChannelState = ChannelState.attached, // arbitrarily chosen
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
                     presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.Failure(
                         presenceError
                     )
                 ),
                 DefaultAblyTestScenarios.Disconnect.ThenConfig(
                     verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
                     verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.FailureWithConnectionException(
-                            ErrorInformation(
-                                presenceError.code,
-                                0,
-                                presenceError.message,
-                                null,
-                                null
-                            )
-                        )
-                    )
+                    verifyChannelUnsubscribeAndRelease = true,
                 )
             )
         }
@@ -2056,7 +1506,7 @@ class DefaultAblyTests {
          * Given...
          *
          * ...that calling containsKey on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in (arbitrarily chosen) state ATTACHED...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel...
          * ...which, when told to leave presence, never finishes doing so...
          *
          * When...
@@ -2068,9 +1518,10 @@ class DefaultAblyTests {
          *
          * ...it calls `containsKey` on the Channels instance...
          * ...and calls `get` on the Channels instance...
-         * ...and fetches the channel’s state once...
          * ...and tells the channel to leave presence...
-         * ...and the call to `disconnect` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
+         * ...and calls `unsubscribe` on the channel and on its Presence instance...
+         * ...and fetches the channel’s name and calls `release` on the Channels instance...
+         * ...and the call to `disconnect` (on the object under test) succeeds after presence leave is timed out.
          */
 
         runBlocking {
@@ -2078,21 +1529,12 @@ class DefaultAblyTests {
                 DefaultAblyTestScenarios.Disconnect.GivenConfig(
                     channelsContainsKey = true,
                     mockChannelsGet = true,
-                    initialChannelState = ChannelState.attached, // arbitrarily chosen
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
                     presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete
                 ),
                 DefaultAblyTestScenarios.Disconnect.ThenConfig(
                     verifyChannelsGet = true,
-                    numberOfChannelStateFetchesToVerify = 1,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
                     verifyPresenceLeave = true,
-                    verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.DoesNotTerminate(
-                        timeoutInMilliseconds = noTimeoutDemonstrationWaitingTimeInMilliseconds
-                    )
+                    verifyChannelUnsubscribeAndRelease = true,
                 )
             )
         }
@@ -2119,21 +1561,12 @@ class DefaultAblyTests {
                 DefaultAblyTestScenarios.Disconnect.GivenConfig(
                     channelsContainsKey = false,
                     mockChannelsGet = false,
-                    initialChannelState = null,
-                    channelStateChangeBehaviour = DefaultAblyTestScenarios.GivenTypes.ChannelStateChangeBehaviour.NoBehaviour,
                     presenceLeaveBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.NotMocked
                 ),
                 DefaultAblyTestScenarios.Disconnect.ThenConfig(
                     verifyChannelsGet = false,
-                    numberOfChannelStateFetchesToVerify = 0,
-                    verifyChannelOn = false,
-                    verifyChannelStateChangeCurrent = false,
-                    verifyChannelOff = false,
                     verifyPresenceLeave = false,
                     verifyChannelUnsubscribeAndRelease = false,
-                    resultOfDisconnectCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.Terminates(
-                        expectedResult = DefaultAblyTestScenarios.ThenTypes.ExpectedResult.Success
-                    )
                 )
             )
         }

--- a/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
+++ b/common/src/test/java/com/ably/tracking/common/helper/DefaultAblyTestScenarios.kt
@@ -810,14 +810,6 @@ class DefaultAblyTestScenarios {
             val channelsContainsKey: Boolean,
             val mockChannelsGet: Boolean,
             /**
-             * This must be `null` if and only if [mockChannelsGet] is `false`.
-             */
-            val initialChannelState: ChannelState?,
-            /**
-             * If [mockChannelsGet] is `false` then this must be [GivenTypes.ChannelStateChangeBehaviour.NoBehaviour].
-             */
-            val channelStateChangeBehaviour: GivenTypes.ChannelStateChangeBehaviour,
-            /**
              * If [mockChannelsGet] is `false` then this must be [GivenTypes.CompletionListenerMockBehaviour.NotMocked].
              */
             val presenceLeaveBehaviour: GivenTypes.CompletionListenerMockBehaviour
@@ -828,17 +820,7 @@ class DefaultAblyTestScenarios {
              * @throws InvalidTestConfigurationException If this object does not represent a valid test configuration.
              */
             init {
-                if (mockChannelsGet) {
-                    if (initialChannelState == null) {
-                        throw InvalidTestConfigurationException("initialChannelState must be non-null when mockChannelsGet is true")
-                    }
-                } else {
-                    if (initialChannelState != null) {
-                        throw InvalidTestConfigurationException("initialChannelState must be null when mockChannelsGet is false")
-                    }
-                    if (channelStateChangeBehaviour !is GivenTypes.ChannelStateChangeBehaviour.NoBehaviour) {
-                        throw InvalidTestConfigurationException("channelStateChangeBehaviour must be NoBehaviour when mockChannelsGet is false")
-                    }
+                if (!mockChannelsGet) {
                     if (presenceLeaveBehaviour !is GivenTypes.CompletionListenerMockBehaviour.NotMocked) {
                         throw InvalidTestConfigurationException("presenceLeaveBehaviour must be NotMocked when mockChannelsGet is false")
                     }
@@ -852,22 +834,6 @@ class DefaultAblyTestScenarios {
         class ThenConfig(
             val verifyChannelsGet: Boolean,
             /**
-             * If [GivenConfig.mockChannelsGet] is `false` then this must be zero.
-             */
-            val numberOfChannelStateFetchesToVerify: Int,
-            /**
-             * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
-             */
-            val verifyChannelOn: Boolean,
-            /**
-             * If [GivenConfig.channelStateChangeBehaviour] is not [GivenTypes.ChannelStateChangeBehaviour.EmitStateChange] then this must be `false`.
-             */
-            val verifyChannelStateChangeCurrent: Boolean,
-            /**
-             * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
-             */
-            val verifyChannelOff: Boolean,
-            /**
              * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
              */
             val verifyPresenceLeave: Boolean,
@@ -875,8 +841,12 @@ class DefaultAblyTestScenarios {
              * If [GivenConfig.mockChannelsGet] is `false` then this must be `false`.
              */
             val verifyChannelUnsubscribeAndRelease: Boolean,
-            val resultOfDisconnectCallOnObjectUnderTest: ThenTypes.ExpectedAsyncResult
         ) {
+            /**
+             * The disconnect should always be successful.
+             */
+            val resultOfDisconnectCallOnObjectUnderTest: ThenTypes.ExpectedAsyncResult =
+                ThenTypes.ExpectedAsyncResult.Terminates(ThenTypes.ExpectedResult.Success)
             /**
              * Checks that this object represents a valid test configuration to be used with [givenConfig].
              *
@@ -885,25 +855,11 @@ class DefaultAblyTestScenarios {
              */
             fun validate(givenConfig: GivenConfig) {
                 if (!givenConfig.mockChannelsGet) {
-                    if (numberOfChannelStateFetchesToVerify != 0) {
-                        throw InvalidTestConfigurationException("numberOfChannelStateFetchesToVerify must be zero when mockChannelsGet is false")
-                    }
-                    if (verifyChannelOn) {
-                        throw InvalidTestConfigurationException("verifyChannelOn must be false when mockChannelsGet is false")
-                    }
                     if (verifyPresenceLeave) {
                         throw InvalidTestConfigurationException("verifyPresenceLeave must be false when mockChannelsGet is false")
                     }
-                    if (verifyChannelOff) {
-                        throw InvalidTestConfigurationException("verifyChannelOff must be false when mockChannelsGet is false")
-                    }
                     if (verifyChannelUnsubscribeAndRelease) {
                         throw InvalidTestConfigurationException("verifyChannelUnsubscribeAndRelease must be false when mockChannelsGet is false")
-                    }
-                }
-                if (givenConfig.channelStateChangeBehaviour !is GivenTypes.ChannelStateChangeBehaviour.EmitStateChange) {
-                    if (verifyChannelStateChangeCurrent) {
-                        throw InvalidTestConfigurationException("verifyChannelStateChangeCurrent must be false when channelStateChangeBehaviour is not EmitStateChange")
                     }
                 }
             }
@@ -918,11 +874,7 @@ class DefaultAblyTestScenarios {
          * ...that calling containsKey on the Channels instance returns ${givenConfig.channelsContainsKey}...
          *
          * if ${givenConfig.mockChannelsGet} {
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel in state ${givenConfig.initialChannelState}...
-         * }
-         *
-         * when ${givenConfig.channelStateChangeBehaviour} is EmitStateChange {
-         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ${givenConfig.channelStateChangeBehaviour.current}...
+         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel...
          * }
          *
          * when ${givenConfig.presenceLeaveBehaviour} is Success {
@@ -950,20 +902,6 @@ class DefaultAblyTestScenarios {
          * ...and calls `get` on the Channels instance...
          * }
          *
-         * ...and fetches the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
-         *
-         * if ${thenConfig.verifyChannelOn} {
-         * ...and calls `on` on the channel...
-         * }
-         *
-         * if ${thenConfig.verifyChannelStateChangeCurrent} {
-         * ...and checks the `current` property of the emitted channel state change...
-         * }
-         *
-         *  if ${thenConfig.verifyChannelOff} {
-         * ...and calls `off` on the channel...
-         * }
-         *
          * if ${thenConfig.verifyPresenceLeave} {
          * ...and tells the channel to leave presence...
          * }
@@ -973,17 +911,7 @@ class DefaultAblyTestScenarios {
          * ...and fetches the channel’s name and calls `release` on the Channels instance...
          * }
          *
-         * when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.expectedResult} is Success {
-         * ...and the call to `disconnect` (on the object under test) succeeds.
-         * }
-         *
-         * when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
-         * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.errorInformation}.
-         * }
-         *
-         * when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is DoesNotTerminate {
-         * ...and the call to `disconnect` (on the object under test) does not complete within ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
-         * }
+         * ...and the call to `disconnect` (on the object under test) always succeeds.
          * ```
          */
         companion object {
@@ -1007,24 +935,6 @@ class DefaultAblyTestScenarios {
                      * }
                      */
                     testEnvironment.mockChannelsGet(DefaultAblyTestEnvironment.ChannelsGetOverload.WITHOUT_CHANNEL_OPTIONS)
-                    configuredChannel.mockState(givenConfig.initialChannelState!!)
-                }
-
-                val channelStateChangeMock: AblySdkChannelStateListener.ChannelStateChange?
-                when (val givenChannelStateBehaviour = givenConfig.channelStateChangeBehaviour) {
-                    is GivenTypes.ChannelStateChangeBehaviour.NoBehaviour -> {
-                        configuredChannel.stubOn()
-                        channelStateChangeMock = null
-                    }
-                    is GivenTypes.ChannelStateChangeBehaviour.EmitStateChange -> {
-                        /* when ${givenConfig.channelStateChangeBehaviour} is EmitStateChange {
-                         * ...which, when its `on` method is called, immediately calls the received listener with a channel state change whose `current` property is ${givenConfig.channelStateChangeBehaviour.current}...
-                         * }
-                         */
-                        channelStateChangeMock =
-                            configuredChannel.mockOnToEmitStateChange(current = givenChannelStateBehaviour.current)
-                        configuredChannel.stubOff()
-                    }
                 }
 
                 when (val givenPresenceLeaveBehaviour = givenConfig.presenceLeaveBehaviour) {
@@ -1082,35 +992,6 @@ class DefaultAblyTestScenarios {
                         testEnvironment.channelsMock.get(configuredChannel.channelName)
                     }
 
-                    // ...and fetches the channel’s state ${thenConfig.numberOfChannelStateFetchesToVerify} times...
-                    repeat(thenConfig.numberOfChannelStateFetchesToVerify) {
-                        configuredChannel.channelMock.state
-                    }
-
-                    if (thenConfig.verifyChannelOn) {
-                        /* if ${thenConfig.verifyChannelOn} {
-                         * ...and calls `on` on the channel...
-                         * }
-                         */
-                        configuredChannel.channelMock.on(any())
-                    }
-
-                    if (thenConfig.verifyChannelStateChangeCurrent) {
-                        /* if ${thenConfig.verifyChannelStateChangeCurrent} {
-                         * ...and checks the `current` property of the emitted channel state change...
-                         * }
-                         */
-                        channelStateChangeMock!!.current
-                    }
-
-                    if (thenConfig.verifyChannelOff) {
-                        /* if ${thenConfig.verifyChannelOff} {
-                         * ...and calls `off` on the channel...
-                         * }
-                         */
-                        configuredChannel.channelMock.off(any())
-                    }
-
                     if (thenConfig.verifyPresenceLeave) {
                         /* if ${thenConfig.verifyPresenceLeave} {
                          * ...and tells the channel to leave presence...
@@ -1132,19 +1013,11 @@ class DefaultAblyTestScenarios {
                     }
                 }
 
-                /* when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.expectedResult} is Success {
+                /* and always {
                  * ...and the call to `disconnect` (on the object under test) succeeds.
                  * }
-                 *
-                 * when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is Terminates and ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.expectedResult} is FailureWithConnectionException {
-                 * ...and the call to `disconnect` (on the object under test) fails with a ConnectionException whose errorInformation is equal to ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.errorInformation}.
-                 * }
-                 *
-                 * when ${thenConfig.resultOfDisconnectCallOnObjectUnderTest} is DoesNotTerminate {
-                 * ...and the call to `disconnect` (on the object under test) does not complete within ${thenConfig.resultOfDisconnectCallOnObjectUnderTest.timeoutInMilliseconds} milliseconds.
-                 * }
                  */
-                thenConfig.resultOfDisconnectCallOnObjectUnderTest.verify(result)
+                Assert.assertNotNull(result)
 
                 confirmVerified(*testEnvironment.allMocks)
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -68,8 +68,7 @@ interface Publisher {
      *
      * @param trackable The object to be removed from this publisher's tracked set, it it's there.
      *
-     * @return `true` if the object was known to this publisher, otherise `false`.
-     * @throws ConnectionException when something goes wrong with the Ably connection
+     * @return `true` if the object was known to this publisher, otherwise `false`.
      */
     @JvmSynthetic
     suspend fun remove(trackable: Trackable): Boolean

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -129,6 +129,8 @@ private constructor(
         }
     val hasNoTrackablesAddingOrAdded: Boolean
         get() = trackables.isEmpty() && !duplicateTrackableGuard.isCurrentlyAddingAnyTrackable()
+    val trackablesWithFinalStateSet: MutableSet<String> = mutableSetOf()
+        get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
 
     override val isStopped: Boolean
         get() = state == PublisherState.STOPPED
@@ -171,6 +173,8 @@ private constructor(
                 it.state = state
             }
 
+    fun hasSetFinalTrackableState(trackableId: String): Boolean = trackablesWithFinalStateSet.contains(trackableId)
+
     fun dispose() {
         trackables.clear()
         trackableStates.clear()
@@ -193,6 +197,7 @@ private constructor(
         rawLocationsPublishingState.clearAll()
         duplicateTrackableGuard.clearAll()
         trackableRemovalGuard.clearAll()
+        trackablesWithFinalStateSet.clear()
         isDisposed = true
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -168,6 +168,7 @@ internal class WorkerFactory(
             is WorkerSpecification.RemoveTrackable -> RemoveTrackableWorker(
                 workerSpecification.trackable,
                 ably,
+                publisherInteractor,
                 workerSpecification.callbackFunction,
             )
             is WorkerSpecification.SendEnhancedLocationFailure -> SendEnhancedLocationFailureWorker(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -41,8 +41,8 @@ internal class ConnectionCreatedWorker(
             // Leave Ably channel.
             doAsyncWork {
                 isBeingRemoved = true
-                val result = ably.disconnect(trackable.id, properties.presenceData)
-                postWork(WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, result))
+                ably.disconnect(trackable.id, properties.presenceData)
+                postWork(WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, Result.success(Unit)))
             }
             return properties
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
@@ -64,8 +64,8 @@ internal class ConnectionReadyWorker(
         properties: PublisherProperties,
         postWork: (WorkerSpecification) -> Unit
     ) {
-        val result = ably.disconnect(trackable.id, properties.presenceData)
-        postWork(WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, result))
+        ably.disconnect(trackable.id, properties.presenceData)
+        postWork(WorkerSpecification.TrackableRemovalRequested(trackable, callbackFunction, Result.success(Unit)))
     }
 
     private fun subscribeForChannelStateChanges() {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -65,6 +65,7 @@ internal class DisconnectSuccessWorker(
         properties.trackableStates.remove(trackable.id)
         properties.lastChannelConnectionStateChanges.remove(trackable.id)
         properties.trackableSubscribedToPresenceFlags.remove(trackable.id)
+        properties.trackablesWithFinalStateSet.remove(trackable.id)
     }
 
     private fun updateResolutions(properties: PublisherProperties) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
@@ -22,12 +22,8 @@ internal class RemoveTrackableWorker(
             properties.trackables.contains(trackable) -> {
                 doAsyncWork {
                     // Leave Ably channel.
-                    val result = ably.disconnect(trackable.id, properties.presenceData)
-                    if (result.isSuccess) {
-                        postWork(buildDisconnectSuccessWorkerSpecification(postWork))
-                    } else {
-                        callbackFunction(Result.failure(result.exceptionOrNull()!!))
-                    }
+                    ably.disconnect(trackable.id, properties.presenceData)
+                    postWork(buildDisconnectSuccessWorkerSpecification(postWork))
                 }
             }
             properties.duplicateTrackableGuard.isCurrentlyAddingTrackable(trackable) -> {

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -5,7 +5,6 @@ import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockConnectFailureThenSuccess
 import com.ably.tracking.test.common.mockConnectSuccess
-import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import io.mockk.coEvery
@@ -40,7 +39,6 @@ class DefaultPublisherTest {
         // given
         val trackableId = UUID.randomUUID().toString()
         ably.mockConnectSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when
@@ -56,7 +54,6 @@ class DefaultPublisherTest {
         // given
         val trackableId = UUID.randomUUID().toString()
         ably.mockConnectSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
         // when

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorkerTest.kt
@@ -90,8 +90,7 @@ class ConnectionCreatedWorkerTest {
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 
-        val disconnectResult = Result.success(Unit)
-        ably.mockDisconnect(trackable.id, disconnectResult)
+        ably.mockDisconnect(trackable.id)
 
         // when
         worker.doWork(
@@ -108,7 +107,6 @@ class ConnectionCreatedWorkerTest {
         val postedWork = postedWorks.first() as WorkerSpecification.TrackableRemovalRequested
         assertThat(postedWork.trackable).isEqualTo(trackable)
         assertThat(postedWork.callbackFunction).isEqualTo(resultCallbackFunction)
-        assertThat(postedWork.result).isEqualTo(disconnectResult)
     }
 
     @Test
@@ -117,8 +115,7 @@ class ConnectionCreatedWorkerTest {
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 
-        val disconnectResult = Result.success(Unit)
-        ably.mockDisconnect(trackable.id, disconnectResult)
+        ably.mockDisconnect(trackable.id)
 
         // when
         worker.doWork(

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorkerTest.kt
@@ -11,7 +11,6 @@ import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockDisconnect
 import com.google.common.truth.Truth.assertThat
-import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
@@ -336,8 +335,7 @@ class ConnectionReadyWorkerTest {
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 
-        val disconnectResult = Result.success(Unit)
-        ably.mockDisconnect(trackable.id, disconnectResult)
+        ably.mockDisconnect(trackable.id)
 
         // when
         worker.doWork(
@@ -356,7 +354,6 @@ class ConnectionReadyWorkerTest {
 
         assertThat(postedWork.trackable).isEqualTo(trackable)
         assertThat(postedWork.callbackFunction).isEqualTo(resultCallbackFunction)
-        assertThat(postedWork.result).isEqualTo(disconnectResult)
     }
 
     @Test
@@ -365,7 +362,7 @@ class ConnectionReadyWorkerTest {
         val initialProperties = createPublisherProperties()
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 
-        coEvery { ably.disconnect(trackable.id, any()) } returns Result.success(Unit)
+        ably.mockDisconnect(trackable.id)
 
         // when
         worker.doWork(
@@ -389,7 +386,7 @@ class ConnectionReadyWorkerTest {
         initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
         initialProperties.duplicateTrackableGuard.startAddingTrackable(trackable)
 
-        coEvery { ably.disconnect(trackable.id, any()) } returns Result.success(Unit)
+        ably.mockDisconnect(trackable.id)
 
         // when
         val updatedProperties = worker.doWork(

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorkerTest.kt
@@ -1,12 +1,17 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
+import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.PublisherInteractor
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockDisconnect
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -16,9 +21,10 @@ import org.junit.Test
 class RemoveTrackableWorkerTest {
     private val trackable = Trackable("testtrackable")
     private val ably: Ably = mockk()
+    private val publisherInteractor: PublisherInteractor = mockk()
     private val callbackFunction: ResultCallbackFunction<Boolean> = mockk(relaxed = true)
 
-    private val worker = RemoveTrackableWorker(trackable, ably, callbackFunction)
+    private val worker = RemoveTrackableWorker(trackable, ably, publisherInteractor, callbackFunction)
 
     private val asyncWorks = mutableListOf<suspend () -> Unit>()
     private val postedWorks = mutableListOf<WorkerSpecification>()
@@ -73,6 +79,8 @@ class RemoveTrackableWorkerTest {
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)
             ably.mockDisconnect(trackable.id)
+            every { publisherInteractor.setFinalTrackableState(any(), trackable.id, any()) } just runs
+            every { publisherInteractor.updateTrackableStateFlows(any()) } just runs
 
             // when
             worker.doWork(
@@ -87,5 +95,53 @@ class RemoveTrackableWorkerTest {
             assertThat(postedWorks.size).isEqualTo(1)
             assertThat(postedWorks[0])
                 .isInstanceOf(WorkerSpecification.DisconnectSuccess::class.java)
+        }
+
+    @Test
+    fun `when removing trackable that is present should immediately call the callback with a success`() =
+        runTest {
+            // given
+            val initialProperties = createPublisherProperties()
+            initialProperties.trackables.add(trackable)
+            ably.mockDisconnect(trackable.id)
+            every { publisherInteractor.setFinalTrackableState(any(), trackable.id, any()) } just runs
+            every { publisherInteractor.updateTrackableStateFlows(any()) } just runs
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+            asyncWorks.executeAll()
+
+            // then
+            verify {
+                callbackFunction(match { it.getOrNull() == true })
+            }
+        }
+
+    @Test
+    fun `when removing trackable that is present should immediately change trackable state to offline`() =
+        runTest {
+            // given
+            val initialProperties = createPublisherProperties()
+            initialProperties.trackables.add(trackable)
+            ably.mockDisconnect(trackable.id)
+            every { publisherInteractor.setFinalTrackableState(any(), trackable.id, any()) } just runs
+            every { publisherInteractor.updateTrackableStateFlows(any()) } just runs
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            verify(exactly = 1) {
+                publisherInteractor.setFinalTrackableState(any(), trackable.id, match { it is TrackableState.Offline })
+                publisherInteractor.updateTrackableStateFlows(any())
+            }
         }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/DefaultSubscriberTest.kt
@@ -3,7 +3,6 @@ package com.ably.tracking.subscriber
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.test.common.mockCreateConnectionSuccess
-import com.ably.tracking.test.common.mockDisconnectSuccess
 import com.ably.tracking.test.common.mockGetCurrentPresenceSuccess
 import com.ably.tracking.test.common.mockSubscribeToPresenceError
 import io.mockk.coVerify
@@ -21,7 +20,6 @@ class DefaultSubscriberTest {
     fun `should return an error when starting the subscriber with subscribing to presence error`() {
         // given
         ably.mockCreateConnectionSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
         ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 
@@ -37,7 +35,6 @@ class DefaultSubscriberTest {
     fun `should disconnect from the channel when starting the subscriber with subscribing to presence error`() {
         // given
         ably.mockCreateConnectionSuccess(trackableId)
-        ably.mockDisconnectSuccess(trackableId)
         ably.mockGetCurrentPresenceSuccess(trackableId)
         ably.mockSubscribeToPresenceError(trackableId)
 

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DisconnectWorkerTest.kt
@@ -4,7 +4,7 @@ import com.ably.tracking.Accuracy
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.Ably
 import com.ably.tracking.subscriber.SubscriberProperties
-import com.ably.tracking.test.common.mockDisconnectSuccess
+import com.ably.tracking.test.common.mockDisconnect
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,7 +27,7 @@ internal class DisconnectWorkerTest {
     fun `should call ably disconnect and notify callback`() = runTest {
         // given
         val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
-        ably.mockDisconnectSuccess(trackableId)
+        ably.mockDisconnect(trackableId)
 
         // when
         val updatedProperties = disconnectWorker.doWork(initialProperties, asyncWorks.appendWork()) {}

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -3,11 +3,12 @@ package com.ably.tracking.test.common
 import com.ably.tracking.ConnectionException
 import com.ably.tracking.ErrorInformation
 import com.ably.tracking.common.Ably
-import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.PresenceMessage
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.delay
 
@@ -96,24 +97,8 @@ fun Ably.mockGetCurrentPresenceError(trackableId: String) {
     coEvery { getCurrentPresence(trackableId) } returns Result.failure(anyConnectionException())
 }
 
-fun Ably.mockDisconnect(trackableId: String, result: Result<Unit>) {
-    val callbackSlot = slot<(Result<Unit>) -> Unit>()
-    every {
-        disconnect(trackableId, any(), capture(callbackSlot))
-    } answers {
-        callbackSlot.captured(result)
-    }
-    coEvery { disconnect(trackableId, any()) } returns result
-}
-
-fun Ably.mockDisconnectSuccess(trackableId: String) {
-    mockDisconnect(trackableId, Result.success(Unit))
-}
-
-fun Ably.mockSuspendingDisconnectSuccessAndCapturePresenceData(trackableId: String): CapturingSlot<PresenceData> {
-    val presenceDataSlot = slot<PresenceData>()
-    coEvery { disconnect(trackableId, capture(presenceDataSlot)) } returns Result.success(Unit)
-    return presenceDataSlot
+fun Ably.mockDisconnect(trackableId: String) {
+    coEvery { disconnect(trackableId, any()) } just runs
 }
 
 fun Ably.mockSendEnhancedLocationSuccess(trackableId: String) {


### PR DESCRIPTION
Changed the `ably.disconnect()` method:
- it takes maximum 30 seconds
- if the `presence.leave()` fails for a retriable reason it is being retried in 15 seconds
- if the `presence.leave()` fails for a non-retriable reason it is not retried
- after the `presence.leave()` the channel is removed

Thanks to this the `disconnect()` method shouldn't fail, therefore, the whole `Publisher.remove()` operation shouldn't have a reason to fail as well. Additionally, the `remove()` now succeeds immediately and switches trackable state to `Offline` and triggers the `disconnect()` operation afterwards.

**Note:**
This fixes the `faultDuringTracking[TcpConnectionRefused]` and `faultDuringTracking[TcpConnectionUnresponsive]` mentioned in the https://github.com/ably/ably-asset-tracking-android/issues/905 issue. However, the `faultBeforeAddingTrackable` test still fails for those faults. Because of that, I'm not able to enable those two faults in `NetworkConnectivityTests`.