### PR TITLE
Fix race conditions in presence retry

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -158,7 +158,7 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
     }
 
     override val type = FaultType.NonfatalWhenResolved(
-        offlineWithinMillis = 30_000,
+        offlineWithinMillis = 60_000,
         onlineWithinMillis = 60_000
     )
 

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -165,8 +165,7 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
     /**
      * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
      * We will re-enable this test when the following have been addressed:
-     * - https://github.com/ably/ably-asset-tracking-android/issues/859
-     * - https://github.com/ably/ably-asset-tracking-android/issues/871
+     * - https://github.com/ably/ably-asset-tracking-android/issues/948
      */
     override val skipTest = true
 
@@ -200,8 +199,7 @@ class TcpConnectionUnresponsive(apiKey: String) : TransportLayerFault(apiKey) {
     /**
      * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
      * We will re-enable this test when the following have been addressed:
-     * - https://github.com/ably/ably-asset-tracking-android/issues/859
-     * - https://github.com/ably/ably-asset-tracking-android/issues/871
+     * - https://github.com/ably/ably-asset-tracking-android/issues/948
      */
     override val skipTest = true
 

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -162,13 +162,6 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
         onlineWithinMillis = 60_000
     )
 
-    /**
-     * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
-     * We will re-enable this test when the following have been addressed:
-     * - https://github.com/ably/ably-asset-tracking-android/issues/948
-     */
-    override val skipTest = true
-
     override fun enable() {
         tcpProxy.stop()
     }

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -196,13 +196,6 @@ class TcpConnectionUnresponsive(apiKey: String) : TransportLayerFault(apiKey) {
         onlineWithinMillis = 60_000
     )
 
-    /**
-     * This fault type is temporarily disabled at runtime. It can be re-enabled by removing this override.
-     * We will re-enable this test when the following have been addressed:
-     * - https://github.com/ably/ably-asset-tracking-android/issues/948
-     */
-    override val skipTest = true
-
     override fun enable() {
         tcpProxy.isForwarding = false
     }

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Faults.kt
@@ -158,7 +158,7 @@ class TcpConnectionRefused(apiKey: String) : TransportLayerFault(apiKey) {
     }
 
     override val type = FaultType.NonfatalWhenResolved(
-        offlineWithinMillis = 60_000,
+        offlineWithinMillis = 30_000,
         onlineWithinMillis = 60_000
     )
 

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -904,9 +904,11 @@ constructor(
      *
      * TODO: At the moment, due to how listeners are wrapped in AAT we're not able to do this the elegant way
      * without rewriting a lot of code. Not ignoring subsequent updates breaks continuations. To get around this for
-     * now - ignore any future event updates.
+     * now - ignore any future event updates. We should change this in the future. There shouldn't be a risk of overflows
+     * as this is at a channel level - and the channels are retired after a trackable is done with.
      */
     override suspend fun waitForChannelToAttach(trackableId: String): Result<Unit> {
+
         return suspendCoroutine { continuation ->
             var resumed = false
             subscribeForChannelStateChange(trackableId) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -909,7 +909,7 @@ constructor(
      */
     override suspend fun waitForChannelToAttach(trackableId: String): Result<Unit> {
 
-        return suspendCoroutine { continuation ->
+        return suspendCancellableCoroutine { continuation ->
             var resumed = false
             subscribeForChannelStateChange(trackableId) {
                 if (resumed) {

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -922,7 +922,9 @@ constructor(
                 }
                 if (it.state == com.ably.tracking.common.ConnectionState.FAILED) {
                     resumed = true
-                    continuation.resume(Result.failure(Exception("Channel failed")))
+                    val errorMessage = "Channel failed whilst waiting for attach: ${it.errorInformation?.message}"
+                    logHandler?.w(errorMessage)
+                    continuation.resume(Result.failure(ConnectionException(ErrorInformation(errorMessage))))
                 }
             }
         }

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -66,6 +66,12 @@ interface Ably {
     fun subscribeForChannelStateChange(trackableId: String, listener: (ConnectionStateChange) -> Unit)
 
     /**
+     * Given a trackable id, wait for the channel to enter the attached state before returning
+     * control to the caller.
+     */
+    suspend fun waitForChannelToAttach(trackableId: String): Result<Unit>
+
+    /**
      * Adds a listener for the presence messages that are received from the channel's presence.
      * After adding a listener it will emit [PresenceMessage] for each client that's currently in the presence.
      * Should be called only when there's an existing channel for the [trackableId].
@@ -888,6 +894,34 @@ constructor(
                 }
             } else {
                 throw exception
+            }
+        }
+    }
+
+    /**
+     * For a given trackable, listen for channel state until it enters a state of ONLINE (which in
+     * Ably channel-terms means ATTACHED).
+     *
+     * TODO: At the moment, due to how listeners are wrapped in AAT we're not able to do this the elegant way
+     * without rewriting a lot of code. Not ignoring subsequent updates breaks continuations. To get around this for
+     * now - ignore any future event updates.
+     */
+    override suspend fun waitForChannelToAttach(trackableId: String): Result<Unit> {
+        return suspendCoroutine { continuation ->
+            var resumed = false
+            subscribeForChannelStateChange(trackableId) {
+                if (resumed) {
+                    return@subscribeForChannelStateChange
+                }
+
+                if (it.state == com.ably.tracking.common.ConnectionState.ONLINE) {
+                    resumed = true
+                    continuation.resume(Result.success(Unit))
+                }
+                if (it.state == com.ably.tracking.common.ConnectionState.FAILED) {
+                    resumed = true
+                    continuation.resume(Result.failure(Exception("Channel failed")))
+                }
             }
         }
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -24,11 +24,6 @@ internal typealias AddTrackableCallbackFunction = ResultCallbackFunction<AddTrac
  */
 private const val WORK_DELAY_IN_MILLISECONDS = 200L
 
-/**
- * How long should we wait before queueing enter retry presence work if enter presence fails.
- */
-private const val PRESENCE_ENTER_DELAY_IN_MILLISECONDS = 15_000L
-
 internal class AddTrackableWorker(
     private val trackable: Trackable,
     private val callbackFunction: AddTrackableCallbackFunction,

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -118,14 +118,11 @@ internal class AddTrackableWorker(
                     isConnectedToAbly = true
                 )
             )
-        } else {
-            val enteredPresence = connectResult.isSuccess
-            postWork(createConnectionCreatedWorker(enteredPresence))
-            if (!enteredPresence) {
-                delay(PRESENCE_ENTER_DELAY_IN_MILLISECONDS)
-                postWork(WorkerSpecification.RetryEnterPresence(trackable))
-            }
+            return
         }
+
+        // If the connection result is successful, then we've entered presence
+        postWork(createConnectionCreatedWorker(connectResult.isSuccess))
     }
 
     private fun createConnectionCreatedWorker(enteredPresence: Boolean) =

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -11,9 +11,9 @@ import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.PublisherState
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
-import java.util.concurrent.TimeoutException
 import kotlin.coroutines.resume
 
 internal class ConnectionCreatedWorker(
@@ -70,7 +70,7 @@ internal class ConnectionCreatedWorker(
                         isSubscribedToPresence = false
                     )
                 )
-            } catch (exception: TimeoutException) {
+            } catch (exception: TimeoutCancellationException) {
                 logHandler?.w("Timeout subscribing to presence for trackable ${trackable.id}")
                 postWork(
                     createConnectionReadyWorkerSpecification(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionCreatedWorker.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
 
+private const val SUBSCRIBE_TO_PRESENCE_TIMEOUT = 5000L
+
 internal class ConnectionCreatedWorker(
     private val trackable: Trackable,
     private val enteredPresence: Boolean,
@@ -84,7 +86,7 @@ internal class ConnectionCreatedWorker(
     }
 
     private suspend fun subscribeToPresenceMessages(): Result<Unit> {
-        return withTimeout(5000) {
+        return withTimeout(SUBSCRIBE_TO_PRESENCE_TIMEOUT) {
             suspendCancellableCoroutine { continuation ->
                 ably.subscribeForPresenceMessages(trackable.id, presenceUpdateListener) { result ->
                     continuation.resume(result)

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
@@ -53,6 +53,10 @@ internal class ConnectionReadyWorker(
             postWork(WorkerSpecification.RetrySubscribeToPresence(trackable, presenceUpdateListener))
         }
 
+        if (properties.trackableEnteredPresenceFlags[trackable.id] == null) {
+            postWork(WorkerSpecification.RetryEnterPresence(trackable))
+        }
+
         return properties
     }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ConnectionReadyWorker.kt
@@ -53,7 +53,7 @@ internal class ConnectionReadyWorker(
             postWork(WorkerSpecification.RetrySubscribeToPresence(trackable, presenceUpdateListener))
         }
 
-        if (properties.trackableEnteredPresenceFlags[trackable.id] == null) {
+        if (properties.trackableEnteredPresenceFlags[trackable.id] != true) {
             postWork(WorkerSpecification.RetryEnterPresence(trackable))
         }
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorker.kt
@@ -28,7 +28,10 @@ internal class RetryEnterPresenceWorker(
         doAsyncWork: (suspend () -> Unit) -> Unit,
         postWork: (WorkerSpecification) -> Unit
     ): PublisherProperties {
-        if (properties.trackables.contains(trackable)) {
+        if (
+            properties.trackables.contains(trackable) &&
+            !properties.trackableRemovalGuard.isMarkedForRemoval(trackable)
+        ) {
             doAsyncWork {
                 enterPresence(postWork, properties.presenceData)
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorker.kt
@@ -58,11 +58,18 @@ internal class RetrySubscribeToPresenceWorker(
 
     private suspend fun waitForChannelToBeConnected(trackable: Trackable): Result<Unit> {
         return suspendCoroutine { continuation ->
+            var resumed = false
             ably.subscribeForChannelStateChange(trackable.id) {
+                if (resumed) {
+                    return@subscribeForChannelStateChange
+                }
+
                 if (it.state == ConnectionState.ONLINE) {
+                    resumed = true
                     continuation.resume(Result.success(Unit))
                 }
                 if (it.state == ConnectionState.FAILED) {
+                    resumed = true
                     continuation.resume(Result.failure(Exception("Channel failed")))
                 }
             }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
@@ -14,8 +14,6 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorkerTest.kt
@@ -163,33 +163,6 @@ class AddTrackableWorkerTest {
     }
 
     @Test
-    fun `should post RetryEnterPresence work after delay when connection failed with a non-fatal error`() {
-        runTest(context = UnconfinedTestDispatcher()) {
-            // given
-            val initialProperties = createPublisherProperties()
-            initialProperties.duplicateTrackableGuard.clear(trackable)
-            ably.mockConnectFailure(trackable.id, isFatal = false)
-
-            // when
-            worker.doWork(
-                initialProperties,
-                asyncWorks.appendWork(),
-                postedWorks.appendSpecification()
-            )
-
-            // then
-            asyncWorks.launchAll(this)
-
-            assertThat(postedWorks).isNotEmpty()
-            assertThat(postedWorks).doesNotContain(WorkerSpecification.RetryEnterPresence(trackable))
-
-            advanceUntilIdle()
-
-            assertThat(postedWorks).contains(WorkerSpecification.RetryEnterPresence(trackable))
-        }
-    }
-
-    @Test
     fun `should fail to add a trackable when connection failed with fatal error`() {
         runTest {
             // given

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorkerTest.kt
@@ -86,6 +86,7 @@ class RetryEnterPresenceWorkerTest {
         runTest {
             // given
             val initialProperties = createPublisherProperties()
+            initialProperties.trackables.add(trackable)
             initialProperties.duplicateTrackableGuard.clear(trackable)
             initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetryEnterPresenceWorkerTest.kt
@@ -1,6 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
+import com.ably.tracking.ErrorInformation
 import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockEnterPresenceFailure
@@ -8,7 +11,9 @@ import com.ably.tracking.test.common.mockEnterPresenceSuccess
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -35,6 +40,7 @@ class RetryEnterPresenceWorkerTest {
             val initialProperties = createPublisherProperties()
             initialProperties.trackables.add(trackable)
             initialProperties.duplicateTrackableGuard.clear(trackable)
+            mockChannelStateChange(ConnectionState.ONLINE)
             ably.mockEnterPresenceSuccess(trackable.id)
 
             // when
@@ -106,6 +112,7 @@ class RetryEnterPresenceWorkerTest {
             val initialProperties = createPublisherProperties()
             initialProperties.duplicateTrackableGuard.clear(trackable)
             initialProperties.trackables.add(trackable)
+            mockChannelStateChange(ConnectionState.ONLINE)
             ably.mockEnterPresenceFailure(trackable.id, isFatal = false)
 
             // when
@@ -128,12 +135,13 @@ class RetryEnterPresenceWorkerTest {
     }
 
     @Test
-    fun `should post RetryEnterPresence work when connection failed with a fatal error`() {
+    fun `should post FailTrackable work when connection failed with a fatal error`() {
         runTest {
             // given
             val initialProperties = createPublisherProperties()
             initialProperties.duplicateTrackableGuard.clear(trackable)
             initialProperties.trackables.add(trackable)
+            mockChannelStateChange(ConnectionState.ONLINE)
             ably.mockEnterPresenceFailure(trackable.id, isFatal = true)
 
             // when
@@ -148,6 +156,39 @@ class RetryEnterPresenceWorkerTest {
 
             val postedWork = postedWorks[0] as WorkerSpecification.FailTrackable
             assertThat(postedWork.trackable).isEqualTo(trackable)
+        }
+    }
+
+    @Test
+    fun `should post FailTrackable work when connection when channel transitions to failed`() {
+        runTest {
+            // given
+            val initialProperties = createPublisherProperties()
+            initialProperties.duplicateTrackableGuard.clear(trackable)
+            initialProperties.trackables.add(trackable)
+            mockChannelStateChange(ConnectionState.FAILED)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.executeAll()
+
+            val postedWork = postedWorks[0] as WorkerSpecification.FailTrackable
+            assertThat(postedWork.trackable).isEqualTo(trackable)
+        }
+    }
+
+    private fun mockChannelStateChange(newState: ConnectionState) {
+        val channelStateListenerSlot = slot<(ConnectionStateChange) -> Unit>()
+        every {
+            ably.subscribeForChannelStateChange(trackable.id, capture(channelStateListenerSlot))
+        } answers {
+            channelStateListenerSlot.captured.invoke(ConnectionStateChange(newState, ErrorInformation("Information")))
         }
     }
 }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/RetrySubscribeToPresenceWorkerTest.kt
@@ -1,8 +1,9 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.ErrorInformation
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionState
-import com.ably.tracking.common.ConnectionStateChange
 import com.ably.tracking.common.PresenceMessage
 import com.ably.tracking.publisher.Trackable
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
@@ -11,9 +12,9 @@ import com.ably.tracking.test.common.mockSubscribeToPresenceSuccess
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -137,11 +138,14 @@ internal class RetrySubscribeToPresenceWorkerTest {
         }
 
     private fun mockChannelStateChange(newState: ConnectionState) {
-        val channelStateListenerSlot = slot<(ConnectionStateChange) -> Unit>()
         every {
-            ably.subscribeForChannelStateChange(trackable.id, capture(channelStateListenerSlot))
-        } answers {
-            channelStateListenerSlot.captured.invoke(ConnectionStateChange(newState, null))
+            runBlocking {
+                ably.waitForChannelToAttach(trackable.id)
+            }
+        } returns when (newState) {
+            ConnectionState.ONLINE -> Result.success(Unit)
+            ConnectionState.FAILED -> Result.failure(ConnectionException(ErrorInformation("Channel attach failed")))
+            ConnectionState.OFFLINE -> throw Exception("Not a valid result")
         }
     }
 }


### PR DESCRIPTION
This change fixes three issues.

1. A race condition on retrying presence enter.

At the moment the work to RetryEnterPresence is queued by AddTrackableWorker. RetryEnterPresenceWorker relies on the trackable being in the publishers trackables list. The trackable is added to this list by ConnectionReadyWorker, which is itself queued a few workers down the connection chan from AddTrackableWorker. The race condition is that in some conditions, especially where flakey connections are involved, the RetryEnterPresenceWorker can run before ConnectionReadyWorker, meaning that the trackable will never enter presence, and therefore never come online (RetryEnterPresenceWorker does not queue a re-attempt if the trackable isn't known).

This change fixes the issue by moving the queuing of the RetryEnterPresence work into ConnectionReadyWorker, which ensures that the trackable is in the publisher properties prior to execution.

2. Trackables entering a failed state

RetryEnterPresenceWorker transitions trackables into the failed state if a fatal error occurs whilst entering presence.
This can happen if the connection re-connects but the channel is not yet attached.

This change fixes the issue by introducing a listener on the ably channel state, which suspends the coroutine until
the channel notifies us of an online state. Thus ensuring that we don't try to enter presence until it is possible to
do so.

3. Do not retry enter presence when trackable marked for removal

Add a check that prevents RetryEnterPresenceWorker from being run if
the trackable has been marked for removal.

There is a test case for this already, but it was a false positive pass - as the trackable
had not been added to the publisher properties, so the worker didn't run anyway. The test case has
been amended to check the correct behaviour.