### PR TITLE
Release/1.6.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The current, non-pre-release SDKs for production use are at version [1.5.1](#151
 - `Publisher.remove\(\)` fails during several connectivity faults [\#905](https://github.com/ably/ably-asset-tracking-android/issues/905)
 - Adding a trackable stalls forever if presence.enter\(\) is interrupted by a disconnection [\#896](https://github.com/ably/ably-asset-tracking-android/issues/896)
 - Publisher crashes when location data has NaN value [\#861](https://github.com/ably/ably-asset-tracking-android/issues/861)
-- Subscriber, upon losing connectivity, continues to show the Publisher as online [\#835](https://github.com/ably/ably-asset-tracking-android/issues/835)
 - Subscriber, upon losing connectivity, continues to show the Publisher as online [\#833](https://github.com/ably/ably-asset-tracking-android/issues/833)
 - Unexpected exceptions fail the worker queue and silently break the SDK [\#830](https://github.com/ably/ably-asset-tracking-android/issues/830)
 - Fix the logic responsible for deciding if an enhanced location update is predicted [\#828](https://github.com/ably/ably-asset-tracking-android/issues/828)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Change log
 
+The current, non-pre-release SDKs for production use are at version [1.5.1](#151).
+
+## [1.6.0, Beta 1](https://github.com/ably/ably-asset-tracking-android/tree/v1.6.0-beta.1)
+
+[Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.5.1...v1.6.0-beta.1)
+
+**Implemented enhancements:**
+
+- Upgrade to Mapbox Nav SDK 2.10.0 [\#882](https://github.com/ably/ably-asset-tracking-android/issues/882)
+- Consider supporting static token authentication [\#730](https://github.com/ably/ably-asset-tracking-android/issues/730)
+
+**Fixed bugs:**
+
+- Retry behaviour improvements for Ably API calls [\#927](https://github.com/ably/ably-asset-tracking-android/issues/927)
+- `Publisher.remove\(\)` fails during several connectivity faults [\#905](https://github.com/ably/ably-asset-tracking-android/issues/905)
+- Adding a trackable stalls forever if presence.enter\(\) is interrupted by a disconnection [\#896](https://github.com/ably/ably-asset-tracking-android/issues/896)
+- Publisher crashes when location data has NaN value [\#861](https://github.com/ably/ably-asset-tracking-android/issues/861)
+- Subscriber, upon losing connectivity, continues to show the Publisher as online [\#835](https://github.com/ably/ably-asset-tracking-android/issues/835)
+- Subscriber, upon losing connectivity, continues to show the Publisher as online [\#833](https://github.com/ably/ably-asset-tracking-android/issues/833)
+- Unexpected exceptions fail the worker queue and silently break the SDK [\#830](https://github.com/ably/ably-asset-tracking-android/issues/830)
+- Fix the logic responsible for deciding if an enhanced location update is predicted [\#828](https://github.com/ably/ably-asset-tracking-android/issues/828)
+- Java users cannot build a publisher due to type issue [\#826](https://github.com/ably/ably-asset-tracking-android/issues/826)
+- NPE from ably-java SDK [\#809](https://github.com/ably/ably-asset-tracking-android/issues/809)
+
+**Closed issues:**
+
+- Reduce publisher location check polling interval [\#946](https://github.com/ably/ably-asset-tracking-android/issues/946)
+- Flakey test: com.ably.tracking.publisher.NetworkConnectivityTests \> faultDuringTracking\[NullTransportFault\] [\#943](https://github.com/ably/ably-asset-tracking-android/issues/943)
+- Make `NetworkConnectivityTests` verify expected side-effects of operations publisher SDK claims was successful [\#925](https://github.com/ably/ably-asset-tracking-android/issues/925)
+- Reduce complexity of state transition assertions in `NetworkConnectivityTests` [\#901](https://github.com/ably/ably-asset-tracking-android/issues/901)
+- `connect - when channel fetched is in DETACHED state and attach fails` causes emulator to hang [\#900](https://github.com/ably/ably-asset-tracking-android/issues/900)
+- `createAndStartPublisherAndSubscriberAndWaitUntilDataEnds` IndexOutOfBoundsException  [\#899](https://github.com/ably/ably-asset-tracking-android/issues/899)
+- Flakey test: `when an unexpected exception is thrown by worker's async work, the queue should call worker's unexpected async exception method` [\#888](https://github.com/ably/ably-asset-tracking-android/issues/888)
+- Investigate documented `ConnectionException` thrown by `Publisher.Builder.start` and how users are meant to handle it [\#876](https://github.com/ably/ably-asset-tracking-android/issues/876)
+- Investigate `ConnectionException` thrown by `Publisher.stop` and whether we can remove it [\#873](https://github.com/ably/ably-asset-tracking-android/issues/873)
+- Try simulating networking problems during core use cases [\#865](https://github.com/ably/ably-asset-tracking-android/issues/865)
+- Sending presence leave event times out whilst still connected [\#862](https://github.com/ably/ably-asset-tracking-android/issues/862)
+- `shouldNotEmitPublisherPresenceFalseIfPublisherIsPresentFromTheStart` \(`PublisherAndSubscriberTests`\) failing with "first publisherPresence value should be true" [\#845](https://github.com/ably/ably-asset-tracking-android/issues/845)
+- `staticTokenAuthenticationShouldCreateWorkingConnectionBetweenPublisherAndSubscriber` \(`AuthenticationTests`\) failing with "Expectation 'subscriber received a location update' unfulfilled." [\#844](https://github.com/ably/ably-asset-tracking-android/issues/844)
+- Replace deprecated `package` attribute in manifest file [\#837](https://github.com/ably/ably-asset-tracking-android/issues/837)
+- Test issue for sync [\#834](https://github.com/ably/ably-asset-tracking-android/issues/834)
+- Enable logging in the example apps by default [\#818](https://github.com/ably/ably-asset-tracking-android/issues/818)
+- Update workflows to stop using the `set-output` command [\#817](https://github.com/ably/ably-asset-tracking-android/issues/817)
+- Update workflows to stop using Node.js 12 actions [\#816](https://github.com/ably/ably-asset-tracking-android/issues/816)
+- Refactor Publisher EventQueue to match Subscriber [\#781](https://github.com/ably/ably-asset-tracking-android/issues/781)
+- Consider if we should allow to create multiple publisher instances [\#464](https://github.com/ably/ably-asset-tracking-android/issues/464)
+- Flakey Test: `createAndStartPublisherAndSubscriberAndWaitUntilDataEnds` \(`PublisherAndSubscriberTests`\) [\#259](https://github.com/ably/ably-asset-tracking-android/issues/259)
+
+**Merged pull requests:**
+
+- Fix `publish.stop\(\)` hang when no trackables added [\#952](https://github.com/ably/ably-asset-tracking-android/pull/952) ([jaley](https://github.com/jaley))
+- Increase back-off when querying history in test [\#949](https://github.com/ably/ably-asset-tracking-android/pull/949) ([AndyTWF](https://github.com/AndyTWF))
+- Reenable disconnect failed resume faults [\#947](https://github.com/ably/ably-asset-tracking-android/pull/947) ([ikbalkaya](https://github.com/ikbalkaya))
+- Change publisher and subscriber stop operation to always succeed [\#945](https://github.com/ably/ably-asset-tracking-android/pull/945) ([KacperKluka](https://github.com/KacperKluka))
+- Fix flakey publisher test [\#944](https://github.com/ably/ably-asset-tracking-android/pull/944) ([AndyTWF](https://github.com/AndyTWF))
+- Change publisher's remove operation to always succeed [\#942](https://github.com/ably/ably-asset-tracking-android/pull/942) ([KacperKluka](https://github.com/KacperKluka))
+- Reset fault state for each test function [\#941](https://github.com/ably/ably-asset-tracking-android/pull/941) ([jaley](https://github.com/jaley))
+- Upgrade core Ably SDK dependency to version `1.2.23` [\#940](https://github.com/ably/ably-asset-tracking-android/pull/940) ([QuintinWillison](https://github.com/QuintinWillison))
+- Switch to CIO ktor engine [\#937](https://github.com/ably/ably-asset-tracking-android/pull/937) ([jaley](https://github.com/jaley))
+- Improve testing in respect of JVM version underlying Gradle [\#936](https://github.com/ably/ably-asset-tracking-android/pull/936) ([QuintinWillison](https://github.com/QuintinWillison))
+- setting log level for test location source AblyRealtime instance [\#935](https://github.com/ably/ably-asset-tracking-android/pull/935) ([davyskiba](https://github.com/davyskiba))
+- Improve `NetworkingConnectivityTest` assertions [\#933](https://github.com/ably/ably-asset-tracking-android/pull/933) ([jaley](https://github.com/jaley))
+- Fix swapped error codes when creating the malformed message exception [\#930](https://github.com/ably/ably-asset-tracking-android/pull/930) ([KacperKluka](https://github.com/KacperKluka))
+- Add methods for detecting retriable and fatal Ably exceptions [\#929](https://github.com/ably/ably-asset-tracking-android/pull/929) ([KacperKluka](https://github.com/KacperKluka))
+- 901 simplify transition assertions [\#916](https://github.com/ably/ably-asset-tracking-android/pull/916) ([davyskiba](https://github.com/davyskiba))
+- Upgrade build tools to make Layer 7 proxy branch work [\#915](https://github.com/ably/ably-asset-tracking-android/pull/915) ([QuintinWillison](https://github.com/QuintinWillison))
+- Write further unit tests for `DefaultAbly` [\#914](https://github.com/ably/ably-asset-tracking-android/pull/914) ([lawrence-forooghian](https://github.com/lawrence-forooghian))
+- wait for publisher emissions before performing test assertion [\#911](https://github.com/ably/ably-asset-tracking-android/pull/911) ([AndyTWF](https://github.com/AndyTWF))
+- Update workflow status badges [\#904](https://github.com/ably/ably-asset-tracking-android/pull/904) ([QuintinWillison](https://github.com/QuintinWillison))
+- Add mapbox testing information to contributing guide [\#895](https://github.com/ably/ably-asset-tracking-android/pull/895) ([AndyTWF](https://github.com/AndyTWF))
+- Wrap `ably-java`’s `ChannelStateChange` in our own type [\#894](https://github.com/ably/ably-asset-tracking-android/pull/894) ([lawrence-forooghian](https://github.com/lawrence-forooghian))
+- Publisher and Subscriber builders start method throws exception descr… [\#893](https://github.com/ably/ably-asset-tracking-android/pull/893) ([davyskiba](https://github.com/davyskiba))
+- Use different locations in test data file [\#892](https://github.com/ably/ably-asset-tracking-android/pull/892) ([AndyTWF](https://github.com/AndyTWF))
+- Add timeout on verification in WorkerQueueTest [\#890](https://github.com/ably/ably-asset-tracking-android/pull/890) ([AndyTWF](https://github.com/AndyTWF))
+- Document Java version requirements for running `./gradlew` [\#889](https://github.com/ably/ably-asset-tracking-android/pull/889) ([lawrence-forooghian](https://github.com/lawrence-forooghian))
+- coroutines and coroutines-test dependency updated to 1.6.4 [\#887](https://github.com/ably/ably-asset-tracking-android/pull/887) ([davyskiba](https://github.com/davyskiba))
+- Layer 7 Proxy for Network Connectivity Tests [\#886](https://github.com/ably/ably-asset-tracking-android/pull/886) ([jaley](https://github.com/jaley))
+- Subscriber gets immediate publisher online state flakey test [\#884](https://github.com/ably/ably-asset-tracking-android/pull/884) ([QuintinWillison](https://github.com/QuintinWillison))
+- Upgrade Mapbox Nav SDK to version 2.10.0 [\#881](https://github.com/ably/ably-asset-tracking-android/pull/881) ([KacperKluka](https://github.com/KacperKluka))
+- Upgrade Ably core SDK dependency to improve testing capability [\#880](https://github.com/ably/ably-asset-tracking-android/pull/880) ([QuintinWillison](https://github.com/QuintinWillison))
+- Write black-box tests for `DefaultAbly.connect` [\#878](https://github.com/ably/ably-asset-tracking-android/pull/878) ([lawrence-forooghian](https://github.com/lawrence-forooghian))
+- Add dedicated unexpected error handling to certain workers [\#877](https://github.com/ably/ably-asset-tracking-android/pull/877) ([KacperKluka](https://github.com/KacperKluka))
+- Static token auth flakey test [\#875](https://github.com/ably/ably-asset-tracking-android/pull/875) ([QuintinWillison](https://github.com/QuintinWillison))
+- Remove `TimeoutCancellationException` from `Publisher.stop` [\#874](https://github.com/ably/ably-asset-tracking-android/pull/874) ([lawrence-forooghian](https://github.com/lawrence-forooghian))
+- Handle unexpected exceptions in the worker queue [\#872](https://github.com/ably/ably-asset-tracking-android/pull/872) ([KacperKluka](https://github.com/KacperKluka))
+- Networking connectivity integration test using local proxy [\#866](https://github.com/ably/ably-asset-tracking-android/pull/866) ([jaley](https://github.com/jaley))
+- location: sanitize locations from mapbox [\#864](https://github.com/ably/ably-asset-tracking-android/pull/864) ([mschristensen](https://github.com/mschristensen))
+
 ## [1.5.1](https://github.com/ably/ably-asset-tracking-android/tree/v1.5.1)
 
 [Full Changelog](https://github.com/ably/ably-asset-tracking-android/compare/v1.5.0...v1.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The current, non-pre-release SDKs for production use are at version [1.5.1](#151
 **Fixed bugs:**
 
 - Retry behaviour improvements for Ably API calls [\#927](https://github.com/ably/ably-asset-tracking-android/issues/927)
-- `Publisher.remove\(\)` fails during several connectivity faults [\#905](https://github.com/ably/ably-asset-tracking-android/issues/905)
+- `Publisher.remove()` fails during several connectivity faults [\#905](https://github.com/ably/ably-asset-tracking-android/issues/905)
 - Adding a trackable stalls forever if presence.enter\(\) is interrupted by a disconnection [\#896](https://github.com/ably/ably-asset-tracking-android/issues/896)
 - Publisher crashes when location data has NaN value [\#861](https://github.com/ably/ably-asset-tracking-android/issues/861)
 - Subscriber, upon losing connectivity, continues to show the Publisher as online [\#833](https://github.com/ably/ably-asset-tracking-android/issues/833)
@@ -49,7 +49,7 @@ The current, non-pre-release SDKs for production use are at version [1.5.1](#151
 
 **Merged pull requests:**
 
-- Fix `publish.stop\(\)` hang when no trackables added [\#952](https://github.com/ably/ably-asset-tracking-android/pull/952) ([jaley](https://github.com/jaley))
+- Fix `publish.stop()` hang when no trackables added [\#952](https://github.com/ably/ably-asset-tracking-android/pull/952) ([jaley](https://github.com/jaley))
 - Increase back-off when querying history in test [\#949](https://github.com/ably/ably-asset-tracking-android/pull/949) ([AndyTWF](https://github.com/AndyTWF))
 - Reenable disconnect failed resume faults [\#947](https://github.com/ably/ably-asset-tracking-android/pull/947) ([ikbalkaya](https://github.com/ikbalkaya))
 - Change publisher and subscriber stop operation to always succeed [\#945](https://github.com/ably/ably-asset-tracking-android/pull/945) ([KacperKluka](https://github.com/KacperKluka))

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
 
     // version MUST conform to the Semantic Versioning Specification (https://semver.org/) version 2.0.0
     // on incrementing this value, ensure to also increment versionCode in android defaultConfig (also in this file)
-    version = '1.5.1'
+    version = '1.6.0-beta.1'
 
     // Values used to publish the SDK to maven repositories.
     ext {
@@ -143,7 +143,7 @@ subprojects {
                 // projects in this repository. Therefore, this same version number is used for SDK and
                 // example app projects alike.
                 // - versionCode MUST be incremented by 1 for each release from the main branch
-                versionCode 35
+                versionCode 36
                 versionName version
 
                 testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
We need to build and upload the Publishing Example App to Firebase App Distribution.

Without significantly changing or decoupling source code or processes within this repository, the logical, linear path to that is to bump the version (SDK and example app versions are tied together).

This pull request is build atop https://github.com/ably/ably-asset-tracking-android/pull/955 which means that once this PR has landed to `main` and we have pushed the `v1.6.0-beta.1` tag then we can use the manually triggered workflow to publish the app for testers to use via Firebase.