### PR TITLE
Bump ably-java to 1.2.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.26'
+    ext.ably_core_version = '1.2.27'
 
     repositories {
         google()


### PR DESCRIPTION
This change bumps ably-java to 1.2.27, which includes a fix for connections entering the suspended state after disconnecting after a long period of being connected.

Fixes #1039 