### PR TITLE
Increase back-off when querying history in test

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/NetworkConnectivityTests.kt
@@ -755,7 +755,7 @@ class PublisherMonitor(
                             }
                         }
 
-                        delay(50)
+                        delay(200)
                     }
                 }
             }


### PR DESCRIPTION
It's causing a large amount of log spam, so making it a little less aggressive.