### PR TITLE
Update resolution retry

### DIFF
--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -225,6 +225,7 @@ interface Ably {
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
      */
+    // This function should be removed together with deprecated suspending resolutionPreference function in Subscriber
     suspend fun updatePresenceDataWithRetry(trackableId: String, presenceData: PresenceData): Result<Unit>
 
     /**
@@ -795,7 +796,6 @@ constructor(
     override suspend fun updatePresenceDataWithRetry(trackableId: String, presenceData: PresenceData): Result<Unit> {
         val trackableChannel = getChannelIfExists(trackableId) ?: return Result.success(Unit)
         return try {
-            // This simple retry mechanism should be removed while fixing https://github.com/ably/ably-asset-tracking-android/issues/962
             withTimeout(30_000L) {
                 updatePresenceDataRepeating(trackableChannel, presenceData)
                 Result.success(Unit)

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -213,13 +213,7 @@ interface Ably {
      *
      * @param trackableId The ID of the trackable channel.
      * @param presenceData The data that will be send via the presence channel.
-     * @param callback The function that will be called when updating presence data completes. If something goes wrong it will be called with [ConnectionException].
      */
-    fun updatePresenceData(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit)
-
-    /**
-     * A suspending version of [updatePresenceData]
-     * */
     suspend fun updatePresenceData(trackableId: String, presenceData: PresenceData): Result<Unit>
 
     /**
@@ -773,13 +767,6 @@ constructor(
             }
         }
 
-    override fun updatePresenceData(trackableId: String, presenceData: PresenceData, callback: (Result<Unit>) -> Unit) {
-        scope.launch {
-            val result = updatePresenceData(trackableId, presenceData)
-            callback(result)
-        }
-    }
-
     override suspend fun updatePresenceData(trackableId: String, presenceData: PresenceData): Result<Unit> {
         val trackableChannel = getChannelIfExists(trackableId) ?: return Result.success(Unit)
         return try {
@@ -927,8 +914,6 @@ constructor(
     override fun getChannelState(trackableId: String): ChannelState? =
         getChannelIfExists(trackableId)?.state
 
-    private fun ChannelState.isConnected(): Boolean = this == ChannelState.attached
-
     private fun ConnectionState.isConnected(): Boolean = this == ConnectionState.connected
 
     private fun ConnectionState.isClosed(): Boolean = this == ConnectionState.closed
@@ -936,9 +921,6 @@ constructor(
     private fun ConnectionState.isFailed(): Boolean = this == ConnectionState.failed
 
     private fun ConnectionState.isInitialized(): Boolean = this == ConnectionState.initialized
-
-    private fun ConnectionException.isConnectionResumeException(): Boolean =
-        errorInformation.let { it.message == "Connection resume failed" && it.code == 50000 && it.statusCode == 500 }
 
     /**
      * Enter the presence of [channel] and waits for this operation to complete.

--- a/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
+++ b/common/src/test/java/com/ably/tracking/common/DefaultAblyTests.kt
@@ -432,46 +432,6 @@ class DefaultAblyTests {
     }
 
     @Test
-    fun `updatePresenceData - when presence update times out`() = runTest {
-        /* Given...
-         *
-         * ...that calling `containsKey` on the Channels instance returns true...
-         * ...and that calling `get` (the overload that does not accept a ChannelOptions object) on the Channels instance returns a channel...
-         * ...which, when told to update presence data, never finishes doing so...
-         *
-         *
-         * When...
-         *
-         * ...we call `updatePresenceData` on the object under test,
-         *
-         * Then...
-         * ...in the following order, precisely the following things happen...
-         *
-         * ...it calls `containsKey` on the Channels instance...
-         * ...and calls `get` (the overload that does not accept a ChannelOptions object) on the Channels instance...
-         * ...and tells the channel to update presence data...
-         * ...and the call to `updatePresenceData` (on the object under test) does not complete (see “Documenting the absence of built-in timeout” above).
-         */
-
-        DefaultAblyTestScenarios.UpdatePresenceData.test(
-            DefaultAblyTestScenarios.UpdatePresenceData.GivenConfig(
-                channelsContainsKey = true,
-                mockChannelsGet = true,
-                presenceUpdateBehaviour = DefaultAblyTestScenarios.GivenTypes.CompletionListenerMockBehaviour.DoesNotComplete
-            ),
-            DefaultAblyTestScenarios.UpdatePresenceData.ThenConfig(
-                verifyChannelsGet = true,
-                verifyGetChannelName = true,
-                verifyPresenceUpdate = true,
-                resultOfUpdatePresenceCallOnObjectUnderTest = DefaultAblyTestScenarios.ThenTypes.ExpectedAsyncResult.TerminatesWithConnectionException(
-                    errorInformation = ErrorInformation("Timeout was thrown when updating presence of channel tracking:someTrackable-1")
-                )
-            ),
-            this
-        )
-    }
-
-    @Test
     fun `updatePresenceData - when channel doesn't exist`() = runTest {
         /* Given...
          *

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/CorePublisher.kt
@@ -619,8 +619,7 @@ constructor(
                 properties.resolutions[trackable.id] = resolution
                 enqueue(WorkerSpecification.ChangeLocationEngineResolution)
                 if (sendResolutionEnabled) {
-                    val presenceData = properties.presenceData.copy(resolution = resolution)
-                    enqueue(WorkerSpecification.UpdatePresenceData(trackable.id, presenceData))
+                    enqueue(WorkerSpecification.UpdateResolution(trackable.id, resolution))
                 }
             }
         }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -23,6 +23,7 @@ private constructor(
     enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationUpdate>,
     rawLocationsPublishingState: LocationsPublishingState<LocationUpdate>,
     trackableRemovalGuard: TrackableRemovalGuard,
+    val updatingResolutions: MutableList<Resolution>,
     private val onActiveTrackableUpdated: (Trackable?) -> Unit,
     private val onRoutingProfileUpdated: (RoutingProfile) -> Unit
 ) : Properties {
@@ -42,6 +43,7 @@ private constructor(
         LocationsPublishingState(),
         LocationsPublishingState(),
         DefaultTrackableRemovalGuard(),
+        mutableListOf(),
         onActiveTrackableUpdated,
         onRoutingProfileUpdated
     )
@@ -64,7 +66,8 @@ private constructor(
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
     val trackableStateFlows: MutableMap<String, MutableStateFlow<TrackableState>> = mutableMapOf()
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
-    val lastChannelConnectionStateChanges: MutableMap<String, ConnectionStateChange> = mutableMapOf()
+    val lastChannelConnectionStateChanges: MutableMap<String, ConnectionStateChange> =
+        mutableMapOf()
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
     var lastConnectionStateChange: ConnectionStateChange = ConnectionStateChange(
         ConnectionState.OFFLINE, null
@@ -110,7 +113,8 @@ private constructor(
     val enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationUpdate> =
         enhancedLocationsPublishingState
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
-    val rawLocationsPublishingState: LocationsPublishingState<LocationUpdate> = rawLocationsPublishingState
+    val rawLocationsPublishingState: LocationsPublishingState<LocationUpdate> =
+        rawLocationsPublishingState
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
     val trackableRemovalGuard: TrackableRemovalGuard = trackableRemovalGuard
         get() = if (isDisposed) throw PublisherPropertiesDisposedException() else field
@@ -140,6 +144,7 @@ private constructor(
             enhancedLocationsPublishingState,
             rawLocationsPublishingState,
             trackableRemovalGuard,
+            updatingResolutions,
             onActiveTrackableUpdated,
             onRoutingProfileUpdated
         )
@@ -169,7 +174,8 @@ private constructor(
                 it.state = state
             }
 
-    fun hasSetFinalTrackableState(trackableId: String): Boolean = trackablesWithFinalStateSet.contains(trackableId)
+    fun hasSetFinalTrackableState(trackableId: String): Boolean =
+        trackablesWithFinalStateSet.contains(trackableId)
 
     fun dispose() {
         trackables.clear()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/PublisherProperties.kt
@@ -23,7 +23,7 @@ private constructor(
     enhancedLocationsPublishingState: LocationsPublishingState<EnhancedLocationUpdate>,
     rawLocationsPublishingState: LocationsPublishingState<LocationUpdate>,
     trackableRemovalGuard: TrackableRemovalGuard,
-    val updatingResolutions: MutableList<Resolution>,
+    private val updatingResolutions: MutableMap<String, MutableList<Resolution>>,
     private val onActiveTrackableUpdated: (Trackable?) -> Unit,
     private val onRoutingProfileUpdated: (RoutingProfile) -> Unit
 ) : Properties {
@@ -43,7 +43,7 @@ private constructor(
         LocationsPublishingState(),
         LocationsPublishingState(),
         DefaultTrackableRemovalGuard(),
-        mutableListOf(),
+        mutableMapOf(),
         onActiveTrackableUpdated,
         onRoutingProfileUpdated
     )
@@ -134,6 +134,25 @@ private constructor(
 
     override val isStopped: Boolean
         get() = state == PublisherState.STOPPED
+
+    fun addUpdatingResolution(trackableId: String, resolution: Resolution) {
+        val updatingList = updatingResolutions[trackableId] ?: mutableListOf()
+        updatingList.add(resolution)
+        updatingResolutions[trackableId] = updatingList
+    }
+
+    fun containsUpdatingResolution(trackableId: String, resolution: Resolution) =
+        updatingResolutions[trackableId]?.contains(resolution) == true
+
+    fun isLastUpdatingResolution(trackableId: String, resolution: Resolution) =
+        updatingResolutions[trackableId]?.last() == resolution
+
+    fun removeUpdatingResolution(trackableId: String, resolution: Resolution) {
+        updatingResolutions[trackableId]?.remove(resolution)
+        if (updatingResolutions[trackableId]?.isEmpty() == true) {
+            updatingResolutions.remove(trackableId)
+        }
+    }
 
     fun copy(): PublisherProperties =
         PublisherProperties(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -48,6 +48,7 @@ import com.ably.tracking.publisher.workerqueue.workers.StopWorker
 import com.ably.tracking.publisher.workerqueue.workers.StoppingConnectionFinishedWorker
 import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
 import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalSuccessWorker
+import com.ably.tracking.publisher.workerqueue.workers.UpdateResolutionSuccessWorker
 import com.ably.tracking.publisher.workerqueue.workers.UpdateResolutionWorker
 import kotlinx.coroutines.flow.StateFlow
 
@@ -143,6 +144,10 @@ internal class WorkerFactory(
                 workerSpecification.trackableId,
                 workerSpecification.resolution,
                 ably
+            )
+            is WorkerSpecification.UpdateResolutionSuccess -> UpdateResolutionSuccessWorker(
+                workerSpecification.trackableId,
+                workerSpecification.resolution
             )
             is WorkerSpecification.ChangeRoutingProfile -> ChangeRoutingProfileWorker(
                 workerSpecification.routingProfile,
@@ -240,6 +245,11 @@ internal sealed class WorkerSpecification {
     object ChangeLocationEngineResolution : WorkerSpecification()
 
     data class UpdateResolution(
+        val trackableId: String,
+        val resolution: Resolution
+    ) : WorkerSpecification()
+
+    data class UpdateResolutionSuccess(
         val trackableId: String,
         val resolution: Resolution
     ) : WorkerSpecification()

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -5,10 +5,10 @@ import com.ably.tracking.ErrorInformation
 import com.ably.tracking.Location
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.LocationUpdateType
+import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.ConnectionStateChange
-import com.ably.tracking.common.PresenceData
 import com.ably.tracking.common.ResultCallbackFunction
 import com.ably.tracking.common.TimeProvider
 import com.ably.tracking.common.workerqueue.Worker
@@ -48,7 +48,7 @@ import com.ably.tracking.publisher.workerqueue.workers.StopWorker
 import com.ably.tracking.publisher.workerqueue.workers.StoppingConnectionFinishedWorker
 import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalRequestedWorker
 import com.ably.tracking.publisher.workerqueue.workers.TrackableRemovalSuccessWorker
-import com.ably.tracking.publisher.workerqueue.workers.UpdatePresenceDataWorker
+import com.ably.tracking.publisher.workerqueue.workers.UpdateResolutionWorker
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -139,9 +139,9 @@ internal class WorkerFactory(
                 resolutionPolicy,
                 mapbox,
             )
-            is WorkerSpecification.UpdatePresenceData -> UpdatePresenceDataWorker(
+            is WorkerSpecification.UpdateResolution -> UpdateResolutionWorker(
                 workerSpecification.trackableId,
-                workerSpecification.presenceData,
+                workerSpecification.resolution,
                 ably
             )
             is WorkerSpecification.ChangeRoutingProfile -> ChangeRoutingProfileWorker(
@@ -239,9 +239,9 @@ internal sealed class WorkerSpecification {
 
     object ChangeLocationEngineResolution : WorkerSpecification()
 
-    data class UpdatePresenceData(
+    data class UpdateResolution(
         val trackableId: String,
-        val presenceData: PresenceData,
+        val resolution: Resolution
     ) : WorkerSpecification()
 
     data class ChangeRoutingProfile(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdatePresenceDataWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdatePresenceDataWorker.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.publisher.workerqueue.workers
 
 import com.ably.tracking.common.Ably
 import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.isFatalAblyFailure
 import com.ably.tracking.common.workerqueue.DefaultWorker
 import com.ably.tracking.publisher.PublisherProperties
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
@@ -18,12 +19,20 @@ internal class UpdatePresenceDataWorker(
         postWork: (WorkerSpecification) -> Unit
     ): PublisherProperties {
         doAsyncWork {
-            val waitResult = ably.waitForChannelToAttach(trackableId)
-            if (waitResult.isSuccess) {
-                // For now we ignore the result of this operation but perhaps we should retry it if it fails
-                ably.updatePresenceData(trackableId, presenceData)
+            val result = waitAndUpdatePresence()
+            if (result.isFailure && !result.isFatalAblyFailure()) {
+                postWork(WorkerSpecification.UpdatePresenceData(trackableId, presenceData))
             }
         }
         return properties
+    }
+
+    private suspend fun waitAndUpdatePresence(): Result<Unit> {
+        val waitResult = ably.waitForChannelToAttach(trackableId)
+        return if (waitResult.isSuccess) {
+            ably.updatePresenceData(trackableId, presenceData)
+        } else {
+            waitResult
+        }
     }
 }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionSuccessWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionSuccessWorker.kt
@@ -1,0 +1,21 @@
+package com.ably.tracking.publisher.workerqueue.workers
+
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.workerqueue.DefaultWorker
+import com.ably.tracking.publisher.PublisherProperties
+import com.ably.tracking.publisher.workerqueue.WorkerSpecification
+
+internal class UpdateResolutionSuccessWorker(
+    private val trackableId: String,
+    private val resolution: Resolution
+) : DefaultWorker<PublisherProperties, WorkerSpecification>() {
+
+    override fun doWork(
+        properties: PublisherProperties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): PublisherProperties {
+        properties.removeUpdatingResolution(trackableId, resolution)
+        return properties
+    }
+}

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
@@ -23,18 +23,26 @@ internal class UpdateResolutionWorker(
             properties.addUpdatingResolution(trackableId, resolution)
         }
         if (properties.isLastUpdatingResolution(trackableId, resolution)) {
-            doAsyncWork {
-                val result = waitAndUpdatePresence(properties.presenceData)
-                if (result.isFailure && !result.isFatalAblyFailure()) {
-                    postWork(WorkerSpecification.UpdateResolution(trackableId, resolution))
-                } else {
-                    postWork(WorkerSpecification.UpdateResolutionSuccess(trackableId, resolution))
-                }
-            }
+            waitAndUpdatePresenceAsync(doAsyncWork, properties, postWork)
         } else {
             properties.removeUpdatingResolution(trackableId, resolution)
         }
         return properties
+    }
+
+    private fun waitAndUpdatePresenceAsync(
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        properties: PublisherProperties,
+        postWork: (WorkerSpecification) -> Unit
+    ) {
+        doAsyncWork {
+            val result = waitAndUpdatePresence(properties.presenceData)
+            if (result.isFailure && !result.isFatalAblyFailure()) {
+                postWork(WorkerSpecification.UpdateResolution(trackableId, resolution))
+            } else {
+                postWork(WorkerSpecification.UpdateResolutionSuccess(trackableId, resolution))
+            }
+        }
     }
 
     private suspend fun waitAndUpdatePresence(presenceData: PresenceData): Result<Unit> {

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
@@ -19,19 +19,20 @@ internal class UpdateResolutionWorker(
         doAsyncWork: (suspend () -> Unit) -> Unit,
         postWork: (WorkerSpecification) -> Unit
     ): PublisherProperties {
-        val updatingResolutions = properties.updatingResolutions
-        if (!updatingResolutions.contains(resolution)) {
-            updatingResolutions.add(resolution)
+        if (!properties.containsUpdatingResolution(trackableId, resolution)) {
+            properties.addUpdatingResolution(trackableId, resolution)
         }
-        if (updatingResolutions.last() == resolution) {
+        if (properties.isLastUpdatingResolution(trackableId, resolution)) {
             doAsyncWork {
                 val result = waitAndUpdatePresence(properties.presenceData)
                 if (result.isFailure && !result.isFatalAblyFailure()) {
                     postWork(WorkerSpecification.UpdateResolution(trackableId, resolution))
+                } else {
+                    postWork(WorkerSpecification.UpdateResolutionSuccess(trackableId, resolution))
                 }
             }
         } else {
-            updatingResolutions.remove(resolution)
+            properties.removeUpdatingResolution(trackableId, resolution)
         }
         return properties
     }

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorker.kt
@@ -22,11 +22,13 @@ internal class UpdateResolutionWorker(
         if (!properties.containsUpdatingResolution(trackableId, resolution)) {
             properties.addUpdatingResolution(trackableId, resolution)
         }
-        if (properties.isLastUpdatingResolution(trackableId, resolution)) {
-            waitAndUpdatePresenceAsync(doAsyncWork, properties, postWork)
-        } else {
+
+        if (!properties.isLastUpdatingResolution(trackableId, resolution)) {
             properties.removeUpdatingResolution(trackableId, resolution)
+            return properties
         }
+
+        waitAndUpdatePresenceAsync(doAsyncWork, properties, postWork)
         return properties
     }
 

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorkerTest.kt
@@ -1,7 +1,8 @@
 package com.ably.tracking.publisher.workerqueue.workers
 
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
 import com.ably.tracking.common.Ably
-import com.ably.tracking.common.PresenceData
 import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 import com.ably.tracking.test.common.mockUpdatePresenceDataFailure
 import com.ably.tracking.test.common.mockUpdatePresenceDataSuccess
@@ -16,14 +17,14 @@ import org.junit.Assert
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class UpdatePresenceDataWorkerTest {
+class UpdateResolutionWorkerTest {
 
     private val ably: Ably = mockk()
     private val trackableId = "testtrackable"
 
-    private val presenceData: PresenceData = mockk()
+    private val resolution: Resolution = Resolution(Accuracy.BALANCED, 100L, 100.0)
 
-    private val worker = UpdatePresenceDataWorker(trackableId, presenceData, ably)
+    private val worker = UpdateResolutionWorker(trackableId, resolution, ably)
 
     private val initialProperties = createPublisherProperties()
     private val asyncWorks = mutableListOf<suspend () -> Unit>()
@@ -47,7 +48,7 @@ class UpdatePresenceDataWorkerTest {
             asyncWorks.executeAll()
 
             coVerify {
-                ably.updatePresenceData(trackableId, presenceData)
+                ably.updatePresenceData(trackableId, match { it.resolution == resolution })
             }
         }
     }
@@ -69,10 +70,10 @@ class UpdatePresenceDataWorkerTest {
             asyncWorks.executeAll()
 
             coVerify(exactly = 0) {
-                ably.updatePresenceData(trackableId, presenceData)
+                ably.updatePresenceData(trackableId, any())
             }
-            val postedWorker = postedWorks[0] as WorkerSpecification.UpdatePresenceData
-            assertThat(postedWorker.presenceData).isEqualTo(presenceData)
+            val postedWorker = postedWorks[0] as WorkerSpecification.UpdateResolution
+            assertThat(postedWorker.resolution).isEqualTo(resolution)
             assertThat(postedWorker.trackableId).isEqualTo(trackableId)
         }
     }
@@ -117,8 +118,8 @@ class UpdatePresenceDataWorkerTest {
             // then
             asyncWorks.executeAll()
 
-            val postedWorker = postedWorks[0] as WorkerSpecification.UpdatePresenceData
-            assertThat(postedWorker.presenceData).isEqualTo(presenceData)
+            val postedWorker = postedWorks[0] as WorkerSpecification.UpdateResolution
+            assertThat(postedWorker.resolution).isEqualTo(resolution)
             assertThat(postedWorker.trackableId).isEqualTo(trackableId)
         }
     }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/UpdateResolutionWorkerTest.kt
@@ -79,6 +79,32 @@ class UpdateResolutionWorkerTest {
     }
 
     @Test
+    fun `should not call updatePresenceData, not post work and remove resolution from properties when newer resolution is present`() {
+        runTest {
+            // given
+            initialProperties.updatingResolutions.add(resolution)
+            initialProperties.updatingResolutions.add(Resolution(Accuracy.HIGH, 50L, 50.0))
+            ably.mockWaitForChannelToAttachFailure(trackableId)
+
+            // when
+            val updatedProperties = worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.executeAll()
+            assertThat(postedWorks).isEmpty()
+
+            assertThat(updatedProperties.updatingResolutions).doesNotContain(resolution)
+            coVerify(exactly = 0) {
+                ably.updatePresenceData(trackableId, any())
+            }
+        }
+    }
+
+    @Test
     fun `should not throw any exception when updatePresenceData returns failure`() {
         runTest {
             // given

--- a/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
+++ b/subscribing-example-app/src/androidTest/java/com/ably/tracking/example/subscriber/ExampleUsage.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 // PLACEHOLDERS:
@@ -62,14 +61,11 @@ fun exampleUsage(trackingId: String) {
         }
         .launchIn(scope)
     // Request a different resolution when needed.
-    scope.launch {
-        try {
-            subscriber.resolutionPreference(
-                Resolution(Accuracy.MAXIMUM, desiredInterval = 100L, minimumDisplacement = 2.0)
-            )
-            // change request submitted successfully
-        } catch (exception: Exception) {
-            // change request could not be submitted
-        }
-    }
+    subscriber.sendResolutionPreference(
+        Resolution(
+            Accuracy.MAXIMUM,
+            desiredInterval = 100L,
+            minimumDisplacement = 2.0
+        )
+    )
 }

--- a/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
+++ b/subscribing-example-app/src/main/java/com/ably/tracking/example/subscriber/MainActivity.kt
@@ -217,20 +217,16 @@ class MainActivity : AppCompatActivity() {
         googleMap?.cameraPosition?.zoom?.let {
             val newResolution = getResolutionForZoomLevel(it)
             if (newResolution != resolution) {
-                scope.launch { changeResolution(newResolution) }
+                changeResolution(newResolution)
             }
         }
     }
 
-    private suspend fun changeResolution(newResolution: Resolution) {
+    private fun changeResolution(newResolution: Resolution) {
         subscriber?.let {
-            try {
-                it.resolutionPreference(newResolution)
-                resolution = newResolution
-                updateResolutionInfo(newResolution)
-            } catch (exception: Exception) {
-                showToast(R.string.error_changing_resolution_failed)
-            }
+            it.sendResolutionPreference(newResolution)
+            resolution = newResolution
+            updateResolutionInfo(newResolution)
         }
     }
 

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -21,9 +21,14 @@ internal class DefaultSubscriberFacade(
 ) : SubscriberFacade, Subscriber by subscriber {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Use sendResolutionPreferenceAsync instead")
     override fun resolutionPreferenceAsync(resolution: Resolution?): CompletableFuture<Void> {
         return scope.future { subscriber.resolutionPreference(resolution) }.thenRun { }
     }
+
+    override fun sendResolutionPreferenceAsync(resolution: Resolution?) =
+        subscriber.sendResolutionPreference(resolution)
 
     override fun addLocationListener(listener: LocationUpdateListener) {
         subscriber.locations

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -31,7 +31,22 @@ interface SubscriberFacade : Subscriber {
      *
      * @return A [CompletableFuture] that completes when the request has been completed.
      */
+    @Deprecated("Use sendResolutionPreferenceAsync instead")
     fun resolutionPreferenceAsync(resolution: Resolution?): CompletableFuture<Void>
+
+    /**
+     * Sends the preferred resolution for updates, to be requested from the remote publisher.
+     * Returns immediately, letting the request to be processed asynchronously.
+     *
+     * An initial resolution may be defined from the outset of a [Subscriber]'s lifespan by using the
+     * [resolution][Builder.resolution] method on the [Builder] instance used to [start][Builder.start] it.
+     *
+     * Requests sent using this method will take time to propagate back to the publisher.
+     *
+     * @param resolution The preferred resolution or null if has no resolution preference.
+     *
+     */
+    fun sendResolutionPreferenceAsync(resolution: Resolution?)
 
     /**
      * Adds a handler to be notified when an enhanced location update is available.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -65,12 +65,13 @@ internal class DefaultSubscriber(
         }
     }
 
+    @Deprecated("Use sendResolutionPreference instead")
     override suspend fun resolutionPreference(resolution: Resolution?) {
         logHandler?.v("$TAG Subscriber resolutionPreference operation started")
         // send change request over channel and wait for the result
         suspendCoroutine<Unit> { continuation ->
             core.enqueue(
-                WorkerSpecification.ChangeResolution(
+                WorkerSpecification.DeprecatedChangeResolution(
                     resolution,
                     continuation.wrapInResultCallback(
                         onSuccess = { logHandler?.v("$TAG Subscriber resolutionPreference operation succeeded") },
@@ -79,6 +80,10 @@ internal class DefaultSubscriber(
                 )
             )
         }
+    }
+
+    override fun sendResolutionPreference(resolution: Resolution?) {
+        core.enqueue(WorkerSpecification.ChangeResolution(resolution))
     }
 
     override suspend fun stop() {

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -43,7 +43,21 @@ interface Subscriber {
      * @throws ConnectionException If something goes wrong when sending the preferred resolution.
      */
     @JvmSynthetic
+    @Deprecated("Use sendResolutionPreference instead")
     suspend fun resolutionPreference(resolution: Resolution?)
+
+    /**
+     * Sends the preferred resolution for updates, to be requested from the remote publisher.
+     * Returns immediately, letting the request to be processed asynchronously.
+     *
+     * An initial resolution may be defined from the outset of a [Subscriber]'s lifespan by using the
+     * [resolution][Builder.resolution] method on the [Builder] instance used to [start][Builder.start] it.
+     *
+     * Requests sent using this method will take time to propagate back to the publisher.
+     *
+     * @param resolution The preferred resolution or null if has no resolution preference.
+     */
+    fun sendResolutionPreference(resolution: Resolution?)
 
     /**
      * The shared flow emitting enhanced location values when they become available.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
@@ -10,6 +10,7 @@ import com.ably.tracking.common.workerqueue.WorkerFactory
 import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberInteractor
 import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionWorker
+import com.ably.tracking.subscriber.workerqueue.workers.DeprecatedChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DisconnectWorker
 import com.ably.tracking.subscriber.workerqueue.workers.ProcessInitialPresenceMessagesWorker
 import com.ably.tracking.subscriber.workerqueue.workers.StartConnectionWorker
@@ -59,11 +60,16 @@ internal class WorkerFactory(
             is WorkerSpecification.UpdatePublisherPresence -> UpdatePublisherPresenceWorker(
                 workerSpecification.presenceMessage
             )
-            is WorkerSpecification.ChangeResolution -> ChangeResolutionWorker(
+            is WorkerSpecification.DeprecatedChangeResolution -> DeprecatedChangeResolutionWorker(
                 ably,
                 trackableId,
                 workerSpecification.resolution,
                 workerSpecification.callbackFunction
+            )
+            is WorkerSpecification.ChangeResolution -> ChangeResolutionWorker(
+                ably,
+                trackableId,
+                workerSpecification.resolution
             )
             is WorkerSpecification.Disconnect -> DisconnectWorker(
                 ably,
@@ -95,9 +101,13 @@ internal sealed class WorkerSpecification {
         val presenceMessage: PresenceMessage
     ) : WorkerSpecification()
 
-    data class ChangeResolution(
+    data class DeprecatedChangeResolution(
         val resolution: Resolution?,
         val callbackFunction: ResultCallbackFunction<Unit>
+    ) : WorkerSpecification()
+
+    data class ChangeResolution(
+        val resolution: Resolution?
     ) : WorkerSpecification()
 
     data class StartConnection(

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
@@ -9,6 +9,7 @@ import com.ably.tracking.common.workerqueue.Worker
 import com.ably.tracking.common.workerqueue.WorkerFactory
 import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.SubscriberInteractor
+import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionSuccessWorker
 import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DeprecatedChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DisconnectWorker
@@ -71,6 +72,10 @@ internal class WorkerFactory(
                 trackableId,
                 workerSpecification.resolution
             )
+            is WorkerSpecification.ChangeResolutionSuccess -> ChangeResolutionSuccessWorker(
+                trackableId,
+                workerSpecification.resolution
+            )
             is WorkerSpecification.Disconnect -> DisconnectWorker(
                 ably,
                 workerSpecification.trackableId,
@@ -107,6 +112,10 @@ internal sealed class WorkerSpecification {
     ) : WorkerSpecification()
 
     data class ChangeResolution(
+        val resolution: Resolution?
+    ) : WorkerSpecification()
+
+    data class ChangeResolutionSuccess(
         val resolution: Resolution?
     ) : WorkerSpecification()
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionSuccessWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionSuccessWorker.kt
@@ -1,0 +1,20 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.workerqueue.DefaultWorker
+import com.ably.tracking.subscriber.SubscriberProperties
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+
+internal class ChangeResolutionSuccessWorker(
+    private val trackableId: String,
+    private val resolution: Resolution?
+) : DefaultWorker<SubscriberProperties, WorkerSpecification>() {
+    override fun doWork(
+        properties: SubscriberProperties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): SubscriberProperties {
+        properties.removeUpdatingResolution(trackableId, resolution)
+        return properties
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorker.kt
@@ -2,29 +2,38 @@ package com.ably.tracking.subscriber.workerqueue.workers
 
 import com.ably.tracking.Resolution
 import com.ably.tracking.common.Ably
-import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.isFatalAblyFailure
 import com.ably.tracking.subscriber.SubscriberProperties
-import com.ably.tracking.common.workerqueue.CallbackWorker
+import com.ably.tracking.common.workerqueue.DefaultWorker
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 
 internal class ChangeResolutionWorker(
     private val ably: Ably,
     private val trackableId: String,
-    private val resolution: Resolution?,
-    callbackFunction: ResultCallbackFunction<Unit>
-) : CallbackWorker<SubscriberProperties, WorkerSpecification>(callbackFunction) {
+    private val resolution: Resolution?
+) : DefaultWorker<SubscriberProperties, WorkerSpecification>() {
     override fun doWork(
         properties: SubscriberProperties,
         doAsyncWork: (suspend () -> Unit) -> Unit,
         postWork: (WorkerSpecification) -> Unit
     ): SubscriberProperties {
         properties.presenceData = properties.presenceData.copy(resolution = resolution)
-
         doAsyncWork {
-            val result = ably.updatePresenceData(trackableId, properties.presenceData)
-            callbackFunction(result)
+            val result = waitAndUpdatePresence(properties.presenceData)
+            if (result.isFailure && !result.isFatalAblyFailure()) {
+                postWork(WorkerSpecification.ChangeResolution(resolution))
+            }
         }
-
         return properties
+    }
+
+    private suspend fun waitAndUpdatePresence(presenceData: PresenceData): Result<Unit> {
+        val waitResult = ably.waitForChannelToAttach(trackableId)
+        return if (waitResult.isSuccess) {
+            ably.updatePresenceData(trackableId, presenceData)
+        } else {
+            waitResult
+        }
     }
 }

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/ChangeResolutionWorker.kt
@@ -18,15 +18,18 @@ internal class ChangeResolutionWorker(
         doAsyncWork: (suspend () -> Unit) -> Unit,
         postWork: (WorkerSpecification) -> Unit
     ): SubscriberProperties {
-        properties.presenceData = properties.presenceData.copy(resolution = resolution)
         if (!properties.containsUpdatingResolution(trackableId, resolution)) {
             properties.addUpdatingResolution(trackableId, resolution)
         }
-        if (properties.isLastUpdatingResolution(trackableId, resolution)) {
-            waitAndUpdatePresenceAsync(doAsyncWork, properties, postWork)
-        } else {
+
+        if (!properties.isLastUpdatingResolution(trackableId, resolution)) {
             properties.removeUpdatingResolution(trackableId, resolution)
+            return properties
         }
+
+        properties.presenceData = properties.presenceData.copy(resolution = resolution)
+        waitAndUpdatePresenceAsync(doAsyncWork, properties, postWork)
+
         return properties
     }
 

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/DeprecatedChangeResolutionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/DeprecatedChangeResolutionWorker.kt
@@ -1,0 +1,30 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.SubscriberProperties
+import com.ably.tracking.common.workerqueue.CallbackWorker
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+
+internal class DeprecatedChangeResolutionWorker(
+    private val ably: Ably,
+    private val trackableId: String,
+    private val resolution: Resolution?,
+    callbackFunction: ResultCallbackFunction<Unit>
+) : CallbackWorker<SubscriberProperties, WorkerSpecification>(callbackFunction) {
+    override fun doWork(
+        properties: SubscriberProperties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): SubscriberProperties {
+        properties.presenceData = properties.presenceData.copy(resolution = resolution)
+
+        doAsyncWork {
+            val result = ably.updatePresenceDataWithRetry(trackableId, properties.presenceData)
+            callbackFunction(result)
+        }
+
+        return properties
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DeprecatedChangeResolutionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/DeprecatedChangeResolutionWorkerTest.kt
@@ -1,0 +1,41 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ResultCallbackFunction
+import com.ably.tracking.subscriber.SubscriberProperties
+import com.ably.tracking.test.common.mockUpdatePresenceDataSuccess
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class DeprecatedChangeResolutionWorkerTest {
+
+    private val ably: Ably = mockk()
+    private val trackableId = "123123"
+    private val updatedResolution = Resolution(Accuracy.HIGH, 10, 10.0)
+    private val callbackFunction: ResultCallbackFunction<Unit> = mockk(relaxed = true)
+    private val deprecatedChangeResolutionWorker = DeprecatedChangeResolutionWorker(ably, trackableId, updatedResolution, callbackFunction)
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+
+    @Test
+    fun `should return Properties with updated resolution and notify callback`() = runTest {
+        // given
+        val initialProperties = SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())
+        ably.mockUpdatePresenceDataSuccess(trackableId)
+
+        // when
+        val updatedProperties = deprecatedChangeResolutionWorker.doWork(initialProperties, asyncWorks.appendWork()) {}
+        asyncWorks.executeAll()
+
+        // then
+        Assert.assertEquals(updatedResolution, updatedProperties.presenceData.resolution)
+        verify { callbackFunction.invoke(match { it.isSuccess }) }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
@@ -1,6 +1,10 @@
 package com.ably.tracking.subscriber.workerqueue.workers
 
+import com.ably.tracking.Accuracy
+import com.ably.tracking.Resolution
+import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import io.mockk.mockk
 
 fun MutableList<suspend () -> Unit>.appendWork(): (suspend () -> Unit) -> Unit =
     { asyncWork ->
@@ -15,3 +19,6 @@ internal fun MutableList<WorkerSpecification>.appendSpecification(): (WorkerSpec
     { workSpecification ->
         add(workSpecification)
     }
+
+internal fun createSubscriberProperties() =
+    SubscriberProperties(Resolution(Accuracy.BALANCED, 100, 100.0), mockk())

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -147,22 +147,10 @@ fun Ably.mockSendEnhancedLocationFailureThenSuccess(trackableId: String) {
 }
 
 fun Ably.mockUpdatePresenceDataSuccess(trackableId: String) {
-    val callbackSlot = slot<(Result<Unit>) -> Unit>()
-    every {
-        updatePresenceData(trackableId, any(), capture(callbackSlot))
-    } answers {
-        callbackSlot.captured(Result.success(Unit))
-    }
     coEvery { updatePresenceData(trackableId, any()) } returns Result.success(Unit)
 }
 
 fun Ably.mockUpdatePresenceDataFailure(trackableId: String) {
-    val callbackSlot = slot<(Result<Unit>) -> Unit>()
-    every {
-        updatePresenceData(trackableId, any(), capture(callbackSlot))
-    } answers {
-        callbackSlot.captured(Result.failure(anyConnectionException()))
-    }
     coEvery { updatePresenceData(trackableId, any()) } returns Result.failure(anyConnectionException())
 }
 

--- a/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
+++ b/test-common/src/main/java/com/ably/tracking/test/common/AblyTestExtensions.kt
@@ -147,10 +147,12 @@ fun Ably.mockSendEnhancedLocationFailureThenSuccess(trackableId: String) {
 }
 
 fun Ably.mockUpdatePresenceDataSuccess(trackableId: String) {
+    coEvery { updatePresenceDataWithRetry(trackableId, any()) } returns Result.success(Unit)
     coEvery { updatePresenceData(trackableId, any()) } returns Result.success(Unit)
 }
 
 fun Ably.mockUpdatePresenceDataFailure(trackableId: String) {
+    coEvery { updatePresenceDataWithRetry(trackableId, any()) } returns Result.failure(anyConnectionException())
     coEvery { updatePresenceData(trackableId, any()) } returns Result.failure(anyConnectionException())
 }
 


### PR DESCRIPTION
Update resolution retries implemented on the worker queue level. 
Old approach annotated in subscriber as `deprecated.` After removing it, the old retry code can be removed.
Added `updatingResolutions` map to the `Properties` object to handle race scenarios when another update is sent before the scheduled update retry, resulting in an overwrite.

Resolves #962 #980 