### PR TITLE
Subscriber enter failed fault

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
@@ -64,7 +64,6 @@ class FaultSimulation(
         "TcpConnectionUnresponsive",
         "DisconnectAndSuspend",
         "EnterUnresponsive",
-        "EnterFailedWithNonfatalNack",
         "UpdateFailedWithNonfatalNack",
         "ReenterOnResumeFailed",
     )

--- a/common/src/main/java/com/ably/tracking/common/Ably.kt
+++ b/common/src/main/java/com/ably/tracking/common/Ably.kt
@@ -45,6 +45,13 @@ import kotlin.coroutines.suspendCoroutine
  * Wrapper for the [AblyRealtime] that's used to interact with the Ably SDK.
  */
 interface Ably {
+
+    companion object {
+        /**
+         * Error code specific to enter presence on a suspended channel error
+         */
+        const val ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE = 91_001
+    }
     /**
      * Adds a listener for the [AblyRealtime] state updates.
      *

--- a/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
+++ b/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/EnterPresenceWorker.kt
@@ -11,11 +11,6 @@ import com.ably.tracking.publisher.workerqueue.WorkerSpecification
 import kotlinx.coroutines.delay
 
 /**
- * Error code specific to enter presence on a suspended channel error
- */
-private const val ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE = 91_001
-
-/**
  * How long should we wait before queueing enter retry presence work if enter presence fails.
  */
 private const val PRESENCE_ENTER_DELAY_IN_MILLISECONDS = 15_000L
@@ -80,7 +75,7 @@ internal class EnterPresenceWorker(
     private fun isFatalFailure(result: Result<Unit>): Boolean {
         val connectionException = result.exceptionOrNull() as? ConnectionException
         return connectionException != null && connectionException.isFatal() &&
-            connectionException.errorInformation.code != ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE
+            connectionException.errorInformation.code != Ably.ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE
     }
 
     private fun postFailTrackableWork(

--- a/subscribing-sdk/src/androidTest/java/com/ably/tracking/subscriber/NetworkConnectivityTests.kt
+++ b/subscribing-sdk/src/androidTest/java/com/ably/tracking/subscriber/NetworkConnectivityTests.kt
@@ -126,7 +126,7 @@ class NetworkConnectivityTests(private val testFault: Fault) {
             subscriberResolution = subscriberResolution,
             subscriberResolutionPreferenceFlow = subscriberResolutions
         ).waitForStateTransition {
-            // Connect up a publisher to do publisher things
+            // Connect up a subscriber to do subscriber things
             defaultAbly.updatePresenceData(
                 trackableId,
                 PresenceData(ClientTypes.PUBLISHER, publisherResolution, false)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/WorkerFactory.kt
@@ -13,6 +13,7 @@ import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionSuccessW
 import com.ably.tracking.subscriber.workerqueue.workers.ChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DeprecatedChangeResolutionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.DisconnectWorker
+import com.ably.tracking.subscriber.workerqueue.workers.EnterPresenceWorker
 import com.ably.tracking.subscriber.workerqueue.workers.ProcessInitialPresenceMessagesWorker
 import com.ably.tracking.subscriber.workerqueue.workers.StartConnectionWorker
 import com.ably.tracking.subscriber.workerqueue.workers.StopConnectionWorker
@@ -43,6 +44,7 @@ internal class WorkerFactory(
                 trackableId,
                 workerSpecification.callbackFunction
             )
+            is WorkerSpecification.EnterPresence -> EnterPresenceWorker(workerSpecification.trackableId, ably)
             is WorkerSpecification.SubscribeForPresenceMessages -> SubscribeForPresenceMessagesWorker(
                 ably,
                 trackableId,
@@ -122,6 +124,8 @@ internal sealed class WorkerSpecification {
     data class StartConnection(
         val callbackFunction: ResultCallbackFunction<Unit>
     ) : WorkerSpecification()
+
+    data class EnterPresence(val trackableId: String) : WorkerSpecification()
 
     data class SubscribeForPresenceMessages(
         val callbackFunction: ResultCallbackFunction<Unit>

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/EnterPresenceWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/EnterPresenceWorker.kt
@@ -1,0 +1,75 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.common.isFatal
+import com.ably.tracking.common.workerqueue.DefaultWorker
+import com.ably.tracking.subscriber.SubscriberProperties
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import kotlinx.coroutines.delay
+
+/**
+ * How long should we wait before queueing enter retry presence work if enter presence fails.
+ */
+private const val PRESENCE_ENTER_DELAY_IN_MILLISECONDS = 15_000L
+
+internal class EnterPresenceWorker(
+    private val trackableId: String,
+    private val ably: Ably
+) : DefaultWorker<SubscriberProperties, WorkerSpecification>() {
+
+    override fun doWork(
+        properties: SubscriberProperties,
+        doAsyncWork: (suspend () -> Unit) -> Unit,
+        postWork: (WorkerSpecification) -> Unit
+    ): SubscriberProperties {
+        doAsyncWork {
+            enterPresence(postWork, properties.presenceData)
+        }
+
+        return properties
+    }
+
+    private suspend fun enterPresence(
+        postWork: (WorkerSpecification) -> Unit,
+        presenceData: PresenceData
+    ) {
+        val waitForChannelToAttachResult = ably.waitForChannelToAttach(trackableId)
+        if (waitForChannelToAttachResult.isFailure) {
+            postDisconnectWork(postWork)
+            return
+        }
+
+        val enterPresenceResult = ably.enterChannelPresence(
+            trackableId = trackableId,
+            presenceData = presenceData
+        )
+
+        val enterPresenceThrowable = enterPresenceResult.exceptionOrNull()
+        if (enterPresenceThrowable != null) {
+            if (isFatalFailure(enterPresenceThrowable)) {
+                postDisconnectWork(postWork)
+            } else {
+                delay(PRESENCE_ENTER_DELAY_IN_MILLISECONDS)
+                postWork(WorkerSpecification.EnterPresence(trackableId))
+            }
+        }
+    }
+
+    private fun isFatalFailure(throwable: Throwable): Boolean =
+        throwable is ConnectionException && throwable.isFatal() && throwable.errorInformation.code != Ably.ENTER_PRESENCE_ON_SUSPENDED_CHANNEL_ERROR_CODE
+
+    private fun postDisconnectWork(postWork: (WorkerSpecification) -> Unit) {
+        postWork(
+            WorkerSpecification.Disconnect(trackableId) {}
+        )
+    }
+
+    override fun onUnexpectedAsyncError(
+        exception: Exception,
+        postWork: (WorkerSpecification) -> Unit
+    ) {
+        postWork(WorkerSpecification.EnterPresence(trackableId))
+    }
+}

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorker.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorker.kt
@@ -17,12 +17,11 @@ internal class StartConnectionWorker(
         postWork: (WorkerSpecification) -> Unit
     ): SubscriberProperties {
         properties.emitStateEventsIfRequired()
-        doAsyncWork { connectAndEnterPresence(properties, postWork) }
+        doAsyncWork { connectAndEnterPresence(postWork) }
         return properties
     }
 
     private suspend fun connectAndEnterPresence(
-        properties: SubscriberProperties,
         postWork: (WorkerSpecification) -> Unit
     ) {
         val startAblyConnectionResult = ably.startConnection()
@@ -41,12 +40,7 @@ internal class StartConnectionWorker(
             return
         }
 
-        val enterPresenceResult = ably.enterChannelPresence(trackableId, properties.presenceData)
-
-        if (enterPresenceResult.isSuccess) {
-            postWork(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction))
-        } else {
-            callbackFunction(enterPresenceResult)
-        }
+        postWork(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction))
+        postWork(WorkerSpecification.EnterPresence(trackableId))
     }
 }

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/EnterPresenceWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/EnterPresenceWorkerTest.kt
@@ -1,0 +1,186 @@
+package com.ably.tracking.subscriber.workerqueue.workers
+
+import com.ably.tracking.ConnectionException
+import com.ably.tracking.ErrorInformation
+import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ClientTypes
+import com.ably.tracking.common.ConnectionState
+import com.ably.tracking.common.PresenceData
+import com.ably.tracking.subscriber.SubscriberProperties
+import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
+import com.ably.tracking.test.common.mockEnterPresenceFailure
+import com.ably.tracking.test.common.mockEnterPresenceSuccess
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EnterPresenceWorkerTest {
+
+    private val trackableId = "testtrackable"
+
+    private val ably: Ably = mockk {
+        coEvery { startConnection() } returns Result.success(Unit)
+    }
+
+    private val worker = EnterPresenceWorker(trackableId, ably)
+
+    private val initialProperties: SubscriberProperties = mockk {
+        every { presenceData } returns PresenceData(ClientTypes.SUBSCRIBER, null, null)
+    }
+
+    private val asyncWorks = mutableListOf<suspend () -> Unit>()
+    private val postedWorks = mutableListOf<WorkerSpecification>()
+
+    @Test
+    fun `should post no work when connection succeeded`() {
+        runTest {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockEnterPresenceSuccess(trackableId)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.executeAll()
+
+            assertThat(postedWorks).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should post EnterPresence work after delay when enter presence failed with a non-fatal error`() {
+        runTest(context = UnconfinedTestDispatcher()) {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockEnterPresenceFailure(trackableId, isFatal = false)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.launchAll(this)
+
+            assertThat(postedWorks).isEmpty()
+
+            advanceUntilIdle()
+
+            assertThat(postedWorks)
+                .contains(WorkerSpecification.EnterPresence(trackableId))
+        }
+    }
+
+    @Test
+    fun `should post Disconnect work when connection failed with a fatal error`() {
+        runTest {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockEnterPresenceFailure(trackableId, isFatal = true)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.executeAll()
+
+            val postedWork = postedWorks[0] as WorkerSpecification.Disconnect
+            assertThat(postedWork.trackableId).isEqualTo(trackableId)
+        }
+    }
+
+    @Test
+    fun `should post EnterPresence work when connection failed with a fatal error with 91001 error code`() {
+        runTest {
+            // given
+            mockChannelStateChange(ConnectionState.ONLINE)
+            ably.mockEnterPresenceChannelSuspendedException(trackableId)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.launchAll(this)
+
+            assertThat(postedWorks).isEmpty()
+
+            advanceUntilIdle()
+
+            assertThat(postedWorks)
+                .contains(WorkerSpecification.EnterPresence(trackableId))
+        }
+    }
+
+    private fun Ably.mockEnterPresenceChannelSuspendedException(trackableId: String) {
+        coEvery {
+            enterChannelPresence(trackableId, any())
+        } returns Result.failure(channelSuspendedException())
+    }
+
+    // returns connection exception specific to enter presence on a suspended channel
+    private fun channelSuspendedException() = ConnectionException(
+        ErrorInformation(
+            code = 91001,
+            statusCode = 400,
+            message = "Test",
+            href = null,
+            cause = null
+        )
+    )
+
+    @Test
+    fun `should post FailTrackable work when connection when channel transitions to failed`() {
+        runTest {
+            // given
+            mockChannelStateChange(ConnectionState.FAILED)
+
+            // when
+            worker.doWork(
+                initialProperties,
+                asyncWorks.appendWork(),
+                postedWorks.appendSpecification()
+            )
+
+            // then
+            asyncWorks.executeAll()
+
+            val postedWork = postedWorks[0] as WorkerSpecification.Disconnect
+            assertThat(postedWork.trackableId).isEqualTo(trackableId)
+        }
+    }
+
+    private fun mockChannelStateChange(newState: ConnectionState) {
+        every {
+            runBlocking {
+                ably.waitForChannelToAttach(trackableId)
+            }
+        } returns when (newState) {
+            ConnectionState.ONLINE -> Result.success(Unit)
+            ConnectionState.FAILED -> Result.failure(ConnectionException(ErrorInformation("Channel attach failed")))
+            ConnectionState.OFFLINE -> throw Exception("Not a valid result")
+        }
+    }
+}

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/StartConnectionWorkerTest.kt
@@ -34,7 +34,7 @@ internal class StartConnectionWorkerTest {
     private val postedWorks = mutableListOf<WorkerSpecification>()
 
     @Test
-    fun `should call ably connect and ably enterChannelPresence and post update trackable worker specification on success`() = runTest {
+    fun `should call ably connect and post enterPresence worker specification and post update trackable worker specification on success`() = runTest {
         // given
         ably.mockStartConnectionSuccess()
         ably.mockConnectSuccess(trackableId)
@@ -61,9 +61,9 @@ internal class StartConnectionWorkerTest {
                 useRewind = true,
                 willSubscribe = true
             )
-            ably.enterChannelPresence(trackableId, presenceData)
         }
         Assert.assertEquals(WorkerSpecification.SubscribeForPresenceMessages(callbackFunction), postedWorks[0])
+        Assert.assertEquals(WorkerSpecification.EnterPresence(trackableId), postedWorks[1])
     }
 
     @Test

--- a/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
+++ b/subscribing-sdk/src/test/java/com/ably/tracking/subscriber/workerqueue/workers/WorkerTestUtils.kt
@@ -5,6 +5,8 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.subscriber.SubscriberProperties
 import com.ably.tracking.subscriber.workerqueue.WorkerSpecification
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 fun MutableList<suspend () -> Unit>.appendWork(): (suspend () -> Unit) -> Unit =
     { asyncWork ->
@@ -13,6 +15,12 @@ fun MutableList<suspend () -> Unit>.appendWork(): (suspend () -> Unit) -> Unit =
 
 suspend fun MutableList<suspend () -> Unit>.executeAll() {
     forEach { it.invoke() }
+}
+
+suspend fun MutableList<suspend () -> Unit>.launchAll(scope: CoroutineScope) {
+    forEach {
+        scope.launch { it.invoke() }
+    }
 }
 
 internal fun MutableList<WorkerSpecification>.appendSpecification(): (WorkerSpecification) -> Unit =


### PR DESCRIPTION
Subscriber start detached from entering presence in a similar way to what was done on the publisher side.

Resolves #1017 