### PR TITLE
Configure the Subscribing Example Project for Firebase App Distribution

### DIFF
--- a/.github/workflows/adhoc-publish-example-apps.yml
+++ b/.github/workflows/adhoc-publish-example-apps.yml
@@ -34,20 +34,23 @@ jobs:
           java-version: '19'
 
       # Hydrating this file before we build (assemble) the app apk(s) in order to ensure Crashlytics support is included.
-      - name: Populate Google Services file from Secrets
+      - name: Populate Google Services files from Secrets
         env:
           PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON: ${{ secrets.PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON }}
-        run: echo "$PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > publishing-example-app/google-services.json
+          SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON: ${{ secrets.SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON }}
+        run: |
+          echo "$PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > publishing-example-app/google-services.json
+          echo "$SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > subscribing-example-app/google-services.json
 
       - name: Populate Android Signing file from Secrets
         env:
           AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64 }}
-        run: echo "$AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64" | openssl base64 -d -out publishing-example-app/signing.jks
+        run: echo "$AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64" | openssl base64 -d -out signing.jks
 
       - name: Populate Google Service Account private key file from Secrets
         env:
           ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON: ${{ secrets.ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON }}
-        run: echo "$ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON" > publishing-example-app/firebase-app-distribution-private-key.json
+        run: echo "$ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON" > firebase-app-distribution-private-key.json
 
       # for S3 uploads from the app
       - name: Populate AWS Amplify Configuration file from Secrets
@@ -57,7 +60,7 @@ jobs:
         env:
           AMPLIFY_CONFIGURATION: ${{ secrets.AMPLIFY_CONFIGURATION }}
 
-      - name: Build and Upload Publishing Example App
+      - name: Build and Upload Example Apps
         env:
           ORG_GRADLE_PROJECT_ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_KEY_ALIAS }}
           ORG_GRADLE_PROJECT_ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_KEY_PASSWORD }}
@@ -69,4 +72,10 @@ jobs:
           ORG_GRADLE_PROJECT_ABLY_BUILD_CONTEXT_BUILD_METADATA: ${{ steps.context.outputs.build-metadata }}
           ORG_GRADLE_PROJECT_APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS: ${{ github.event.inputs.include-individual-riders }}
           ORG_GRADLE_PROJECT_APP_DISTRIBUTION_RELEASE_NOTES: ${{ github.event.inputs.release-notes }}
-        run: ./gradlew :publishing-example-app:assembleRelease :publishing-example-app:appDistributionUploadRelease --stacktrace
+        run: |
+          ./gradlew \
+            :publishing-example-app:assembleRelease \
+            :subscribing-example-app:assembleRelease \
+            :publishing-example-app:appDistributionUploadRelease \
+            :subscribing-example-app:appDistributionUploadRelease \
+            --stacktrace

--- a/.github/workflows/publish-example-apps.yml
+++ b/.github/workflows/publish-example-apps.yml
@@ -24,20 +24,23 @@ jobs:
           java-version: '19'
 
       # Hydrating this file before we build (assemble) the app apk(s) in order to ensure Crashlytics support is included.
-      - name: Populate Google Services file from Secrets
+      - name: Populate Google Services files from Secrets
         env:
           PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON: ${{ secrets.PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON }}
-        run: echo "$PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > publishing-example-app/google-services.json
+          SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON: ${{ secrets.SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON }}
+        run: |
+          echo "$PUBLISHING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > publishing-example-app/google-services.json
+          echo "$SUBSCRIBING_EXAMPLE_APP_GOOGLE_SERVICES_JSON" > subscribing-example-app/google-services.json
 
       - name: Populate Android Signing file from Secrets
         env:
           AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64 }}
-        run: echo "$AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64" | openssl base64 -d -out publishing-example-app/signing.jks
+        run: echo "$AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_JKS_FILE_BASE64" | openssl base64 -d -out signing.jks
 
       - name: Populate Google Service Account private key file from Secrets
         env:
           ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON: ${{ secrets.ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON }}
-        run: echo "$ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON" > publishing-example-app/firebase-app-distribution-private-key.json
+        run: echo "$ASSET_TRACKING_SDKS_GSERVICEACCOUNT_PRIVATE_KEY_JSON" > firebase-app-distribution-private-key.json
 
       # for S3 uploads from the app
       - name: Populate AWS Amplify Configuration file from Secrets
@@ -47,7 +50,7 @@ jobs:
         env:
           AMPLIFY_CONFIGURATION: ${{ secrets.AMPLIFY_CONFIGURATION }}
 
-      - name: Build and Upload Publishing Example App
+      - name: Build and Upload Example Apps
         env:
           ORG_GRADLE_PROJECT_ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_KEY_ALIAS }}
           ORG_GRADLE_PROJECT_ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.AAT_SDK_EXAMPLE_APPS_ANDROID_SIGNING_KEY_PASSWORD }}
@@ -55,4 +58,10 @@ jobs:
           ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
           ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
-        run: ./gradlew :publishing-example-app:assembleRelease :publishing-example-app:appDistributionUploadRelease --stacktrace
+        run: |
+          ./gradlew \
+            :publishing-example-app:assembleRelease \
+            :subscribing-example-app:assembleRelease \
+            :publishing-example-app:appDistributionUploadRelease \
+            :subscribing-example-app:appDistributionUploadRelease \
+            --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ local.properties
 .idea/
 .DS_Store
 build/
+
+# Secrets which should never be committed
+/firebase-app-distribution-private-key.json
+/signing.jks

--- a/firebase-app.gradle
+++ b/firebase-app.gradle
@@ -1,0 +1,89 @@
+// Configuration applied to our example app projects which need Firebase build configuration for:
+// - Crashlytics
+// - App Distribution
+
+// These files are optional for builds of this project.
+// Depending on the file, it needs to be placed either in this project's folder or at repository root
+// (e.g. by our assemble GitHub workflow).
+// These files should never be checked in, hence why they're also in this project's Git ignore file.
+final firebaseAppDistributionPrivateKeyFile = project.rootProject.file('firebase-app-distribution-private-key.json')
+final signingKeyStoreFile = project.rootProject.file('signing.jks')
+final hasGoogleServices = project.file('google-services.json').exists()
+final canDistribute = firebaseAppDistributionPrivateKeyFile.exists()
+
+if (hasGoogleServices) {
+    apply plugin: 'com.google.gms.google-services'
+    apply plugin: 'com.google.firebase.crashlytics'
+    logger.lifecycle("✅ Google Services and Crashlytics")
+}
+if (canDistribute) {
+    if (!hasGoogleServices) {
+        // When we configure `android.buildTypes.release.firebaseAppDistribution` then we don't want to have to supply
+        // values which can already be found in google-services.json (e.g. appId).
+        // Therefore, this project build insists on Google Services configuration being available if Firebase App
+        // Distribution (`canDistribute`) is in the mix.
+        throw new GradleException("Firebase App Distribution private key file was found but Google Services file was not found.")
+    }
+    apply plugin: 'com.google.firebase.appdistribution'
+    logger.lifecycle("✅ Firebase App Distribution")
+}
+
+// By design, these properties are only injected by our adhoc-publish-example-apps workflow, not by other workflows (for example, publish-example-apps).
+// This means that when not adhoc-publishing example app builds they will all have a value of `null` (org.codehaus.groovy.runtime.NullObject).
+final githubTitle = findProperty("ABLY_BUILD_CONTEXT_TITLE")
+final includeIndividualRiders = findProperty("APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS")
+final additionalReleaseNotes = findProperty("APP_DISTRIBUTION_RELEASE_NOTES")
+logger.lifecycle("githubTitle [${githubTitle.getClass()}]: $githubTitle")
+logger.lifecycle("includeIndividualRiders [${includeIndividualRiders.getClass()}]: $includeIndividualRiders")
+logger.lifecycle("additionalReleaseNotes [${additionalReleaseNotes.getClass()}]: $additionalReleaseNotes")
+
+android {
+    if (canDistribute) {
+        if (!(signingKeyStoreFile.exists())) {
+            throw new GradleException("Java KeyStore file was not found, despite the presence of a Firebase App Distribution private key file.")
+        }
+
+        signingConfigs {
+            release {
+                keyAlias findProperty("ANDROID_SIGNING_KEY_ALIAS")
+                keyPassword findProperty("ANDROID_SIGNING_KEY_PASSWORD")
+                storeFile signingKeyStoreFile
+                storePassword findProperty("ANDROID_SIGNING_STORE_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            if (canDistribute) {
+                // https://firebase.google.com/docs/app-distribution/android/distribute-gradle#step_3_configure_your_distribution_properties
+                firebaseAppDistribution {
+                    serviceCredentialsFile = firebaseAppDistributionPrivateKeyFile.getAbsolutePath()
+
+                    if (includeIndividualRiders == "true") {
+                        groups = "individual-riders"
+                    }
+
+                    if (githubTitle || additionalReleaseNotes) {
+                        releaseNotes = additionalReleaseNotes ? "$additionalReleaseNotes\n\n" : ""
+                        releaseNotes += githubTitle ? githubTitle : ""
+                    }
+                }
+                signingConfig signingConfigs.release
+            }
+        }
+    }
+}
+
+dependencies {
+    // Add application runtime implementation dependencies required for Crashlytics.
+    if (hasGoogleServices) {
+        // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).
+        implementation platform('com.google.firebase:firebase-bom:31.2.0')
+
+        // Firebase dependencies, which should not specifies versions as those are provided
+        // for us because we're including the BoM above.
+        // see: https://firebase.google.com/docs/crashlytics/get-started?platform=android
+        implementation 'com.google.firebase:firebase-crashlytics'
+    }
+}

--- a/publishing-example-app/build.gradle
+++ b/publishing-example-app/build.gradle
@@ -5,37 +5,7 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
 }
 
-// These files are optional for builds of this project.
-// They need to be placed in this project's folder (e.g. by our assemble GitHub workflow).
-// They should never be checked in, hence why they're also in this project's Git ignore file.
-final firebaseAppDistributionPrivateKeyFile = project.file('firebase-app-distribution-private-key.json')
-final signingKeyStoreFile = project.file('signing.jks')
-final hasGoogleServices = project.file('google-services.json').exists()
-final canDistribute = firebaseAppDistributionPrivateKeyFile.exists()
-
-if (hasGoogleServices) {
-    apply plugin: 'com.google.gms.google-services'
-    apply plugin: 'com.google.firebase.crashlytics'
-}
-if (canDistribute) {
-    if (!hasGoogleServices) {
-        // When we configure `android.buildTypes.release.firebaseAppDistribution` then we don't want to have to supply
-        // values which can already be found in google-services.json (e.g. appId).
-        // Therefore, this project build insists on Google Services configuration being available if Firebase App
-        // Distribution (`canDistribute`) is in the mix.
-        throw new GradleException("Firebase App Distribution private key file was found but Google Services file was not found.")
-    }
-    apply plugin: 'com.google.firebase.appdistribution'
-}
-
-// By design, these properties are only injected by our adhoc-publish-example-apps workflow, not by other workflows (for example, publish-example-apps).
-// This means that when not adhoc-publishing example app builds they will all have a value of `null` (org.codehaus.groovy.runtime.NullObject).
-final githubTitle = findProperty("ABLY_BUILD_CONTEXT_TITLE")
-final includeIndividualRiders = findProperty("APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS")
-final additionalReleaseNotes = findProperty("APP_DISTRIBUTION_RELEASE_NOTES")
-logger.lifecycle("githubTitle [${githubTitle.getClass()}]: $githubTitle")
-logger.lifecycle("includeIndividualRiders [${includeIndividualRiders.getClass()}]: $includeIndividualRiders")
-logger.lifecycle("additionalReleaseNotes [${additionalReleaseNotes.getClass()}]: $additionalReleaseNotes")
+apply from: "../firebase-app.gradle"
 
 android {
     defaultConfig {
@@ -46,42 +16,6 @@ android {
         resValue "string", "mapbox_access_token", findProperty('MAPBOX_ACCESS_TOKEN') ?: ""
     }
     namespace 'com.ably.tracking.example.publisher'
-
-    if (canDistribute) {
-        if (!(signingKeyStoreFile.exists())) {
-            throw new GradleException("Java KeyStore file was not found, despite the presence of a Firebase App Distribution private key file.")
-        }
-
-        signingConfigs {
-            release {
-                keyAlias findProperty("ANDROID_SIGNING_KEY_ALIAS")
-                keyPassword findProperty("ANDROID_SIGNING_KEY_PASSWORD")
-                storeFile signingKeyStoreFile
-                storePassword findProperty("ANDROID_SIGNING_STORE_PASSWORD")
-            }
-        }
-    }
-
-    buildTypes {
-        release {
-            if (canDistribute) {
-                // https://firebase.google.com/docs/app-distribution/android/distribute-gradle#step_3_configure_your_distribution_properties
-                firebaseAppDistribution {
-                    serviceCredentialsFile = firebaseAppDistributionPrivateKeyFile.getAbsolutePath()
-
-                    if (includeIndividualRiders == "true") {
-                        groups = "individual-riders"
-                    }
-
-                    if (githubTitle || additionalReleaseNotes) {
-                        releaseNotes = additionalReleaseNotes ? "$additionalReleaseNotes\n\n" : ""
-                        releaseNotes += githubTitle ? githubTitle : ""
-                    }
-                }
-                signingConfig signingConfigs.release
-            }
-        }
-    }
 }
 
 dependencies {
@@ -93,15 +27,4 @@ dependencies {
     implementation 'pub.devrel:easypermissions:3.0.0'
     // This version needs to be compatible with the "com.mapbox.navigation:core" dependency version from publishing-sdk.
     implementation 'com.mapbox.maps:android:10.10.0'
-
-    // Add application runtime implementation dependencies required for Crashlytics.
-    if (hasGoogleServices) {
-        // The BoM for the Firebase platform (it specifies the versions for Firebase dependencies).
-        implementation platform('com.google.firebase:firebase-bom:31.2.0')
-
-        // Firebase dependencies, which should not specifies versions as those are provided
-        // for us because we're including the BoM above.
-        // see: https://firebase.google.com/docs/crashlytics/get-started?platform=android
-        implementation 'com.google.firebase:firebase-crashlytics'
-    }
 }

--- a/subscribing-example-app/.gitignore
+++ b/subscribing-example-app/.gitignore
@@ -1,5 +1,4 @@
 # Secrets which should never be committed
-/src/main/res/raw/amplifyconfiguration.json
 /google-services.json
 
 # Intermediary or transient folders created when assembling the app.

--- a/subscribing-example-app/build.gradle
+++ b/subscribing-example-app/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
 }
 
+apply from: "../firebase-app.gradle"
+
 android {
     defaultConfig {
         applicationId 'com.ably.tracking.example.subscriber'


### PR DESCRIPTION
I've already tested this from my local machine with the same Gradle incantation used in the workflows:

```
./gradlew \
    :publishing-example-app:assembleRelease \
    :subscribing-example-app:assembleRelease \
    :publishing-example-app:appDistributionUploadRelease \
    :subscribing-example-app:appDistributionUploadRelease \
    --stacktrace
```

And that works, pushing a new build of both the Publishing and Subscribing apps to Firebase.

That command doesn't test release notes or add+notify to the `individual-riders` testers' group, however I'm confident those features will not have been broken by this change. We'll know for sure when we land this pull request to `main` branch and give it a whirl from there.

The biggest change, generating the most noise, is moving most of the Gradle configuration from `publishing-example-app/build.gradle` to `firebase-app.gradle` so that it can be shared with the two projects that need it.