### PR TITLE
Reenable disconnect failed resume faults

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -499,11 +499,6 @@ class DisconnectWithFailedResume(apiKey: String) : ApplicationLayerFault(apiKey)
         }
     }
 
-    /*
-        Currently failing due to ably-java#474 presence bug
-     */
-    override val skipTest = false
-
     /**
      * State of the fault, used to control whether we're intercepting
      * the connection or looking to inject a WebSocket CLOSE at an appropriate time

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -474,12 +474,6 @@ class EnterUnresponsive(apiKey: String) : UnresponsiveAfterAction(
         }
     }
 
-    /*
-        This test currently fails because the ably-java hangs the client
-        waiting for a presence response if there's there's a reconnection
-        before successful completion of enter()
-    */
-    override val skipTest = true
 }
 
 /**

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -473,7 +473,6 @@ class EnterUnresponsive(apiKey: String) : UnresponsiveAfterAction(
             override val name = "EnterUnresponsive"
         }
     }
-
 }
 
 /**

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -446,7 +446,7 @@ class DisconnectWithFailedResume(apiKey: String) : ApplicationLayerFault(apiKey)
     /*
         Currently failing due to ably-java#474 presence bug
      */
-    override val skipTest = true
+    override val skipTest = false
 
     /**
      * State of the fault, used to control whether we're intercepting

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.22'
+    ext.ably_core_version = '1.2.23'
 
     repositories {
         google()


### PR DESCRIPTION
This PR does three things 
* Increases ably-android version to 1.2.23
* Reenables skipped tests for `DisconnectFailedWithResume`
* Reenables skipped tests for `EnterUnresponsive`
Closes https://github.com/ably/ably-asset-tracking-android/issues/896