### PR TITLE
POC: Add stateflow for Ably connection state to subscriber

### DIFF
--- a/core-sdk-java/build.gradle
+++ b/core-sdk-java/build.gradle
@@ -9,6 +9,7 @@ apply from: '../jacoco.gradle'
 
 dependencies {
     api project(':core-sdk')
+    implementation project(path: ':common')
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2'
 }
 

--- a/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
+++ b/core-sdk-java/src/main/java/com/ably/tracking/java/ListenerInterfaces.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.java
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
+import com.ably.tracking.common.ConnectionState
 
 /**
  * Defines an interface, to be implemented in Java code utilising the Ably Asset Tracking SDKs, allowing that code to
@@ -18,6 +19,14 @@ interface LocationUpdateListener {
  */
 interface TrackableStateListener {
     fun onStateChanged(trackableState: TrackableState)
+}
+
+/**
+ * Defines an interface, to be implemented in Java code utilising the Ably Asset Tracking SDKs, allowing that code to
+ * handle events containing the ably connection state changes.
+ */
+interface ConnectionStateListener {
+    fun onAblyConnectionStateChanged(connectionState: ConnectionState)
 }
 
 /**

--- a/subscribing-sdk-java/build.gradle
+++ b/subscribing-sdk-java/build.gradle
@@ -10,6 +10,7 @@ apply from: '../jacoco.gradle'
 dependencies {
     api project(':subscribing-sdk')
     api project(':core-sdk-java')
+    api project(':common')
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2'
 }
 

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/DefaultSubscriberFacade.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
 import com.ably.tracking.annotations.Experimental
+import com.ably.tracking.java.ConnectionStateListener
 import com.ably.tracking.java.LocationUpdateIntervalListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.java.PublisherPresenceListener
@@ -45,6 +46,13 @@ internal class DefaultSubscriberFacade(
     override fun addListener(listener: TrackableStateListener) {
         subscriber.trackableStates
             .onEach { listener.onStateChanged(it) }
+            .launchIn(scope)
+    }
+
+    @Experimental
+    override fun addAblyConnectionStateListener(listener: ConnectionStateListener) {
+        subscriber.connectionStates
+            .onEach { listener.onAblyConnectionStateChanged(it) }
             .launchIn(scope)
     }
 

--- a/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
+++ b/subscribing-sdk-java/src/main/java/com/ably/tracking/subscriber/java/SubscriberFacade.kt
@@ -2,6 +2,7 @@ package com.ably.tracking.subscriber.java
 
 import com.ably.tracking.Resolution
 import com.ably.tracking.annotations.Experimental
+import com.ably.tracking.java.ConnectionStateListener
 import com.ably.tracking.java.LocationUpdateIntervalListener
 import com.ably.tracking.java.LocationUpdateListener
 import com.ably.tracking.java.PublisherPresenceListener
@@ -70,7 +71,15 @@ interface SubscriberFacade : Subscriber {
     fun addListener(listener: TrackableStateListener)
 
     /**
-     * Adds a handler to be notified when the the presence of the publisher changes.
+     * Adds a handler to be notified when the Ably connection state changes.
+     *
+     * @param listener the listening function to be notified.
+     */
+    @Experimental
+    fun addAblyConnectionStateListener(listener: ConnectionStateListener)
+
+    /**
+     * Adds a handler to be notified when the presence of the publisher changes.
      * The publisher is present when the value is "true". If the value is "false" the publisher is not present.
      *
      * @param listener the listening function to be notified.

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/DefaultSubscriber.kt
@@ -5,6 +5,7 @@ import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.annotations.Experimental
 import com.ably.tracking.common.Ably
+import com.ably.tracking.common.ConnectionState
 import com.ably.tracking.common.logging.createLoggingTag
 import com.ably.tracking.common.logging.v
 import com.ably.tracking.common.logging.w
@@ -42,6 +43,10 @@ internal class DefaultSubscriber(
 
     override val nextLocationUpdateIntervals: SharedFlow<Long>
         get() = core.nextLocationUpdateIntervals
+
+    @Experimental
+    override val connectionStates: StateFlow<ConnectionState>
+        get() = core.connectionStates
 
     init {
         core = createCoreSubscriber(ably, resolution, trackableId, logHandler)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/Subscriber.kt
@@ -6,6 +6,7 @@ import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
 import com.ably.tracking.annotations.Experimental
+import com.ably.tracking.common.ConnectionState
 import com.ably.tracking.connection.ConnectionConfiguration
 import com.ably.tracking.logging.LogHandler
 import kotlinx.coroutines.flow.SharedFlow
@@ -96,6 +97,13 @@ interface Subscriber {
      * The shared flow emitting the estimated next location update intervals in milliseconds when they become available.
      */
     val nextLocationUpdateIntervals: SharedFlow<Long>
+        @JvmSynthetic get
+
+    /**
+     * The shared flow emitting values when the ably connection state changes.
+     */
+    @Experimental
+    val connectionStates: StateFlow<ConnectionState>
         @JvmSynthetic get
 
     /**


### PR DESCRIPTION
Adds a StateFlow that monitors the the Ably connection state to the subscriber so that people can monitor the raw connection state.