### PR TITLE
Use random trackable ids in integration tests

### DIFF
--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/PublisherIntegrationTests.kt
@@ -19,6 +19,7 @@ import com.google.gson.Gson
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 private const val MAPBOX_ACCESS_TOKEN = BuildConfig.MAPBOX_ACCESS_TOKEN
 private const val CLIENT_ID = "IntegrationTestsClient"
@@ -52,7 +53,7 @@ class PublisherIntegrationTests {
         )
         runBlocking {
             try {
-                publisher.track(Trackable("ID"))
+                publisher.track(Trackable(UUID.randomUUID().toString()))
                 testLogD("track success")
                 trackExpectation.fulfill(true)
             } catch (e: Exception) {

--- a/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/RequestingNewTokenTest.kt
+++ b/publishing-sdk/src/androidTest/java/com/ably/tracking/publisher/RequestingNewTokenTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 private const val MAPBOX_ACCESS_TOKEN = BuildConfig.MAPBOX_ACCESS_TOKEN
 private const val CLIENT_ID = "RequestingNewTokenTestClient"
@@ -33,7 +34,7 @@ class RequestingNewTokenTest {
     fun shouldAddTrackableWhenRenewedTokenHasCapabilityForTrackableId() {
         // given
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val trackableId = "abc"
+        val trackableId = UUID.randomUUID().toString()
         val authentication = createTokenAuthenticationConfiguration(
             initialEnabledTrackableIds = listOf("xyz"),
             newEnabledTrackableIds = listOf("xyz", trackableId)
@@ -51,7 +52,7 @@ class RequestingNewTokenTest {
     fun shouldNotAddTrackableWhenRenewedTokenDoesNotHaveCapabilityForTrackableId() {
         // given
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val trackableId = "abc"
+        val trackableId = UUID.randomUUID().toString()
         val authentication = createTokenAuthenticationConfiguration(
             initialEnabledTrackableIds = listOf("xyz"),
             newEnabledTrackableIds = listOf("xyz")


### PR DESCRIPTION
As multiple runs operate at the same time, this avoids any clashes between tests using the same channel.