### PR TITLE
additional faults enabled in subscribers NetworkConnectivityTests

### DIFF
--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
@@ -62,7 +62,8 @@ class FaultSimulation(
     private val faultNamesSkippedForSubscriberTest = listOf(
         "TcpConnectionRefused",
         "DisconnectAndSuspend",
-        "EnterUnresponsive"
+        "EnterUnresponsive",
+        "ReenterOnResumeFailed"
     )
 
     val skipSubscriberTest = faultNamesSkippedForSubscriberTest.contains(dto.name)

--- a/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
+++ b/android-test-common/src/main/java/com/ably/tracking/test/android/common/Fault.kt
@@ -62,9 +62,7 @@ class FaultSimulation(
     private val faultNamesSkippedForSubscriberTest = listOf(
         "TcpConnectionRefused",
         "DisconnectAndSuspend",
-        "EnterUnresponsive",
-        "UpdateFailedWithNonfatalNack",
-        "ReenterOnResumeFailed",
+        "EnterUnresponsive"
     )
 
     val skipSubscriberTest = faultNamesSkippedForSubscriberTest.contains(dto.name)


### PR DESCRIPTION
This PR enables additional faults for Subscriber-side tests now passing after TcpConnectionUnresponsive-related changes.