### PR TITLE
Enhance Publish Example Apps workflow

### DIFF
--- a/.github/workflows/publish-example-apps.yml
+++ b/.github/workflows/publish-example-apps.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           ref: v${{ github.event.inputs.version }}
 
+      # TODO replace branch ref (underlying https://github.com/ably/github-event-context-action/pull/2) with `v1` tag
+      - uses: ably/github-event-context-action@add-build-metadata-output-and-release
+        id: context
+
       - uses: actions/setup-java@v3
         with:
           distribution: zulu
@@ -64,6 +68,7 @@ jobs:
           ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
           ORG_GRADLE_PROJECT_APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS: ${{ github.event.inputs.include-individual-riders }}
+          ORG_GRADLE_PROJECT_APP_DISTRIBUTION_RELEASE_NOTES: "${{ steps.context.outputs.title }} [${{ steps.context.outputs.build-metadata }}]"
         run: |
           ./gradlew \
             :publishing-example-app:assembleRelease \

--- a/.github/workflows/publish-example-apps.yml
+++ b/.github/workflows/publish-example-apps.yml
@@ -8,6 +8,11 @@ on:
       version:
         description: 'Version, without v prefix, appended to v to locate tag'
         required: true
+      include-individual-riders:
+        type: boolean
+        description: Include the `individual-riders` testers' group, immediately adding them to and notifying them of the new release.
+        default: true
+        required: true
 
 jobs:
   publish:
@@ -58,6 +63,7 @@ jobs:
           ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
           ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           ORG_GRADLE_PROJECT_ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
+          ORG_GRADLE_PROJECT_APP_DISTRIBUTION_INCLUDE_INDIVIDUAL_RIDERS: ${{ github.event.inputs.include-individual-riders }}
         run: |
           ./gradlew \
             :publishing-example-app:assembleRelease \


### PR DESCRIPTION
I noticed from [this run](https://github.com/ably/ably-asset-tracking-android/actions/runs/4079366643) that I had overlooked something with the primary example app publishing workflow, from Git tag. I had been somewhat myopically focussed on the adhoc publishing workflow that I had not carried the support for notifying testers from there to the primary workflow. This pull request fixes that in https://github.com/ably/ably-asset-tracking-android/commit/440b220fccebaf925207954d700077cf0b4067ad.

I've also taken this opportunity to add some auto-generated release notes in https://github.com/ably/ably-asset-tracking-android/commit/0f5c6cedcc633b7d4da76bf7748829cb2bf11599.