### PR TITLE
Ably action version

### DIFF
--- a/.github/workflows/adhoc-publish-example-apps.yml
+++ b/.github/workflows/adhoc-publish-example-apps.yml
@@ -24,8 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # TODO replace branch ref (underlying https://github.com/ably/github-event-context-action/pull/2) with `v1` tag
-      - uses: ably/github-event-context-action@add-build-metadata-output-and-release
+      - uses: ably/github-event-context-action@v1
         id: context
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/publish-example-apps.yml
+++ b/.github/workflows/publish-example-apps.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           ref: v${{ github.event.inputs.version }}
 
-      # TODO replace branch ref (underlying https://github.com/ably/github-event-context-action/pull/2) with `v1` tag
-      - uses: ably/github-event-context-action@add-build-metadata-output-and-release
+      - uses: ably/github-event-context-action@v1
         id: context
 
       - uses: actions/setup-java@v3


### PR DESCRIPTION
Our publish apps workflow was pointed at a branch which has now been deleted, this re-targets the workflows to v1 of the action.