### PR TITLE
Remove `ConnectionException` from docstrings of `Publisher.add/track`

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/Publisher.kt
@@ -40,8 +40,6 @@ interface Publisher {
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there, and to be
      * made the actively tracked object.
      * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
-     *
-     * @throws ConnectionException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
     suspend fun track(trackable: Trackable): StateFlow<TrackableState>
@@ -54,8 +52,6 @@ interface Publisher {
      *
      * @param trackable The object to be added to this publisher's tracked set, if it's not already there.
      * @return [StateFlow] that represents the [TrackableState] of the added [Trackable].
-     *
-     * @throws ConnectionException when something goes wrong with the Ably connection
      */
     @JvmSynthetic
     suspend fun add(trackable: Trackable): StateFlow<TrackableState>


### PR DESCRIPTION
Now that #871, #907 and #966 are closed, this exception is no longer thrown, but we forgot to remove it from the docstrings.

Closes #995.