### PR TITLE
Change publisher and subscriber stop operation to always succeed

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -217,8 +217,6 @@ interface Ably {
      * Cleanups and closes all the connected channels and their presence. In the end closes Ably connection.
      *
      * @param presenceData The data that will be send via the presence channels.
-     *
-     * @throws ConnectionException if something goes wrong.
      */
     suspend fun close(presenceData: PresenceData)
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -116,8 +116,6 @@ interface Publisher {
     /**
      * Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
-     *
-     * @throws ConnectionException If something goes wrong during connection closing
      */
     suspend fun stop()
 
@@ -126,8 +124,6 @@ interface Publisher {
      * Please note that calling this method will remove the notification provided by [Builder.backgroundTrackingNotificationProvider].
      *
      * @param timeoutInMilliseconds This parameter will be ignored.
-     *
-     * @throws ConnectionException If something goes wrong during connection closing
      */
     @JvmSynthetic
     @Deprecated(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/StopWorker.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
-import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.common.workerqueue.CallbackWorker
@@ -25,17 +24,13 @@ internal class StopWorker(
         publisherInteractor
         // We're using [runBlocking] on purpose as we want to block the whole publisher when it's stopping.
         runBlocking {
-            try {
-                if (properties.isTracking) {
-                    publisherInteractor.stopLocationUpdates(properties)
-                }
-                publisherInteractor.closeMapbox()
-                ably.close(properties.presenceData)
-                properties.dispose()
-                callbackFunction(Result.success(Unit))
-            } catch (exception: ConnectionException) {
-                callbackFunction(Result.failure(exception))
+            if (properties.isTracking) {
+                publisherInteractor.stopLocationUpdates(properties)
             }
+            publisherInteractor.closeMapbox()
+            ably.close(properties.presenceData)
+            properties.dispose()
+            callbackFunction(Result.success(Unit))
         }
         // We should mark the publisher as stopped no matter if the whole stopping process completed successfully.
         properties.state = PublisherState.STOPPED

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/StopWorkerTest.kt
@@ -6,7 +6,6 @@ import com.ably.tracking.publisher.PublisherInteractor
 import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.PublisherStoppedException
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
-import com.ably.tracking.test.common.mockCloseFailure
 import com.google.common.truth.Truth.assertThat
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
@@ -142,51 +141,9 @@ class StopWorkerTest {
     }
 
     @Test
-    fun `should not dispose the publisher properties if closing Ably failed`() {
-        // given
-        val initialProperties = createPublisherProperties()
-        ably.mockCloseFailure()
-
-        // when
-        worker.doWork(
-            initialProperties,
-            asyncWorks.appendWork(),
-            postedWorks.appendSpecification()
-        )
-
-        // then
-        assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
-
-        assertThat(initialProperties.isDisposed)
-            .isFalse()
-    }
-
-    @Test
     fun `should mark that the publisher is stopped if closing Ably was successful`() {
         // given
         val initialProperties = createPublisherProperties()
-
-        // when
-        val updatedProperties = worker.doWork(
-            initialProperties,
-            asyncWorks.appendWork(),
-            postedWorks.appendSpecification()
-        )
-
-        // then
-        assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
-
-        assertThat(updatedProperties.state)
-            .isEqualTo(PublisherState.STOPPED)
-    }
-
-    @Test
-    fun `should mark that the publisher is stopped if closing Ably failed`() {
-        // given
-        val initialProperties = createPublisherProperties()
-        ably.mockCloseFailure()
 
         // when
         val updatedProperties = worker.doWork(
@@ -221,28 +178,6 @@ class StopWorkerTest {
         assertThat(postedWorks).isEmpty()
 
         assertThat(resultSlot.captured.isSuccess)
-            .isTrue()
-    }
-
-    @Test
-    fun `should call the callback function with a failure if closing Ably failed`() {
-        // given
-        val initialProperties = createPublisherProperties()
-        val resultSlot = captureCallbackFunctionResult()
-        ably.mockCloseFailure()
-
-        // when
-        worker.doWork(
-            initialProperties,
-            asyncWorks.appendWork(),
-            postedWorks.appendSpecification()
-        )
-
-        // then
-        assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
-
-        assertThat(resultSlot.captured.isFailure)
             .isTrue()
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -87,8 +87,6 @@ interface Subscriber {
     /**
      * Stops this subscriber from listening to published locations. Once a subscriber has been stopped, it cannot be
      * restarted.
-     *
-     * @throws ConnectionException If something goes wrong during connection closing
      */
     @JvmSynthetic
     suspend fun stop()

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorker.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.subscriber.workerqueue.workers
 
-import com.ably.tracking.ConnectionException
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.common.workerqueue.CallbackWorker
@@ -21,14 +20,10 @@ internal class StopConnectionWorker(
     ): SubscriberProperties {
         // We're using [runBlocking] on purpose as we want to block the whole subscriber when it's stopping.
         runBlocking {
-            try {
-                ably.close(properties.presenceData)
-                properties.isStopped = true
-                subscriberInteractor.notifyAssetIsOffline()
-                callbackFunction(Result.success(Unit))
-            } catch (exception: ConnectionException) {
-                callbackFunction(Result.failure(exception))
-            }
+            ably.close(properties.presenceData)
+            properties.isStopped = true
+            subscriberInteractor.notifyAssetIsOffline()
+            callbackFunction(Result.success(Unit))
         }
         return properties
     }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StopConnectionWorkerTest.kt
@@ -8,7 +8,6 @@ import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberStoppedException
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
-import com.ably.tracking.test.common.mockCloseFailure
 import com.ably.tracking.test.common.mockCloseSuccess
 import io.mockk.every
 import io.mockk.just
@@ -47,19 +46,6 @@ internal class StopConnectionWorkerTest {
         Assert.assertTrue(updatedProperties.isStopped)
         verify { callbackFunction.invoke(match { it.isSuccess }) }
         verify { subscriberInteractor.notifyAssetIsOffline() }
-    }
-
-    @Test
-    fun `should call ably close and notify callback with failure when it fails`() = runTest {
-        // given
-        val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
-        ably.mockCloseFailure()
-
-        // when
-        stopConnectionWorker.doWork(initialProperties, asyncWorks.appendWork(), postedWorks.appendSpecification())
-
-        // then
-        verify { callbackFunction.invoke(match { it.isFailure }) }
     }
 
     @Test

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -153,10 +153,6 @@ fun Ably.mockSendRawLocationSuccess(trackableId: String) {
     }
 }
 
-fun Ably.mockCloseFailure(exception: ConnectionException = anyConnectionException()) {
-    coEvery { close(any()) } throws exception
-}
-
 fun Ably.mockCloseSuccess() {
     coEvery { close(any()) } returns Unit
 }


### PR DESCRIPTION
Previously, publisher and subscriber `stop()` method could throw an `ConnectionException`. By a lucky accident it was changed when we introduced the `Ably.stopConnection()` method (a few moths ago) which caught the exception and wrapped it within a `Result`. Now we made it clear that the `stop()` method won't throw by removing the `@throws` information from its code docs.

Additionally, the `stopConnection()` method will now wait for the connection to close only for 30 seconds. After that time passes it will log that a timeout happened and carry on.