### PR TITLE
Disallow online state for subscriber active fatal fault

### DIFF
--- a/subscribing-sdk/src/androidTest/java/com/ably/tracking/subscriber/NetworkConnectivityTests.kt
+++ b/subscribing-sdk/src/androidTest/java/com/ably/tracking/subscriber/NetworkConnectivityTests.kt
@@ -648,7 +648,7 @@ class SubscriberMonitor(
                 else -> TrackableState.Online::class
             },
             failureStates = when (faultType) {
-                is FaultType.Fatal -> setOf(TrackableState.Offline::class)
+                is FaultType.Fatal -> setOf(TrackableState.Online::class, TrackableState.Offline::class)
                 is FaultType.Nonfatal, is FaultType.NonfatalWhenResolved ->
                     setOf(TrackableState.Failed::class)
             },


### PR DESCRIPTION
Andy noticed this when reviewing the Swift tests which copy these ones — see [this comment](https://github.com/ably/ably-asset-tracking-swift/pull/612/files#r1142432884).