### PR TITLE
Fix issues re-adding trackable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.24'
+    ext.ably_core_version = '1.2.25'
 
     repositories {
         google()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -47,6 +47,7 @@ import com.ably.tracking.publisher.workerqueue.workers.SetActiveTrackableWorker
 import com.ably.tracking.publisher.workerqueue.workers.StopWorker
 import com.ably.tracking.publisher.workerqueue.workers.StoppingConnectionFinishedWorker
 import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
+import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalSuccessWorker
 import com.ably.tracking.publisher.workerqueue.workers.UpdatePresenceDataWorker
 import kotlinx.coroutines.flow.StateFlow
 
@@ -124,6 +125,10 @@ internal class WorkerFactory(
                 workerSpecification.trackable,
                 ably,
                 workerSpecification.result,
+            )
+            is WorkerSpecification.TrackableRemovalSuccess -> TrackableRemovalSuccessWorker(
+                workerSpecification.trackable,
+                workerSpecification.result
             )
             is WorkerSpecification.AblyConnectionStateChange -> AblyConnectionStateChangeWorker(
                 workerSpecification.connectionStateChange,
@@ -344,6 +349,11 @@ internal sealed class WorkerSpecification {
     data class TrackableRemovalRequested(
         val trackable: Trackable,
         val result: Result<Unit>,
+    ) : WorkerSpecification()
+
+    data class TrackableRemovalSuccess(
+        val trackable: Trackable,
+        val result: Result<Boolean>,
     ) : WorkerSpecification()
 
     object StoppingConnectionFinished : WorkerSpecification()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -116,7 +116,6 @@ internal class WorkerFactory(
             )
             is WorkerSpecification.DisconnectSuccess -> DisconnectSuccessWorker(
                 workerSpecification.trackable,
-                workerSpecification.callbackFunction,
                 publisherInteractor,
                 workerSpecification.shouldRecalculateResolutionCallback,
                 ably,
@@ -286,7 +285,6 @@ internal sealed class WorkerSpecification {
 
     data class DisconnectSuccess(
         val trackable: Trackable,
-        val callbackFunction: ResultCallbackFunction<Unit>,
         val shouldRecalculateResolutionCallback: () -> Unit,
     ) : WorkerSpecification()
 

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/AddTrackableWorker.kt
@@ -50,11 +50,11 @@ internal class AddTrackableWorker(
         postWork: (WorkerSpecification) -> Unit
     ): PublisherProperties {
         when {
-            properties.trackables.contains(trackable) -> {
+            properties.trackables.contains(trackable) && !properties.trackableRemovalGuard.isMarkedForRemoval(trackable) -> {
                 val trackableFlow = properties.trackableStateFlows[trackable.id]!!
                 callbackFunction(Result.success(trackableFlow))
             }
-            properties.state == PublisherState.DISCONNECTING -> {
+            properties.state == PublisherState.DISCONNECTING || properties.trackableRemovalGuard.isMarkedForRemoval(trackable) -> {
                 doAsyncWork {
                     isDelayingWork = true
                     // delay work until Ably disconnection ends

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -1,8 +1,7 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.common.Ably
-import com.ably.tracking.common.ResultCallbackFunction
-import com.ably.tracking.common.workerqueue.CallbackWorker
+import com.ably.tracking.common.workerqueue.Worker
 import com.ably.tracking.publisher.PublisherInteractor
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.PublisherState
@@ -11,11 +10,10 @@ import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 
 internal class DisconnectSuccessWorker(
     private val trackable: Trackable,
-    callbackFunction: ResultCallbackFunction<Unit>,
     private val publisherInteractor: PublisherInteractor,
     private val shouldRecalculateResolutionCallback: () -> Unit,
     private val ably: Ably,
-) : CallbackWorker<PublisherProperties, WorkerSpecification>(callbackFunction) {
+) : Worker<PublisherProperties, WorkerSpecification> {
     /**
      * Whether the worker is also performing disconnecting.
      * Used to properly handle unexpected exceptions in [onUnexpectedAsyncError].
@@ -107,7 +105,6 @@ internal class DisconnectSuccessWorker(
     }
 
     private fun notifyRemoveOperationFinished(properties: PublisherProperties) {
-        callbackFunction(Result.success(Unit))
         properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
     }
 
@@ -117,5 +114,13 @@ internal class DisconnectSuccessWorker(
             // When async work fails we should make sure that the SDK state is not stuck in DISCONNECTING so we post a new worker
             postWork(WorkerSpecification.StoppingConnectionFinished)
         }
+    }
+
+    override fun doWhenStopped(exception: Exception) {
+        // No op
+    }
+
+    override fun onUnexpectedError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
+        // No op
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -36,7 +36,7 @@ internal class DisconnectSuccessWorker(
         if (isRemovedTrackableTheLastOne(properties)) {
             stopLocationUpdates(properties)
         }
-        notifyRemoveOperationFinished(postWork)
+        notifyRemoveOperationFinished(postWork, Result.success(true))
 
         val removedTheLastTrackable = properties.hasNoTrackablesAdded
         if (removedTheLastTrackable) {
@@ -104,8 +104,8 @@ internal class DisconnectSuccessWorker(
         }
     }
 
-    private fun notifyRemoveOperationFinished(postWork: (WorkerSpecification) -> Unit) {
-        postWork(WorkerSpecification.TrackableRemovalSuccess(trackable, Result.success(true)))
+    private fun notifyRemoveOperationFinished(postWork: (WorkerSpecification) -> Unit, result: Result<Boolean>) {
+        postWork(WorkerSpecification.TrackableRemovalSuccess(trackable, result))
     }
 
     override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
@@ -121,6 +121,6 @@ internal class DisconnectSuccessWorker(
     }
 
     override fun onUnexpectedError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
-        notifyRemoveOperationFinished(postWork)
+        notifyRemoveOperationFinished(postWork, Result.failure(exception))
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -36,7 +36,7 @@ internal class DisconnectSuccessWorker(
         if (isRemovedTrackableTheLastOne(properties)) {
             stopLocationUpdates(properties)
         }
-        notifyRemoveOperationFinished(properties)
+        notifyRemoveOperationFinished(postWork)
 
         val removedTheLastTrackable = properties.hasNoTrackablesAdded
         if (removedTheLastTrackable) {
@@ -104,8 +104,8 @@ internal class DisconnectSuccessWorker(
         }
     }
 
-    private fun notifyRemoveOperationFinished(properties: PublisherProperties) {
-        properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
+    private fun notifyRemoveOperationFinished(postWork: (WorkerSpecification) -> Unit) {
+        postWork(WorkerSpecification.TrackableRemovalSuccess(trackable, Result.success(true)))
     }
 
     override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
@@ -121,6 +121,6 @@ internal class DisconnectSuccessWorker(
     }
 
     override fun onUnexpectedError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {
-        // No op
+        notifyRemoveOperationFinished(postWork)
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorker.kt
@@ -38,7 +38,7 @@ internal class DisconnectSuccessWorker(
         if (isRemovedTrackableTheLastOne(properties)) {
             stopLocationUpdates(properties)
         }
-        notifyRemoveOperationFinished()
+        notifyRemoveOperationFinished(properties)
 
         val removedTheLastTrackable = properties.hasNoTrackablesAdded
         if (removedTheLastTrackable) {
@@ -106,8 +106,9 @@ internal class DisconnectSuccessWorker(
         }
     }
 
-    private fun notifyRemoveOperationFinished() {
+    private fun notifyRemoveOperationFinished(properties: PublisherProperties) {
         callbackFunction(Result.success(Unit))
+        properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
     }
 
     override fun onUnexpectedAsyncError(exception: Exception, postWork: (WorkerSpecification) -> Unit) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
@@ -20,7 +20,6 @@ private const val ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE = 91_001
  */
 private const val PRESENCE_ENTER_DELAY_IN_MILLISECONDS = 15_000L
 
-// TODO rename this to EnterPresenceWorker - probably already done by Andy
 internal class EnterPresenceWorker(
     private val trackable: Trackable,
     private val ably: Ably

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
@@ -54,7 +54,6 @@ internal class RemoveTrackableWorker(
     private fun buildDisconnectSuccessWorkerSpecification(postWork: (WorkerSpecification) -> Unit) =
         WorkerSpecification.DisconnectSuccess(
             trackable = trackable,
-            callbackFunction = {}, // no-op as we've already notified the caller
             shouldRecalculateResolutionCallback = {
                 postWork(WorkerSpecification.ChangeLocationEngineResolution)
             }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/RemoveTrackableWorker.kt
@@ -25,7 +25,7 @@ internal class RemoveTrackableWorker(
             properties.trackables.contains(trackable) -> {
                 // Immediately change trackable state to "Offline"
                 setTrackableStateToOffline(properties)
-                properties.trackableRemovalGuard.markForRemoval(trackable, callbackFunction)
+                properties.trackableRemovalGuard.markForRemoval(trackable) {}
                 doAsyncWork {
                     // Immediately notify the caller as disconnecting should happen in the background
                     callbackFunction(Result.success(true))

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalRequestedWorker.kt
@@ -24,9 +24,9 @@ internal class TrackableRemovalRequestedWorker(
         postWork: (WorkerSpecification) -> Unit
     ): PublisherProperties {
         if (result.isSuccess) {
-            properties.trackableRemovalGuard.removeMarked(trackable, Result.success(true))
+            postWork(WorkerSpecification.TrackableRemovalSuccess(trackable, Result.success(true)))
         } else {
-            properties.trackableRemovalGuard.removeMarked(trackable, Result.failure(result.exceptionOrNull()!!))
+            postWork(WorkerSpecification.TrackableRemovalSuccess(trackable, Result.failure(result.exceptionOrNull()!!)))
         }
         val removedTheLastTrackable = properties.hasNoTrackablesAdded
         if (removedTheLastTrackable) {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalSuccessWorker.kt
@@ -1,0 +1,24 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.common.workerqueue.DefaultWorker
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.WorkerSpecification
+
+/**
+ * Removes a trackable from the removal guard to signal success.
+ */
+internal class TrackableRemovalSuccessWorker(
+    private val trackable: Trackable,
+    private val result: Result<Boolean>
+) : DefaultWorker<PublisherProperties, WorkerSpecification>() {
+    override fun doWork(
+        properties: PublisherProperties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): PublisherProperties {
+        properties.trackableRemovalGuard.removeMarked(trackable, result)
+
+        return properties
+    }
+}

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/DefaultPublisherTest.kt
@@ -132,28 +132,6 @@ class DefaultPublisherTest {
 
             // Have to remove the previous one before re-adding
             publisher.remove(trackable)
-        }
-
-        // We need to wait for the trackable to have fully left the publisher before continuing
-        // See: https://github.com/ably/ably-asset-tracking-android/issues/984
-        var trackableRemovedFromPublisher = false
-        publisher.trackables.onEach {
-            if (!it.contains(trackable)) {
-                trackableRemovedFromPublisher = true
-            }
-        }.launchIn(scope)
-
-        runBlocking {
-            withTimeout(5000) {
-                while (true) {
-                    if (trackableRemovedFromPublisher) {
-                        break
-                    }
-
-                    delay(5)
-                }
-            }
-
             publisher.add(trackable)
         }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -9,7 +9,6 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionState
 import com.ably.tracking.common.ConnectionStateChange
-import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.publisher.PublisherInteractor
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.Trackable
@@ -33,7 +32,6 @@ class DisconnectSuccessWorkerTest {
 
     private val trackable = Trackable("testtrackable")
     private val otherTrackable = Trackable("other-trackable")
-    private val resultCallbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
     private val recalculateResolutionCallbackFunction = mockk<() -> Unit>(relaxed = true)
     private val publisherInteractor = mockk<PublisherInteractor> {
         every { updateTrackables(any()) } just runs
@@ -50,7 +48,6 @@ class DisconnectSuccessWorkerTest {
 
     private val worker = DisconnectSuccessWorker(
         trackable,
-        resultCallbackFunction,
         publisherInteractor,
         recalculateResolutionCallbackFunction,
         ably
@@ -447,28 +444,6 @@ class DisconnectSuccessWorkerTest {
         assertThat(asyncWorks).isEmpty()
         assertThat(postedWorks).isEmpty()
         assertThat(updatedProperties.trackableRemovalGuard.isMarkedForRemoval(trackable)).isFalse()
-    }
-
-    @Test
-    fun `should always call the result callback with a success`() {
-        // given
-        val initialProperties = createPublisherPropertiesWithMultipleTrackables()
-
-        // when
-        worker.doWork(
-            initialProperties,
-            asyncWorks.appendWork(),
-            postedWorks.appendSpecification()
-        )
-
-        // then
-        assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
-
-        // then
-        verify(exactly = 1) {
-            resultCallbackFunction(Result.success(Unit))
-        }
     }
 
     @Test

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -430,6 +430,25 @@ class DisconnectSuccessWorkerTest {
         assertThat(updatedProperties.rawLocationsPublishingState.shouldRetryPublishing(trackable.id)).isTrue()
     }
 
+    fun `should remove the trackable from the trackable removal guard`() {
+        // given
+        val initialProperties = createPublisherPropertiesWithMultipleTrackables()
+        initialProperties.trackableStateFlows[trackable.id] = MutableStateFlow(TrackableState.Offline())
+        initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
+
+        // when
+        val updatedProperties = worker.doWork(
+            initialProperties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        assertThat(asyncWorks).isEmpty()
+        assertThat(postedWorks).isEmpty()
+        assertThat(updatedProperties.trackableRemovalGuard.isMarkedForRemoval(trackable)).isFalse()
+    }
+
     @Test
     fun `should always call the result callback with a success`() {
         // given

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/DisconnectSuccessWorkerTest.kt
@@ -70,7 +70,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.trackables).doesNotContain(trackable)
     }
@@ -90,7 +90,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.trackableStateFlows).isEmpty()
     }
 
@@ -109,7 +109,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.trackableStates).isEmpty()
     }
 
@@ -128,7 +128,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.resolutions).isEmpty()
     }
 
@@ -147,7 +147,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             recalculateResolutionCallbackFunction.invoke()
@@ -169,7 +169,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 0) {
             recalculateResolutionCallbackFunction.invoke()
@@ -191,7 +191,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.requests).isEmpty()
     }
 
@@ -210,7 +210,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.lastSentEnhancedLocations).isEmpty()
     }
 
@@ -229,7 +229,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.lastSentRawLocations).isEmpty()
     }
 
@@ -249,7 +249,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         assertThat(updatedProperties.lastChannelConnectionStateChanges).isEmpty()
     }
 
@@ -267,7 +267,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
         verify(exactly = 1) {
             publisherInteractor.updateTrackables(updatedProperties)
         }
@@ -287,7 +287,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.updateTrackableStateFlows(updatedProperties)
@@ -308,7 +308,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.notifyResolutionPolicyThatTrackableWasRemoved(trackable)
@@ -329,7 +329,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.removeAllSubscribers(trackable, updatedProperties)
@@ -351,7 +351,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.skippedEnhancedLocations.toList(trackable.id)).isEmpty()
     }
@@ -371,7 +371,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.skippedRawLocations.toList(trackable.id)).isEmpty()
     }
@@ -395,7 +395,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.enhancedLocationsPublishingState.hasPendingMessage(trackable.id)).isFalse()
         assertThat(updatedProperties.enhancedLocationsPublishingState.getNextWaiting(trackable.id)).isNull()
@@ -420,21 +420,20 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.rawLocationsPublishingState.hasPendingMessage(trackable.id)).isFalse()
         assertThat(updatedProperties.rawLocationsPublishingState.getNextWaiting(trackable.id)).isNull()
         assertThat(updatedProperties.rawLocationsPublishingState.shouldRetryPublishing(trackable.id)).isTrue()
     }
 
-    fun `should remove the trackable from the trackable removal guard`() {
+    fun `should post TrackableRemovalSuccess work`() {
         // given
         val initialProperties = createPublisherPropertiesWithMultipleTrackables()
         initialProperties.trackableStateFlows[trackable.id] = MutableStateFlow(TrackableState.Offline())
-        initialProperties.trackableRemovalGuard.markForRemoval(trackable) {}
 
         // when
-        val updatedProperties = worker.doWork(
+        worker.doWork(
             initialProperties,
             asyncWorks.appendWork(),
             postedWorks.appendSpecification()
@@ -442,8 +441,10 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
-        assertThat(updatedProperties.trackableRemovalGuard.isMarkedForRemoval(trackable)).isFalse()
+        assertThat(postedWorks).hasSize(1)
+        val postedWork = postedWorks[0] as WorkerSpecification.TrackableRemovalSuccess
+        assertThat(postedWork.trackable).isEqualTo(trackable)
+        assertThat(postedWork.result.isSuccess).isTrue()
     }
 
     @Test
@@ -461,7 +462,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.active).isNull()
     }
@@ -481,7 +482,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.removeCurrentDestination(updatedProperties)
@@ -503,7 +504,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.notifyResolutionPolicyThatActiveTrackableHasChanged(null)
@@ -525,7 +526,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         assertThat(updatedProperties.active).isEqualTo(otherTrackable)
     }
@@ -545,7 +546,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 0) {
             publisherInteractor.removeCurrentDestination(updatedProperties)
@@ -567,7 +568,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 0) {
             publisherInteractor.notifyResolutionPolicyThatActiveTrackableHasChanged(null)
@@ -589,7 +590,7 @@ class DisconnectSuccessWorkerTest {
         )
 
         // then
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 1) {
             publisherInteractor.stopLocationUpdates(updatedProperties)
@@ -611,7 +612,7 @@ class DisconnectSuccessWorkerTest {
 
         // then
         assertThat(asyncWorks).isEmpty()
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 0) {
             publisherInteractor.stopLocationUpdates(updatedProperties)
@@ -633,7 +634,7 @@ class DisconnectSuccessWorkerTest {
         )
 
         // then
-        assertThat(postedWorks).isEmpty()
+        assertThat(postedWorks).hasSize(1)
 
         verify(exactly = 0) {
             publisherInteractor.stopLocationUpdates(updatedProperties)
@@ -657,8 +658,8 @@ class DisconnectSuccessWorkerTest {
 
             // then
             assertThat(asyncWorks).hasSize(1)
-            assertThat(postedWorks).hasSize(1)
-            val postedWorker = postedWorks.first()
+            assertThat(postedWorks).hasSize(2)
+            val postedWorker = postedWorks[1]
 
             coVerify(exactly = 1) {
                 ably.stopConnection()

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalSuccessWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/TrackableRemovalSuccessWorkerTest.kt
@@ -1,0 +1,48 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.publisher.Trackable
+import com.ably.tracking.publisher.workerqueue.WorkerSpecification
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class TrackableRemovalSuccessWorkerTest {
+
+    private val trackable = Trackable("test-trackable")
+    private val worker = TrackableRemovalSuccessWorker(trackable, Result.success(true))
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should remove trackable from guard`() {
+        // given
+        val properties = createPublisherProperties()
+        properties.trackables.add(trackable)
+        val removeTrackableCallbackFunction: ResultCallbackFunction<Boolean> = mockk(relaxed = true)
+        properties.trackableRemovalGuard.markForRemoval(trackable, removeTrackableCallbackFunction)
+
+        // when
+        worker.doWork(
+            properties,
+            asyncWorks.appendWork(),
+            postedWorks.appendSpecification()
+        )
+
+        // then
+        assertThat(asyncWorks).isEmpty()
+        assertThat(postedWorks).isEmpty()
+
+        assertThat(properties.trackableRemovalGuard.isMarkedForRemoval(trackable)).isFalse()
+        verify(exactly = 1) {
+            removeTrackableCallbackFunction.invoke(
+                match {
+                    it.getOrNull() == true
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
This change:

- Fixes an issue where re-adding a removed trackable would prevent that trackable from entering presence. This is because DisconnectSuccessWorker does not remove trackables from the removal guard, meaning that once a trackable is removed the first time it is permanently marked for removal. This change makes sure that this un-marking occurs.
- Fixes an issue where a NullPointerException is thrown if a trackable is re-added very quickly after being removed. This is caused by the fact that RemoveTrackableWorker clears the trackables StateFlow but doesn't remove the trackable itself until a later worker (DisconnectSuccessWorker). Therefore, if AddTracakbleWorker is called in the meantime, that will see the trackable is around, and throw an NPE when it tries to access the non-existent StateFlow. This change fixes the issue by adding a check to the trackable removal guard when doing AddTrackableWorker, and delaying the work for a bit if a trackable is being removed.
- Introduces a new version of ably-java that fixes an issue where channels can be brought back spuriously after being released, meaning that trackables cannot be re-added.
 
Fixes #988  
Fixes #984 
Fixes #989 

To test the ably-java fixes, see this draft PR: https://github.com/ably/ably-asset-tracking-android/pull/993

- Go to the publishing example app
- Add two trackables
- Remove one trackable
- Re-add the trackable with the same ID
- The trackable should come online almost immediately
