### PR TITLE
Ably Java Version Bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // The version of Ably's client library for Java that we're using.
     // Source code: https://github.com/ably/ably-java
     // Maven coordinates: groupId 'io.ably', artifactId ':'ably-android'.
-    ext.ably_core_version = '1.2.27'
+    ext.ably_core_version = '1.2.31'
 
     repositories {
         google()


### PR DESCRIPTION
Bumps ably-java to 1.2.31. This contains stability and performance fixes.