### PR TITLE
Remove reference to RetryEnterPresenceWorker

### DIFF
--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/WorkerFactory.kt
@@ -86,10 +86,6 @@ internal class WorkerFactory(
                 workerSpecification.trackable,
                 ably,
             )
-            is WorkerSpecification.RetryEnterPresence -> EnterPresenceWorker(
-                workerSpecification.trackable,
-                ably
-            )
             is WorkerSpecification.EnterPresenceSuccess -> EnterPresenceSuccessWorker(
                 workerSpecification.trackable,
                 publisherInteractor
@@ -265,10 +261,6 @@ internal sealed class WorkerSpecification {
 
     data class EnterPresence(
         val trackable: Trackable,
-    ) : WorkerSpecification()
-
-    data class RetryEnterPresence(
-        val trackable: Trackable
     ) : WorkerSpecification()
 
     data class EnterPresenceSuccess(

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
@@ -72,7 +72,7 @@ internal class EnterPresenceWorker(
             )
             else -> {
                 delay(PRESENCE_ENTER_DELAY_IN_MILLISECONDS)
-                postWork(WorkerSpecification.RetryEnterPresence(trackable))
+                postWork(WorkerSpecification.EnterPresence(trackable))
             }
         }
     }
@@ -95,6 +95,6 @@ internal class EnterPresenceWorker(
         exception: Exception,
         postWork: (WorkerSpecification) -> Unit
     ) {
-        postWork(WorkerSpecification.RetryEnterPresence(trackable))
+        postWork(WorkerSpecification.EnterPresence(trackable))
     }
 }

--- a/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorkerTest.kt
+++ b/publishing-sdk/src/test/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorkerTest.kt
@@ -35,7 +35,7 @@ class EnterPresenceWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should post RetryEnterPresenceSuccess work when connection succeeded`() {
+    fun `should post EnterPresenceSuccess work when connection succeeded`() {
         runTest {
             // given
             val initialProperties = createPublisherProperties()
@@ -105,7 +105,7 @@ class EnterPresenceWorkerTest {
     }
 
     @Test
-    fun `should post RetryEnterPresence work after delay when connection failed with a non-fatal error`() {
+    fun `should post EnterPresence work after delay when connection failed with a non-fatal error`() {
         runTest(context = UnconfinedTestDispatcher()) {
             // given
             val initialProperties = createPublisherProperties()
@@ -128,7 +128,7 @@ class EnterPresenceWorkerTest {
             advanceUntilIdle()
 
             assertThat(postedWorks)
-                .contains(WorkerSpecification.RetryEnterPresence(trackable))
+                .contains(WorkerSpecification.EnterPresence(trackable))
         }
     }
 
@@ -157,7 +157,7 @@ class EnterPresenceWorkerTest {
     }
 
     @Test
-    fun `should post RetryEnterPresence work when connection failed with a fatal error with 91001 error code`() {
+    fun `should post EnterPresence work when connection failed with a fatal error with 91001 error code`() {
         runTest {
             // given
             val initialProperties = createPublisherProperties()
@@ -180,7 +180,7 @@ class EnterPresenceWorkerTest {
             advanceUntilIdle()
 
             assertThat(postedWorks)
-                .contains(WorkerSpecification.RetryEnterPresence(trackable))
+                .contains(WorkerSpecification.EnterPresence(trackable))
         }
     }
 


### PR DESCRIPTION
It was removed prior to 1.6.1 and the worker specification just proxies to EnterPresence, so remove it.