### PR TITLE
Fix minor issue in the adhoc example app publishing workflow

### DIFF
--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -30,7 +30,7 @@ if (canDistribute) {
 
 // By design, these properties are only injected by our adhoc-publish-example-apps workflow, not by other workflows (for example, publish-example-apps).
 // This means that when not adhoc-publishing example app builds they will all have a value of `null` (org.codehaus.groovy.runtime.NullObject).
-final githubTitle = findProperty("ORG_GRADLE_PROJECT_ABLY_BUILD_CONTEXT_TITLE")
+final githubTitle = findProperty("ABLY_BUILD_CONTEXT_TITLE")
 final includeIndividualRiders = findProperty("APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS")
 final additionalReleaseNotes = findProperty("APP_DISTRIBUTION_RELEASE_NOTES")
 logger.lifecycle("githubTitle [${githubTitle.getClass()}]: $githubTitle")


### PR DESCRIPTION
Remove copy-pasted prefix from property name.

The `ORG_GRADLE_PROJECT_` prefix is used in our GitHub workflows as a means to convert an environment variable into a Gradle property, however the property name then strips that prefix.

I had correctly stripped it for `ABLY_BUILD_CONTEXT_BUILD_METADATA` [here](https://github.com/ably/ably-asset-tracking-android/blob/af9f47cfed2fcf9abad822232b0aa4a7a5768de6/build.gradle#L50), injected [here](https://github.com/ably/ably-asset-tracking-android/blob/af9f47cfed2fcf9abad822232b0aa4a7a5768de6/.github/workflows/adhoc-publish-example-apps.yml#L69), but for some reason hadn't done the same for `ABLY_BUILD_CONTEXT_TITLE`. This pull request fixes that oversight.