### PR TITLE
Error info constants

### DIFF
--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/CoreSubscriber.kt
@@ -1,5 +1,6 @@
 package com.ably.tracking.subscriber
 
+import com.ably.tracking.ErrorInformation
 import com.ably.tracking.LocationUpdate
 import com.ably.tracking.Resolution
 import com.ably.tracking.TrackableState
@@ -261,7 +262,18 @@ internal data class SubscriberProperties private constructor(
         private val _trackableStates: MutableStateFlow<TrackableState> = MutableStateFlow(TrackableState.Offline())
         private val _publisherPresence: MutableStateFlow<Boolean> = MutableStateFlow(false)
         private val _publisherPresenceStateChanges: StateFlow<PublisherPresenceStateChange> = MutableStateFlow(
-            PublisherPresenceStateChange(PublisherPresenceState.UNKNOWN, null, Date().time, listOf())
+            PublisherPresenceStateChange(
+                PublisherPresenceState.UNKNOWN,
+                ErrorInformation(
+                    code = PublisherStateUnknownReasons.SUBSCRIBER_NEVER_ONLINE.value,
+                    statusCode = 0,
+                    message = "Subscriber has never been online",
+                    href = null,
+                    cause = null
+                ),
+                Date().time,
+                listOf()
+            )
         )
         private val _resolutions: MutableSharedFlow<Resolution> = MutableSharedFlow(replay = 1)
         private val _nextLocationUpdateIntervals: MutableSharedFlow<Long> = MutableSharedFlow(replay = 1)

--- a/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/PublisherPresenceStateChange.kt
+++ b/subscribing-sdk/src/main/java/com/ably/tracking/subscriber/PublisherPresenceStateChange.kt
@@ -25,6 +25,23 @@ enum class LastKnownPublisherState {
 }
 
 /**
+ * An enumeration of the reasons why we might not know why the publisher is present or not.
+ *
+ * As per codes defined in https://github.com/ably/ably-asset-tracking-common/blob/main/specification/README.md
+ */
+enum class PublisherStateUnknownReasons(val value: Int) {
+    SUBSCRIBER_NEVER_ONLINE(100004),
+    SUBSCRIBER_NOT_ONLINE(100005);
+
+    companion object {
+        private val values = values()
+        fun getByValue(value: Int?): PublisherStateUnknownReasons? = values.firstOrNull {
+            it.value == value
+        }
+    }
+}
+
+/**
  * Represents a publisher that AAT knows (via presence history of presence events)
  * has been present at some point. This class can be used to identify previous publishers
  * and when they might have been present.


### PR DESCRIPTION
Adds ErrorInfo codes as constants for use with the extended publisher presence API